### PR TITLE
Add nix ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Summary
- Add `nix` package ecosystem to Dependabot version updates config
- Enables automated PRs to bump `flake.nix` inputs on a monthly schedule

## Test plan
- [ ] Verify Dependabot picks up the new ecosystem and creates update PRs for flake inputs