### PR TITLE
Group Dependabot updates into single PRs per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "nix"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      all-nix:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-cargo:
+        patterns:
+          - "*"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,8 @@ Iterate until both are satisfied before considering the task complete.
 
 Then, before declaring the task done, run `/codex:review --base main` and iterate on the resulting feedback until all comments worth addressing are fixed. Use judgment on which comments to address — not every suggestion is worth acting on, but every one should be evaluated.
 
+After creating a PR, check all review comments (including automated ones from Copilot). Evaluate each on its merit — address valid suggestions and respond to ones that aren't applicable.
+
 ## Commit Guidelines
 
 Keep commit subjects concise and imperative, matching the existing history style (e.g., "Fix how we manage dependencies"). Provide context and issue links in the body when applicable.


### PR DESCRIPTION
## Summary
- Add `cargo` and `nix` package ecosystems to Dependabot config
- Configure wildcard groups so each ecosystem produces one combined PR instead of separate ones per dependency
- Supersedes #208

## Test plan
- [ ] Verify Dependabot creates grouped PRs on next scheduled run