### PR TITLE
Fix overwrite

### DIFF
--- a/rcp/src/main.rs
+++ b/rcp/src/main.rs
@@ -104,21 +104,6 @@ async fn async_main(args: Args) -> Result<CopySummary> {
     let mut join_set = tokio::task::JoinSet::new();
     for (src_path, dst_path) in src_dst {
         let do_copy = || async move {
-            if dst_path.exists() {
-                if args.overwrite {
-                    // TODO: is this the right behavior?
-                    if tokio::fs::metadata(&dst_path).await?.is_file() {
-                        tokio::fs::remove_file(&dst_path).await?;
-                    } else {
-                        tokio::fs::remove_dir_all(&dst_path).await?;
-                    }
-                } else {
-                    return Err(anyhow::anyhow!(
-                        "destination {:?} already exists, use --overwrite to overwrite",
-                        dst_path
-                    ));
-                }
-            }
             common::copy(
                 &src_path,
                 &dst_path,
@@ -127,6 +112,7 @@ async fn async_main(args: Args) -> Result<CopySummary> {
                     read_buffer,
                     dereference: args.dereference,
                     fail_early: args.fail_early,
+                    overwrite: args.overwrite,
                 },
             )
             .await

--- a/rlink/src/main.rs
+++ b/rlink/src/main.rs
@@ -5,6 +5,10 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug, Clone)]
 #[structopt(name = "rlink")]
 struct Args {
+    /// Overwrite existing files/directories
+    #[structopt(short, long)]
+    overwrite: bool,
+
     /// Exit on first error
     #[structopt(short = "-e", long = "fail-early")]
     fail_early: bool,
@@ -87,6 +91,7 @@ async fn async_main(args: Args) -> Result<LinkSummary> {
             read_buffer,
             dereference: args.dereference,
             fail_early: args.fail_early,
+            overwrite: args.overwrite,
         },
     )
     .await


### PR DESCRIPTION
Previously, overwrite would simply remove the whole directory tree if it found an existing path under <dst>.

This change modifies the overwrite behavior to:
- Check the file metadata to see if it's identical to <src> and copy/link only if different
- If a directory exists - update the metadata and recursively update the contents

Symlinks are always re-created.