### PR TITLE
Add age-based filtering to rrm via --modified-before / --created-before

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .claude
 .codex
 .direnv/
+/codex-review*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,14 +118,6 @@ Before making any changes to remote copy operations, **always read [docs/remote_
 
 ## Agent Team Workflow
 
-For any non-trivial coding task, create an agent team with two members:
-
-1. **coder** — plans, writes code, runs tests, responds to reviewer feedback.
-2. **reviewer** — reviews changes for correctness, conventions, and potential issues.
-
-Iterate until both are satisfied before considering the task complete.
-
-Then, before declaring the task done, run `/codex:review --base main` and iterate on the resulting feedback until all comments worth addressing are fixed. Use judgment on which comments to address — not every suggestion is worth acting on, but every one should be evaluated.
 
 After creating a PR, check all review comments (including automated ones from Copilot). Evaluate each on its merit — address valid suggestions and respond to ones that aren't applicable.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1810,6 +1810,7 @@ dependencies = [
  "assert_cmd",
  "async-recursion",
  "clap",
+ "humantime",
  "predicates",
  "rcp-tools-common",
  "thiserror",

--- a/common/src/copy.rs
+++ b/common/src/copy.rs
@@ -242,6 +242,7 @@ pub async fn copy_file(
                     fail_early: settings.fail_early,
                     filter: None,
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await
@@ -575,6 +576,7 @@ async fn copy_internal(
                         fail_early: settings.fail_early,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await
@@ -732,6 +734,7 @@ async fn copy_internal(
                         fail_early: settings.fail_early,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await
@@ -1519,6 +1522,7 @@ mod copy_tests {
                     fail_early: false,
                     filter: None,
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?
@@ -1529,6 +1533,7 @@ mod copy_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?;
@@ -1596,6 +1601,7 @@ mod copy_tests {
                     fail_early: false,
                     filter: None,
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?
@@ -1606,6 +1612,7 @@ mod copy_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?;
@@ -1678,6 +1685,7 @@ mod copy_tests {
                     fail_early: false,
                     filter: None,
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?
@@ -1688,6 +1696,7 @@ mod copy_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?;
@@ -1763,6 +1772,7 @@ mod copy_tests {
                     fail_early: false,
                     filter: None,
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?
@@ -1773,6 +1783,7 @@ mod copy_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?;

--- a/common/src/dry_run.rs
+++ b/common/src/dry_run.rs
@@ -1,7 +1,7 @@
 //! Dry-run reporting helpers shared by copy, link, and rm operations.
 
 use crate::config::DryRunMode;
-use crate::filter::FilterResult;
+use crate::filter::{FilterResult, TimeSkipReason};
 
 /// Reports a dry-run action (would copy/link/remove) to stdout.
 /// When `dst` is `None`, prints only the source path (used by rm).
@@ -53,5 +53,29 @@ pub fn format_skip_reason(result: &FilterResult) -> Option<String> {
         FilterResult::Included => None,
         FilterResult::ExcludedByDefault => Some("no include pattern matched".to_string()),
         FilterResult::ExcludedByPattern(p) => Some(format!("excluded by '{}'", p)),
+    }
+}
+
+/// Reports an entry skipped by a time filter during dry-run to stdout.
+/// Respects dry-run mode: Brief suppresses, All shows path, Explain shows reason.
+pub fn report_time_skip(
+    path: &std::path::Path,
+    reason: TimeSkipReason,
+    mode: DryRunMode,
+    entry_type: &str,
+) {
+    match mode {
+        DryRunMode::Brief => { /* brief mode doesn't show skipped entries */ }
+        DryRunMode::All => {
+            println!("skip {} {:?}", entry_type, path);
+        }
+        DryRunMode::Explain => {
+            let reason_str = match reason {
+                TimeSkipReason::TooNewModified => "mtime is too recent",
+                TimeSkipReason::TooNewCreated => "btime is too recent",
+                TimeSkipReason::TooNewBoth => "mtime and btime are too recent",
+            };
+            println!("skip {} {:?} ({})", entry_type, path, reason_str);
+        }
     }
 }

--- a/common/src/filter.rs
+++ b/common/src/filter.rs
@@ -389,6 +389,135 @@ impl FilterSettings {
     }
 }
 
+/// Time-based filter for matching entries by age (mtime/btime).
+///
+/// Used in addition to glob filters to skip entries that are not yet old enough.
+/// Each threshold is interpreted as a minimum age — an entry matches when its
+/// timestamp is at least the threshold ago (i.e. the timestamp is "before"
+/// `now - threshold`). When both fields are set, both conditions must hold (AND).
+///
+/// `created_before` uses the file's birth time (`std::fs::Metadata::created()`).
+/// Some Linux filesystems do not expose btime; in that case [`Self::matches`]
+/// returns an error rather than silently treating the file as a match.
+#[derive(Debug, Clone, Default)]
+pub struct TimeFilter {
+    /// minimum age based on mtime; entry matches when mtime is at least this old
+    pub modified_before: Option<std::time::Duration>,
+    /// minimum age based on btime; entry matches when btime is at least this old
+    pub created_before: Option<std::time::Duration>,
+}
+
+/// Outcome of evaluating a [`TimeFilter`] against a metadata entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeFilterResult {
+    /// entry passes both configured time thresholds (or no thresholds are set)
+    Matched,
+    /// entry's mtime is too recent to satisfy `modified_before`
+    TooNewModified,
+    /// entry's btime is too recent to satisfy `created_before`
+    TooNewCreated,
+    /// entry fails both `modified_before` and `created_before`
+    TooNewBoth,
+}
+
+/// Why an entry was skipped by a [`TimeFilter`] — the subset of [`TimeFilterResult`]
+/// that does not include `Matched`. Constructed via `TimeFilterResult::as_skip_reason`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeSkipReason {
+    /// entry's mtime is too recent
+    TooNewModified,
+    /// entry's btime is too recent
+    TooNewCreated,
+    /// both mtime and btime are too recent
+    TooNewBoth,
+}
+
+impl TimeFilterResult {
+    /// Returns the skip reason when this result represents a skip, or `None` when matched.
+    pub fn as_skip_reason(self) -> Option<TimeSkipReason> {
+        match self {
+            TimeFilterResult::Matched => None,
+            TimeFilterResult::TooNewModified => Some(TimeSkipReason::TooNewModified),
+            TimeFilterResult::TooNewCreated => Some(TimeSkipReason::TooNewCreated),
+            TimeFilterResult::TooNewBoth => Some(TimeSkipReason::TooNewBoth),
+        }
+    }
+}
+
+impl TimeFilter {
+    /// Returns true when no time thresholds are configured.
+    pub fn is_empty(&self) -> bool {
+        self.modified_before.is_none() && self.created_before.is_none()
+    }
+    /// Evaluate this filter against `metadata`.
+    ///
+    /// Returns:
+    /// - `Ok(TimeFilterResult::Matched)` when the entry passes all configured thresholds.
+    /// - `Ok(TimeFilterResult::TooNew*)` when one or both thresholds are not yet met.
+    /// - `Err(_)` when `created_before` is configured and the underlying `created()`
+    ///   call fails (e.g., a filesystem that does not expose birth time).
+    pub fn matches(&self, metadata: &std::fs::Metadata) -> anyhow::Result<TimeFilterResult> {
+        let mtime = if self.modified_before.is_some() {
+            Some(
+                metadata
+                    .modified()
+                    .context("failed to read mtime from metadata")?,
+            )
+        } else {
+            None
+        };
+        let btime = if self.created_before.is_some() {
+            Some(
+                metadata
+                    .created()
+                    .context("failed to read birth time (created) from metadata")?,
+            )
+        } else {
+            None
+        };
+        Ok(self.evaluate(mtime, btime, std::time::SystemTime::now()))
+    }
+    /// Pure-logic evaluation of this filter against raw timestamps.
+    ///
+    /// The timestamps are only inspected when the corresponding threshold is configured.
+    /// When a threshold is configured but the timestamp is `None`, the entry is treated as
+    /// "too new" for that axis (a `None` timestamp has no age signal, so it cannot satisfy
+    /// an age threshold). This helper is for deterministic unit testing of the AND logic;
+    /// prefer [`Self::matches`] for real callers.
+    fn evaluate(
+        &self,
+        mtime: Option<std::time::SystemTime>,
+        btime: Option<std::time::SystemTime>,
+        now: std::time::SystemTime,
+    ) -> TimeFilterResult {
+        let modified_too_new = self
+            .modified_before
+            .is_some_and(|threshold| mtime.is_none_or(|t| !is_at_least_age(now, t, threshold)));
+        let created_too_new = self
+            .created_before
+            .is_some_and(|threshold| btime.is_none_or(|t| !is_at_least_age(now, t, threshold)));
+        match (modified_too_new, created_too_new) {
+            (false, false) => TimeFilterResult::Matched,
+            (true, false) => TimeFilterResult::TooNewModified,
+            (false, true) => TimeFilterResult::TooNewCreated,
+            (true, true) => TimeFilterResult::TooNewBoth,
+        }
+    }
+}
+
+/// Returns true if `timestamp` is at least `age` old relative to `now`.
+/// Treats clock skew (timestamp in the future) as "not old enough".
+fn is_at_least_age(
+    now: std::time::SystemTime,
+    timestamp: std::time::SystemTime,
+    age: std::time::Duration,
+) -> bool {
+    match now.duration_since(timestamp) {
+        Ok(elapsed) => elapsed >= age,
+        Err(_) => false,
+    }
+}
+
 /// Data transfer object for FilterSettings serialization.
 /// Used for passing filter settings across process boundaries (e.g., to rcpd).
 #[derive(Serialize, Deserialize)]
@@ -880,5 +1009,285 @@ mod tests {
         assert!(settings.directly_matches_include(Path::new("foo/target"), true));
         // should not match files
         assert!(!settings.directly_matches_include(Path::new("target"), false));
+    }
+
+    mod time_filter_tests {
+        use super::*;
+        use crate::testutils;
+
+        fn write_with_mtime(path: &std::path::Path, age: std::time::Duration) {
+            std::fs::write(path, "x").unwrap();
+            let past = filetime::FileTime::from_system_time(std::time::SystemTime::now() - age);
+            filetime::set_file_mtime(path, past).unwrap();
+        }
+
+        #[test]
+        fn is_empty_when_no_thresholds_set() {
+            assert!(TimeFilter::default().is_empty());
+            let only_mtime = TimeFilter {
+                modified_before: Some(std::time::Duration::from_secs(1)),
+                created_before: None,
+            };
+            assert!(!only_mtime.is_empty());
+            let only_btime = TimeFilter {
+                modified_before: None,
+                created_before: Some(std::time::Duration::from_secs(1)),
+            };
+            assert!(!only_btime.is_empty());
+        }
+
+        #[tokio::test]
+        async fn matches_returns_matched_when_no_thresholds() {
+            let tmp = testutils::create_temp_dir().await.unwrap();
+            let path = tmp.join("file");
+            write_with_mtime(&path, std::time::Duration::from_secs(0));
+            let metadata = std::fs::metadata(&path).unwrap();
+            assert_eq!(
+                TimeFilter::default().matches(&metadata).unwrap(),
+                TimeFilterResult::Matched
+            );
+        }
+
+        #[tokio::test]
+        async fn matches_when_mtime_older_than_threshold() {
+            let tmp = testutils::create_temp_dir().await.unwrap();
+            let path = tmp.join("file");
+            write_with_mtime(&path, std::time::Duration::from_secs(7200));
+            let metadata = std::fs::metadata(&path).unwrap();
+            let filter = TimeFilter {
+                modified_before: Some(std::time::Duration::from_secs(3600)),
+                created_before: None,
+            };
+            assert_eq!(
+                filter.matches(&metadata).unwrap(),
+                TimeFilterResult::Matched
+            );
+        }
+
+        #[tokio::test]
+        async fn reports_too_new_modified_when_mtime_recent() {
+            let tmp = testutils::create_temp_dir().await.unwrap();
+            let path = tmp.join("file");
+            write_with_mtime(&path, std::time::Duration::from_secs(0));
+            let metadata = std::fs::metadata(&path).unwrap();
+            let filter = TimeFilter {
+                modified_before: Some(std::time::Duration::from_secs(3600)),
+                created_before: None,
+            };
+            assert_eq!(
+                filter.matches(&metadata).unwrap(),
+                TimeFilterResult::TooNewModified
+            );
+        }
+
+        /// Exercises `matches()` on the `created_before` axis with real metadata.
+        /// The expected outcome depends on whether the filesystem exposes birth time:
+        /// - Supported: a freshly-written file has a recent btime → `TooNewCreated`.
+        /// - Unsupported: `matches()` must return `Err` (the contract is to surface
+        ///   the failure rather than silently treat the file as a match).
+        /// Deterministic on either platform — drift in either branch will fail loudly.
+        #[tokio::test]
+        async fn matches_exercises_btime_deterministically() {
+            let tmp = testutils::create_temp_dir().await.unwrap();
+            let path = tmp.join("file");
+            std::fs::write(&path, "x").unwrap();
+            let metadata = std::fs::metadata(&path).unwrap();
+            let filter = TimeFilter {
+                modified_before: None,
+                created_before: Some(std::time::Duration::from_secs(3600)),
+            };
+            let result = filter.matches(&metadata);
+            match metadata.created() {
+                Ok(_) => assert_eq!(result.unwrap(), TimeFilterResult::TooNewCreated),
+                Err(_) => assert!(
+                    result.is_err(),
+                    "matches() must return Err when created_before is set but btime is unavailable"
+                ),
+            }
+        }
+
+        #[tokio::test]
+        async fn matches_with_zero_threshold_is_always_satisfied() {
+            // any file is at least zero seconds old
+            let tmp = testutils::create_temp_dir().await.unwrap();
+            let path = tmp.join("file");
+            write_with_mtime(&path, std::time::Duration::from_secs(0));
+            let metadata = std::fs::metadata(&path).unwrap();
+            let filter = TimeFilter {
+                modified_before: Some(std::time::Duration::from_secs(0)),
+                created_before: None,
+            };
+            assert_eq!(
+                filter.matches(&metadata).unwrap(),
+                TimeFilterResult::Matched
+            );
+        }
+
+        /// Focused unit tests for the pure-logic [`TimeFilter::evaluate`] helper.
+        /// Using raw timestamps makes AND/OR boundaries deterministic without depending
+        /// on platform btime support or filesystem timestamp resolution.
+        mod evaluate_and_or_logic {
+            use super::*;
+
+            fn now() -> std::time::SystemTime {
+                // pick a fixed anchor far in the past so threshold subtraction cannot underflow
+                std::time::UNIX_EPOCH + std::time::Duration::from_secs(10_000_000)
+            }
+
+            fn age_before(
+                t: std::time::SystemTime,
+                age: std::time::Duration,
+            ) -> std::time::SystemTime {
+                t - age
+            }
+
+            #[test]
+            fn no_thresholds_always_matches_regardless_of_timestamps() {
+                let filter = TimeFilter::default();
+                assert_eq!(
+                    filter.evaluate(None, None, now()),
+                    TimeFilterResult::Matched
+                );
+                assert_eq!(
+                    filter.evaluate(
+                        Some(age_before(now(), std::time::Duration::from_secs(0))),
+                        None,
+                        now()
+                    ),
+                    TimeFilterResult::Matched
+                );
+            }
+
+            #[test]
+            fn and_logic_both_pass_is_matched() {
+                let filter = TimeFilter {
+                    modified_before: Some(std::time::Duration::from_secs(3600)),
+                    created_before: Some(std::time::Duration::from_secs(3600)),
+                };
+                let old = age_before(now(), std::time::Duration::from_secs(7200));
+                assert_eq!(
+                    filter.evaluate(Some(old), Some(old), now()),
+                    TimeFilterResult::Matched
+                );
+            }
+
+            #[test]
+            fn and_logic_only_mtime_passes_reports_created_too_new() {
+                let filter = TimeFilter {
+                    modified_before: Some(std::time::Duration::from_secs(3600)),
+                    created_before: Some(std::time::Duration::from_secs(3600)),
+                };
+                let old = age_before(now(), std::time::Duration::from_secs(7200));
+                let recent = age_before(now(), std::time::Duration::from_secs(60));
+                assert_eq!(
+                    filter.evaluate(Some(old), Some(recent), now()),
+                    TimeFilterResult::TooNewCreated
+                );
+            }
+
+            #[test]
+            fn and_logic_only_btime_passes_reports_modified_too_new() {
+                let filter = TimeFilter {
+                    modified_before: Some(std::time::Duration::from_secs(3600)),
+                    created_before: Some(std::time::Duration::from_secs(3600)),
+                };
+                let old = age_before(now(), std::time::Duration::from_secs(7200));
+                let recent = age_before(now(), std::time::Duration::from_secs(60));
+                assert_eq!(
+                    filter.evaluate(Some(recent), Some(old), now()),
+                    TimeFilterResult::TooNewModified
+                );
+            }
+
+            #[test]
+            fn and_logic_neither_passes_reports_too_new_both() {
+                let filter = TimeFilter {
+                    modified_before: Some(std::time::Duration::from_secs(3600)),
+                    created_before: Some(std::time::Duration::from_secs(3600)),
+                };
+                let recent = age_before(now(), std::time::Duration::from_secs(60));
+                assert_eq!(
+                    filter.evaluate(Some(recent), Some(recent), now()),
+                    TimeFilterResult::TooNewBoth
+                );
+            }
+
+            #[test]
+            fn threshold_boundary_exactly_at_age_matches() {
+                // a timestamp exactly `threshold` ago is considered "at least threshold old"
+                let filter = TimeFilter {
+                    modified_before: Some(std::time::Duration::from_secs(3600)),
+                    created_before: None,
+                };
+                let exact = age_before(now(), std::time::Duration::from_secs(3600));
+                assert_eq!(
+                    filter.evaluate(Some(exact), None, now()),
+                    TimeFilterResult::Matched
+                );
+            }
+
+            #[test]
+            fn future_timestamp_treated_as_too_new() {
+                // clock skew: if mtime is AFTER now, treat as "not old enough"
+                let filter = TimeFilter {
+                    modified_before: Some(std::time::Duration::from_secs(1)),
+                    created_before: None,
+                };
+                let future = now() + std::time::Duration::from_secs(3600);
+                assert_eq!(
+                    filter.evaluate(Some(future), None, now()),
+                    TimeFilterResult::TooNewModified
+                );
+            }
+
+            #[test]
+            fn missing_timestamp_when_threshold_configured_is_too_new() {
+                // None with a configured threshold has no age signal; treat as too new
+                // (used when the OS can't produce the timestamp — see evaluate doc comment)
+                let filter = TimeFilter {
+                    modified_before: Some(std::time::Duration::from_secs(3600)),
+                    created_before: Some(std::time::Duration::from_secs(3600)),
+                };
+                let old = age_before(now(), std::time::Duration::from_secs(7200));
+                assert_eq!(
+                    filter.evaluate(Some(old), None, now()),
+                    TimeFilterResult::TooNewCreated
+                );
+                assert_eq!(
+                    filter.evaluate(None, Some(old), now()),
+                    TimeFilterResult::TooNewModified
+                );
+                assert_eq!(
+                    filter.evaluate(None, None, now()),
+                    TimeFilterResult::TooNewBoth
+                );
+            }
+        }
+
+        /// Tests for the skip-reason projection.
+        mod skip_reason {
+            use super::*;
+
+            #[test]
+            fn matched_yields_none() {
+                assert_eq!(TimeFilterResult::Matched.as_skip_reason(), None);
+            }
+
+            #[test]
+            fn too_new_variants_yield_matching_reasons() {
+                assert_eq!(
+                    TimeFilterResult::TooNewModified.as_skip_reason(),
+                    Some(TimeSkipReason::TooNewModified)
+                );
+                assert_eq!(
+                    TimeFilterResult::TooNewCreated.as_skip_reason(),
+                    Some(TimeSkipReason::TooNewCreated)
+                );
+                assert_eq!(
+                    TimeFilterResult::TooNewBoth.as_skip_reason(),
+                    Some(TimeSkipReason::TooNewBoth)
+                );
+            }
+        }
     }
 }

--- a/common/src/link.rs
+++ b/common/src/link.rs
@@ -138,6 +138,7 @@ async fn hard_link_helper(
                     fail_early: settings.copy_settings.fail_early,
                     filter: None,
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await
@@ -487,6 +488,7 @@ async fn link_internal(
                         fail_early: settings.copy_settings.fail_early,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await
@@ -1147,6 +1149,7 @@ mod link_tests {
                     fail_early: false,
                     filter: None,
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?
@@ -1157,6 +1160,7 @@ mod link_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?;
@@ -1209,6 +1213,7 @@ mod link_tests {
                     fail_early: false,
                     filter: None,
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?
@@ -1219,6 +1224,7 @@ mod link_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?;
@@ -1285,6 +1291,7 @@ mod link_tests {
                     fail_early: false,
                     filter: None,
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?
@@ -1295,6 +1302,7 @@ mod link_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?
@@ -1305,6 +1313,7 @@ mod link_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?
@@ -1315,6 +1324,7 @@ mod link_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?;
@@ -1380,6 +1390,7 @@ mod link_tests {
                     fail_early: false,
                     filter: None,
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?
@@ -1390,6 +1401,7 @@ mod link_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?
@@ -1400,6 +1412,7 @@ mod link_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?
@@ -1410,6 +1423,7 @@ mod link_tests {
                         fail_early: false,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?;

--- a/common/src/rm.rs
+++ b/common/src/rm.rs
@@ -3,7 +3,7 @@ use async_recursion::async_recursion;
 use std::os::unix::fs::PermissionsExt;
 use tracing::instrument;
 
-use crate::filter::{FilterResult, FilterSettings};
+use crate::filter::{FilterResult, FilterSettings, TimeFilter};
 use crate::progress;
 
 /// Error type for remove operations that preserves operation summary even on failure.
@@ -35,6 +35,8 @@ pub struct Settings {
     pub fail_early: bool,
     /// filter settings for include/exclude patterns
     pub filter: Option<crate::filter::FilterSettings>,
+    /// time-based filter (mtime/btime); applies to files and symlinks only
+    pub time_filter: Option<TimeFilter>,
     /// dry-run mode for previewing operations
     pub dry_run: Option<crate::config::DryRunMode>,
 }
@@ -160,6 +162,9 @@ pub async fn rm(
             }
         }
     }
+    // note: time filter for files/symlinks is applied inside rm_internal — no need to
+    // duplicate the check here since rm_internal already skips the file/symlink branch
+    // without touching directories.
     rm_internal(prog_track, path, path, settings).await
 }
 #[instrument(skip(prog_track, settings))]
@@ -180,6 +185,50 @@ async fn rm_internal(
         tracing::debug!("not a directory, just remove");
         let is_symlink = src_metadata.file_type().is_symlink();
         let file_size = if is_symlink { 0 } else { src_metadata.len() };
+        // apply time filter before removing (files/symlinks only)
+        if let Some(ref time_filter) = settings.time_filter {
+            let entry_type = if is_symlink { "symlink" } else { "file" };
+            let make_skipped_summary = || {
+                tracing::debug!("skipping {:?} due to time filter", &path);
+                if is_symlink {
+                    prog_track.symlinks_skipped.inc();
+                    Summary {
+                        symlinks_skipped: 1,
+                        ..Default::default()
+                    }
+                } else {
+                    prog_track.files_skipped.inc();
+                    Summary {
+                        files_skipped: 1,
+                        ..Default::default()
+                    }
+                }
+            };
+            match time_filter.matches(&src_metadata) {
+                Ok(result) => {
+                    if let Some(skip_reason) = result.as_skip_reason() {
+                        if let Some(mode) = settings.dry_run {
+                            crate::dry_run::report_time_skip(path, skip_reason, mode, entry_type);
+                        }
+                        return Ok(make_skipped_summary());
+                    }
+                }
+                Err(err) => {
+                    let err = err.context(format!("failed evaluating time filter on {:?}", &path));
+                    if settings.fail_early {
+                        return Err(Error::new(err, Default::default()));
+                    }
+                    // log and skip — never delete an entry whose age we cannot verify
+                    tracing::error!(
+                        "time filter evaluation failed for {} {:?}, skipping: {:#}",
+                        entry_type,
+                        &path,
+                        &err
+                    );
+                    return Ok(make_skipped_summary());
+                }
+            }
+        }
         // handle dry-run mode for files/symlinks
         if settings.dry_run.is_some() {
             let entry_type = if is_symlink { "symlink" } else { "file" };
@@ -370,12 +419,13 @@ async fn rm_internal(
     // when filtering is active, directories may not be empty because we only removed
     // matching files (includes) or skipped excluded files; use remove_dir (not remove_dir_all)
     // so non-empty directories fail gracefully with ENOTEMPTY
+    let any_filter_active = settings.filter.is_some() || settings.time_filter.is_some();
     match tokio::fs::remove_dir(path).await {
         Ok(()) => {
             prog_track.directories_removed.inc();
             rm_summary.directories_removed += 1;
         }
-        Err(err) if settings.filter.is_some() => {
+        Err(err) if any_filter_active => {
             // with filtering, it's expected that directories may not be empty because we only
             // removed matching files; raw_os_error 39 is ENOTEMPTY on Linux
             if err.kind() == std::io::ErrorKind::DirectoryNotEmpty || err.raw_os_error() == Some(39)
@@ -433,6 +483,7 @@ mod tests {
                 fail_early: false,
                 filter: None,
                 dry_run: None,
+                time_filter: None,
             },
         )
         .await?;
@@ -461,6 +512,7 @@ mod tests {
                 fail_early: true,
                 filter: None,
                 dry_run: None,
+                time_filter: None,
             },
         )
         .await;
@@ -495,6 +547,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?;
@@ -541,6 +594,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?;
@@ -573,6 +627,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?;
@@ -609,6 +664,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?;
@@ -645,6 +701,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?;
@@ -691,6 +748,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?;
@@ -744,6 +802,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?;
@@ -789,6 +848,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?;
@@ -833,6 +893,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: Some(DryRunMode::Explain),
+                    time_filter: None,
                 },
             )
             .await?;
@@ -873,6 +934,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: None,
+                    time_filter: None,
                 },
             )
             .await?;
@@ -918,6 +980,7 @@ mod tests {
                     fail_early: false,
                     filter: None,
                     dry_run: Some(DryRunMode::Brief),
+                    time_filter: None,
                 },
             )
             .await?;
@@ -965,6 +1028,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: Some(DryRunMode::Brief),
+                    time_filter: None,
                 },
             )
             .await?;
@@ -1021,6 +1085,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: Some(DryRunMode::Explain),
+                    time_filter: None,
                 },
             )
             .await?;
@@ -1069,6 +1134,7 @@ mod tests {
                     fail_early: false,
                     filter: Some(filter),
                     dry_run: Some(DryRunMode::Explain),
+                    time_filter: None,
                 },
             )
             .await?;
@@ -1080,6 +1146,234 @@ mod tests {
             // verify nothing was actually removed (dry-run mode)
             assert!(test_path.join("foo").exists(), "foo should still exist");
             assert!(test_path.join("baz").exists(), "baz should still exist");
+            Ok(())
+        }
+    }
+    mod time_filter_tests {
+        use super::*;
+        use crate::filter::TimeFilter;
+
+        fn set_mtime_age(path: &std::path::Path, age: std::time::Duration) -> anyhow::Result<()> {
+            let past = filetime::FileTime::from_system_time(std::time::SystemTime::now() - age);
+            filetime::set_file_mtime(path, past)?;
+            Ok(())
+        }
+
+        /// File with mtime older than threshold is removed.
+        #[tokio::test]
+        #[traced_test]
+        async fn removes_files_older_than_modified_before() -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let file = test_path.join("old.txt");
+            tokio::fs::write(&file, "x").await?;
+            set_mtime_age(&file, std::time::Duration::from_secs(7200))?;
+            let summary = rm(
+                &PROGRESS,
+                &test_path,
+                &Settings {
+                    fail_early: false,
+                    filter: None,
+                    time_filter: Some(TimeFilter {
+                        modified_before: Some(std::time::Duration::from_secs(3600)),
+                        created_before: None,
+                    }),
+                    dry_run: None,
+                },
+            )
+            .await?;
+            assert_eq!(summary.files_removed, 1, "old file should be removed");
+            assert_eq!(summary.files_skipped, 0);
+            assert!(!file.exists(), "old.txt should be removed");
+            Ok(())
+        }
+
+        /// File with mtime newer than threshold is skipped.
+        #[tokio::test]
+        #[traced_test]
+        async fn keeps_files_newer_than_modified_before() -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let file = test_path.join("new.txt");
+            tokio::fs::write(&file, "x").await?;
+            set_mtime_age(&file, std::time::Duration::from_secs(60))?;
+            let summary = rm(
+                &PROGRESS,
+                &test_path,
+                &Settings {
+                    fail_early: false,
+                    filter: None,
+                    time_filter: Some(TimeFilter {
+                        modified_before: Some(std::time::Duration::from_secs(3600)),
+                        created_before: None,
+                    }),
+                    dry_run: None,
+                },
+            )
+            .await?;
+            assert_eq!(summary.files_removed, 0, "new file should not be removed");
+            assert_eq!(summary.files_skipped, 1, "new file should be skipped");
+            assert!(file.exists(), "new.txt should still exist");
+            Ok(())
+        }
+
+        /// Time filter applies to files only — directories descend regardless.
+        #[tokio::test]
+        #[traced_test]
+        async fn time_filter_does_not_apply_to_directories() -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let dir = test_path.join("dir");
+            tokio::fs::create_dir(&dir).await?;
+            let old_file = dir.join("old.txt");
+            let new_file = dir.join("new.txt");
+            tokio::fs::write(&old_file, "x").await?;
+            tokio::fs::write(&new_file, "x").await?;
+            set_mtime_age(&old_file, std::time::Duration::from_secs(7200))?;
+            set_mtime_age(&new_file, std::time::Duration::from_secs(60))?;
+            // even though 'dir' is freshly created (recent mtime), it should be traversed.
+            let summary = rm(
+                &PROGRESS,
+                &test_path,
+                &Settings {
+                    fail_early: false,
+                    filter: None,
+                    time_filter: Some(TimeFilter {
+                        modified_before: Some(std::time::Duration::from_secs(3600)),
+                        created_before: None,
+                    }),
+                    dry_run: None,
+                },
+            )
+            .await?;
+            assert_eq!(summary.files_removed, 1, "old file should be removed");
+            assert_eq!(summary.files_skipped, 1, "new file should be skipped");
+            // directories must never be counted as time-filter-skipped; even though
+            // 'dir' and test_path both have recent mtime, they are traversed normally.
+            assert_eq!(
+                summary.directories_skipped, 0,
+                "directories must never be skipped by time filter"
+            );
+            // 'dir' still contains 'new.txt', so neither 'dir' nor the root are empty —
+            // neither should be removed.
+            assert_eq!(
+                summary.directories_removed, 0,
+                "non-empty directories should not be removed"
+            );
+            assert!(!old_file.exists(), "old.txt should be removed");
+            assert!(new_file.exists(), "new.txt should still exist");
+            assert!(dir.exists(), "dir should still exist (contains new.txt)");
+            Ok(())
+        }
+
+        /// Time filter combines with glob exclude — both must pass for removal.
+        #[tokio::test]
+        #[traced_test]
+        async fn time_filter_combines_with_glob_exclude() -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let old_keep = test_path.join("keep.log");
+            let old_drop = test_path.join("drop.txt");
+            let new_drop = test_path.join("recent.txt");
+            tokio::fs::write(&old_keep, "x").await?;
+            tokio::fs::write(&old_drop, "x").await?;
+            tokio::fs::write(&new_drop, "x").await?;
+            set_mtime_age(&old_keep, std::time::Duration::from_secs(7200))?;
+            set_mtime_age(&old_drop, std::time::Duration::from_secs(7200))?;
+            set_mtime_age(&new_drop, std::time::Duration::from_secs(60))?;
+            let mut filter = crate::filter::FilterSettings::new();
+            filter.add_exclude("*.log").unwrap();
+            let summary = rm(
+                &PROGRESS,
+                &test_path,
+                &Settings {
+                    fail_early: false,
+                    filter: Some(filter),
+                    time_filter: Some(TimeFilter {
+                        modified_before: Some(std::time::Duration::from_secs(3600)),
+                        created_before: None,
+                    }),
+                    dry_run: None,
+                },
+            )
+            .await?;
+            // only old_drop passes both filters
+            assert_eq!(summary.files_removed, 1, "only old_drop should be removed");
+            assert_eq!(
+                summary.files_skipped, 2,
+                "old_keep and recent_drop should be skipped"
+            );
+            assert!(
+                old_keep.exists(),
+                "keep.log excluded by glob, should remain"
+            );
+            assert!(!old_drop.exists(), "drop.txt should be removed");
+            assert!(new_drop.exists(), "recent.txt should remain (too new)");
+            Ok(())
+        }
+
+        /// Dry-run with time filter previews removal without modifying files.
+        #[tokio::test]
+        #[traced_test]
+        async fn time_filter_with_dry_run() -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let old_file = test_path.join("old.txt");
+            let new_file = test_path.join("new.txt");
+            tokio::fs::write(&old_file, "x").await?;
+            tokio::fs::write(&new_file, "x").await?;
+            set_mtime_age(&old_file, std::time::Duration::from_secs(7200))?;
+            set_mtime_age(&new_file, std::time::Duration::from_secs(60))?;
+            let summary = rm(
+                &PROGRESS,
+                &test_path,
+                &Settings {
+                    fail_early: false,
+                    filter: None,
+                    time_filter: Some(TimeFilter {
+                        modified_before: Some(std::time::Duration::from_secs(3600)),
+                        created_before: None,
+                    }),
+                    dry_run: Some(DryRunMode::Explain),
+                },
+            )
+            .await?;
+            assert_eq!(
+                summary.files_removed, 1,
+                "should report old file would be removed"
+            );
+            assert_eq!(
+                summary.files_skipped, 1,
+                "should report new file would be skipped"
+            );
+            assert!(old_file.exists(), "old.txt should still exist (dry-run)");
+            assert!(new_file.exists(), "new.txt should still exist (dry-run)");
+            Ok(())
+        }
+
+        /// Time filter on a single-file root argument increments skip when too new.
+        #[tokio::test]
+        #[traced_test]
+        async fn time_filter_on_root_file_argument() -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let new_file = test_path.join("new.txt");
+            tokio::fs::write(&new_file, "x").await?;
+            set_mtime_age(&new_file, std::time::Duration::from_secs(60))?;
+            let summary = rm(
+                &PROGRESS,
+                &new_file,
+                &Settings {
+                    fail_early: false,
+                    filter: None,
+                    time_filter: Some(TimeFilter {
+                        modified_before: Some(std::time::Duration::from_secs(3600)),
+                        created_before: None,
+                    }),
+                    dry_run: None,
+                },
+            )
+            .await?;
+            assert_eq!(summary.files_removed, 0);
+            assert_eq!(
+                summary.files_skipped, 1,
+                "root file too new should be skipped"
+            );
+            assert!(new_file.exists(), "root file should still exist");
             Ok(())
         }
     }

--- a/common/src/rm.rs
+++ b/common/src/rm.rs
@@ -35,10 +35,28 @@ pub struct Settings {
     pub fail_early: bool,
     /// filter settings for include/exclude patterns
     pub filter: Option<crate::filter::FilterSettings>,
-    /// time-based filter (mtime/btime); applies to files and symlinks only
+    /// time-based filter (mtime/btime); applied to each entry individually (files,
+    /// symlinks, and directories). This is an entry filter, not a subtree gate:
+    /// directories are always traversed, and the filter only decides whether each
+    /// entry — including the directory itself, after its children are processed — is
+    /// eligible for removal. A directory whose own timestamps are too recent is left
+    /// intact even when its children have been removed; a non-empty leftover directory
+    /// is logged at info and not treated as an error.
     pub time_filter: Option<TimeFilter>,
     /// dry-run mode for previewing operations
     pub dry_run: Option<crate::config::DryRunMode>,
+}
+
+/// Returns true when `err`'s chain contains an `io::Error` with `ErrorKind::Unsupported`.
+/// Used to downgrade time-filter eval failures on filesystems / entry types that don't
+/// report btime (e.g. many symlinks) from `error!` to `warn!` so they don't flood logs
+/// on otherwise-successful runs.
+fn is_unsupported_io_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io_err| io_err.kind() == std::io::ErrorKind::Unsupported)
+    })
 }
 
 /// Check if a path should be filtered out
@@ -162,9 +180,8 @@ pub async fn rm(
             }
         }
     }
-    // note: time filter for files/symlinks is applied inside rm_internal — no need to
-    // duplicate the check here since rm_internal already skips the file/symlink branch
-    // without touching directories.
+    // note: the time filter (applied to files, symlinks, and directories) is handled
+    // inside rm_internal, so we don't duplicate the check here.
     rm_internal(prog_track, path, path, settings).await
 }
 #[instrument(skip(prog_track, settings))]
@@ -218,13 +235,24 @@ async fn rm_internal(
                     if settings.fail_early {
                         return Err(Error::new(err, Default::default()));
                     }
-                    // log and skip — never delete an entry whose age we cannot verify
-                    tracing::error!(
-                        "time filter evaluation failed for {} {:?}, skipping: {:#}",
-                        entry_type,
-                        &path,
-                        &err
-                    );
+                    // log and skip — never delete an entry whose age we cannot verify.
+                    // btime being unsupported (common for symlinks) is expected noise, so
+                    // downgrade to warn; anything else is unexpected and stays at error.
+                    if is_unsupported_io_error(&err) {
+                        tracing::warn!(
+                            "time filter evaluation unsupported for {} {:?}, skipping: {:#}",
+                            entry_type,
+                            &path,
+                            &err
+                        );
+                    } else {
+                        tracing::error!(
+                            "time filter evaluation failed for {} {:?}, skipping: {:#}",
+                            entry_type,
+                            &path,
+                            &err
+                        );
+                    }
                     return Ok(make_skipped_summary());
                 }
             }
@@ -386,20 +414,69 @@ async fn rm_internal(
             .filter
             .as_ref()
             .is_some_and(|f| f.has_includes() && !f.directly_matches_include(relative_path, true));
+    // evaluate the directory's own time filter to decide whether to remove it.
+    // the time filter is an entry filter, not a subtree gate: children are already handled
+    // by their own recursive calls, so this decision only controls the final remove_dir.
+    // returns Ok(true) = proceed, Ok(false) = skip (too new), Err propagates a fail-early.
+    // the src_metadata captured at entry is used so rrm's own mutations during traversal
+    // don't change the answer.
+    let dir_passes_time_filter: bool = if let Some(ref time_filter) = settings.time_filter {
+        match time_filter.matches(&src_metadata) {
+            Ok(result) => match result.as_skip_reason() {
+                Some(reason) => {
+                    if let Some(mode) = settings.dry_run {
+                        crate::dry_run::report_time_skip(path, reason, mode, "dir");
+                    }
+                    false
+                }
+                None => true,
+            },
+            Err(err) => {
+                let err = err.context(format!("failed evaluating time filter on {:?}", &path));
+                if settings.fail_early {
+                    return Err(Error::new(err, rm_summary));
+                }
+                // log and skip — never remove a directory whose age we cannot verify.
+                // btime being unsupported on the filesystem is expected noise; downgrade
+                // to warn. anything else is unexpected and stays at error.
+                if is_unsupported_io_error(&err) {
+                    tracing::warn!(
+                        "time filter evaluation unsupported for dir {:?}, leaving it intact: {:#}",
+                        &path,
+                        &err
+                    );
+                } else {
+                    tracing::error!(
+                        "time filter evaluation failed for dir {:?}, leaving it intact: {:#}",
+                        &path,
+                        &err
+                    );
+                }
+                false
+            }
+        }
+    } else {
+        true
+    };
     // handle dry-run mode for directories.
     // `traversed_only` catches dirs only entered to search for include pattern matches.
-    // `anything_skipped` catches dirs that would still have content after partial removal
-    // (applies to both include and exclude filters).
-    // the real-mode path below only needs `traversed_only` because the subsequent `remove_dir`
-    // call handles the non-empty case via ENOTEMPTY.
+    // `anything_skipped` catches dirs that would still have content after partial removal.
+    // `!dir_passes_time_filter` catches dirs whose own timestamps disqualify removal.
+    // the real-mode path below only needs `traversed_only` and `!dir_passes_time_filter`
+    // because the subsequent `remove_dir` call handles the non-empty case via ENOTEMPTY.
     if settings.dry_run.is_some() {
-        if traversed_only || anything_skipped {
+        if traversed_only || anything_skipped || !dir_passes_time_filter {
             tracing::debug!(
-                "dry-run: directory {:?} would not be removed (removed={}, skipped={})",
+                "dry-run: directory {:?} would not be removed (removed={}, skipped={}, time_ok={})",
                 &path,
                 anything_removed,
-                anything_skipped
+                anything_skipped,
+                dir_passes_time_filter
             );
+            if !dir_passes_time_filter {
+                prog_track.directories_skipped.inc();
+                rm_summary.directories_skipped += 1;
+            }
         } else {
             crate::dry_run::report_action("remove", path, None, "dir");
             rm_summary.directories_removed += 1;
@@ -416,6 +493,17 @@ async fn rm_internal(
         );
         return Ok(rm_summary);
     }
+    // skip directories whose own timestamps don't satisfy the time filter.
+    // children have already been processed; this only gates the dir's own removal.
+    if !dir_passes_time_filter {
+        tracing::debug!(
+            "directory {:?} skipped by time filter, leaving it intact",
+            &path
+        );
+        prog_track.directories_skipped.inc();
+        rm_summary.directories_skipped += 1;
+        return Ok(rm_summary);
+    }
     // when filtering is active, directories may not be empty because we only removed
     // matching files (includes) or skipped excluded files; use remove_dir (not remove_dir_all)
     // so non-empty directories fail gracefully with ENOTEMPTY
@@ -427,10 +515,11 @@ async fn rm_internal(
         }
         Err(err) if any_filter_active => {
             // with filtering, it's expected that directories may not be empty because we only
-            // removed matching files; raw_os_error 39 is ENOTEMPTY on Linux
+            // removed matching files; raw_os_error 39 is ENOTEMPTY on Linux. this is not an
+            // error — surface it at info so users can see which directories survived.
             if err.kind() == std::io::ErrorKind::DirectoryNotEmpty || err.raw_os_error() == Some(39)
             {
-                tracing::debug!(
+                tracing::info!(
                     "directory {:?} not empty after filtering, leaving it intact",
                     &path
                 );
@@ -1167,6 +1256,8 @@ mod tests {
             let file = test_path.join("old.txt");
             tokio::fs::write(&file, "x").await?;
             set_mtime_age(&file, std::time::Duration::from_secs(7200))?;
+            // age test_path so the root dir passes its own time filter check
+            set_mtime_age(&test_path, std::time::Duration::from_secs(7200))?;
             let summary = rm(
                 &PROGRESS,
                 &test_path,
@@ -1195,6 +1286,7 @@ mod tests {
             let file = test_path.join("new.txt");
             tokio::fs::write(&file, "x").await?;
             set_mtime_age(&file, std::time::Duration::from_secs(60))?;
+            set_mtime_age(&test_path, std::time::Duration::from_secs(7200))?;
             let summary = rm(
                 &PROGRESS,
                 &test_path,
@@ -1215,20 +1307,25 @@ mod tests {
             Ok(())
         }
 
-        /// Time filter applies to files only — directories descend regardless.
+        /// A fresh subdirectory is descended into (children are handled individually),
+        /// but the fresh_dir itself is not removed because its own mtime is too recent.
         #[tokio::test]
         #[traced_test]
-        async fn time_filter_does_not_apply_to_directories() -> Result<(), anyhow::Error> {
+        async fn fresh_subdirectory_is_descended_but_not_removed() -> Result<(), anyhow::Error> {
             let test_path = testutils::create_temp_dir().await?;
-            let dir = test_path.join("dir");
-            tokio::fs::create_dir(&dir).await?;
-            let old_file = dir.join("old.txt");
-            let new_file = dir.join("new.txt");
+            let old_file = test_path.join("old.txt");
+            let fresh_dir = test_path.join("fresh_dir");
+            let fresh_child = fresh_dir.join("fresh_child.txt");
+            let old_child = fresh_dir.join("old_child.txt");
             tokio::fs::write(&old_file, "x").await?;
-            tokio::fs::write(&new_file, "x").await?;
+            tokio::fs::create_dir(&fresh_dir).await?;
+            tokio::fs::write(&fresh_child, "x").await?;
+            tokio::fs::write(&old_child, "x").await?;
             set_mtime_age(&old_file, std::time::Duration::from_secs(7200))?;
-            set_mtime_age(&new_file, std::time::Duration::from_secs(60))?;
-            // even though 'dir' is freshly created (recent mtime), it should be traversed.
+            set_mtime_age(&old_child, std::time::Duration::from_secs(7200))?;
+            // fresh_child keeps its recent mtime; so does fresh_dir (we took the mtime
+            // snapshot before remove_file mutates it)
+            set_mtime_age(&test_path, std::time::Duration::from_secs(7200))?;
             let summary = rm(
                 &PROGRESS,
                 &test_path,
@@ -1243,23 +1340,101 @@ mod tests {
                 },
             )
             .await?;
-            assert_eq!(summary.files_removed, 1, "old file should be removed");
-            assert_eq!(summary.files_skipped, 1, "new file should be skipped");
-            // directories must never be counted as time-filter-skipped; even though
-            // 'dir' and test_path both have recent mtime, they are traversed normally.
+            // we descend into fresh_dir: old_child removed, fresh_child skipped
+            assert_eq!(summary.files_removed, 2, "old.txt and old_child removed");
             assert_eq!(
-                summary.directories_skipped, 0,
-                "directories must never be skipped by time filter"
+                summary.files_skipped, 1,
+                "fresh_child skipped inside fresh_dir"
             );
-            // 'dir' still contains 'new.txt', so neither 'dir' nor the root are empty —
-            // neither should be removed.
+            assert_eq!(
+                summary.directories_skipped, 1,
+                "fresh_dir itself is skipped at removal time"
+            );
             assert_eq!(
                 summary.directories_removed, 0,
-                "non-empty directories should not be removed"
+                "root survives because fresh_dir is still inside it"
             );
-            assert!(!old_file.exists(), "old.txt should be removed");
+            assert!(!old_file.exists());
+            assert!(!old_child.exists(), "old_child inside fresh_dir removed");
+            assert!(
+                fresh_dir.exists(),
+                "fresh_dir kept despite its old child being removed"
+            );
+            assert!(fresh_child.exists(), "fresh_child inside fresh_dir kept");
+            Ok(())
+        }
+
+        /// An old directory that still holds a new (skipped) file survives as non-empty.
+        /// The leftover-dir case is not treated as an error.
+        #[tokio::test]
+        #[traced_test]
+        async fn old_dir_with_new_file_leaves_non_empty_dir_without_error(
+        ) -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let old_dir = test_path.join("old_dir");
+            tokio::fs::create_dir(&old_dir).await?;
+            let new_file = old_dir.join("new.txt");
+            tokio::fs::write(&new_file, "x").await?;
+            set_mtime_age(&new_file, std::time::Duration::from_secs(60))?;
+            set_mtime_age(&old_dir, std::time::Duration::from_secs(7200))?;
+            set_mtime_age(&test_path, std::time::Duration::from_secs(7200))?;
+            let result = rm(
+                &PROGRESS,
+                &test_path,
+                &Settings {
+                    fail_early: false,
+                    filter: None,
+                    time_filter: Some(TimeFilter {
+                        modified_before: Some(std::time::Duration::from_secs(3600)),
+                        created_before: None,
+                    }),
+                    dry_run: None,
+                },
+            )
+            .await;
+            let summary = result.expect("ENOTEMPTY should not surface as an error");
+            assert_eq!(summary.files_skipped, 1, "new file should be skipped");
+            assert_eq!(
+                summary.directories_removed, 0,
+                "old_dir cannot be removed while new.txt remains"
+            );
+            assert!(old_dir.exists(), "old_dir should still exist");
             assert!(new_file.exists(), "new.txt should still exist");
-            assert!(dir.exists(), "dir should still exist (contains new.txt)");
+            // the 'left intact' message is logged at info level
+            assert!(
+                logs_contain("not empty after filtering, leaving it intact"),
+                "should log ENOTEMPTY case at info"
+            );
+            Ok(())
+        }
+
+        /// An old, already-empty directory is removed by the time filter run.
+        #[tokio::test]
+        #[traced_test]
+        async fn old_empty_directory_is_removed() -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let old_empty = test_path.join("old_empty");
+            tokio::fs::create_dir(&old_empty).await?;
+            set_mtime_age(&old_empty, std::time::Duration::from_secs(7200))?;
+            set_mtime_age(&test_path, std::time::Duration::from_secs(7200))?;
+            let summary = rm(
+                &PROGRESS,
+                &test_path,
+                &Settings {
+                    fail_early: false,
+                    filter: None,
+                    time_filter: Some(TimeFilter {
+                        modified_before: Some(std::time::Duration::from_secs(3600)),
+                        created_before: None,
+                    }),
+                    dry_run: None,
+                },
+            )
+            .await?;
+            // both old_empty and test_path itself are removed
+            assert_eq!(summary.directories_removed, 2);
+            assert!(!old_empty.exists());
+            assert!(!test_path.exists());
             Ok(())
         }
 
@@ -1277,6 +1452,7 @@ mod tests {
             set_mtime_age(&old_keep, std::time::Duration::from_secs(7200))?;
             set_mtime_age(&old_drop, std::time::Duration::from_secs(7200))?;
             set_mtime_age(&new_drop, std::time::Duration::from_secs(60))?;
+            set_mtime_age(&test_path, std::time::Duration::from_secs(7200))?;
             let mut filter = crate::filter::FilterSettings::new();
             filter.add_exclude("*.log").unwrap();
             let summary = rm(
@@ -1319,6 +1495,7 @@ mod tests {
             tokio::fs::write(&new_file, "x").await?;
             set_mtime_age(&old_file, std::time::Duration::from_secs(7200))?;
             set_mtime_age(&new_file, std::time::Duration::from_secs(60))?;
+            set_mtime_age(&test_path, std::time::Duration::from_secs(7200))?;
             let summary = rm(
                 &PROGRESS,
                 &test_path,
@@ -1343,6 +1520,48 @@ mod tests {
             );
             assert!(old_file.exists(), "old.txt should still exist (dry-run)");
             assert!(new_file.exists(), "new.txt should still exist (dry-run)");
+            Ok(())
+        }
+
+        /// A fresh top-level directory is traversed (its old children are removed),
+        /// but the root itself is not removed because its own mtime is too recent.
+        #[tokio::test]
+        #[traced_test]
+        async fn fresh_top_level_directory_is_traversed_but_not_removed(
+        ) -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let old_inside = test_path.join("old.txt");
+            tokio::fs::write(&old_inside, "x").await?;
+            set_mtime_age(&old_inside, std::time::Duration::from_secs(7200))?;
+            // test_path itself is left fresh (recent mtime)
+            let summary = rm(
+                &PROGRESS,
+                &test_path,
+                &Settings {
+                    fail_early: false,
+                    filter: None,
+                    time_filter: Some(TimeFilter {
+                        modified_before: Some(std::time::Duration::from_secs(3600)),
+                        created_before: None,
+                    }),
+                    dry_run: None,
+                },
+            )
+            .await?;
+            assert_eq!(
+                summary.files_removed, 1,
+                "old child should be removed despite fresh parent"
+            );
+            assert_eq!(
+                summary.directories_skipped, 1,
+                "fresh root itself is skipped at removal time"
+            );
+            assert_eq!(
+                summary.directories_removed, 0,
+                "fresh root must not be removed"
+            );
+            assert!(test_path.exists(), "fresh root should still exist");
+            assert!(!old_inside.exists(), "old child should be gone");
             Ok(())
         }
 

--- a/rcp/src/destination.rs
+++ b/rcp/src/destination.rs
@@ -194,6 +194,7 @@ async fn process_single_file(
                         fail_early: settings.fail_early,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await
@@ -520,6 +521,7 @@ async fn create_directory(
                         fail_early: settings.fail_early,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await?;
@@ -612,6 +614,7 @@ async fn create_symlink(
                         fail_early: settings.fail_early,
                         filter: None,
                         dry_run: None,
+                        time_filter: None,
                     },
                 )
                 .await

--- a/rrm/Cargo.toml
+++ b/rrm/Cargo.toml
@@ -30,6 +30,7 @@ anyhow = "1.0"
 async-recursion = "1.1"
 clap = { version = "4", features = ["derive"] }
 common = { workspace = true }
+humantime = "2.3"
 thiserror = "2.0"
 tokio = { version = "1.52", features = ["full", "parking_lot", "tracing"] }
 tracing = "0.1"

--- a/rrm/src/main.rs
+++ b/rrm/src/main.rs
@@ -44,6 +44,29 @@ struct Args {
     #[arg(long, value_name = "PATH", conflicts_with_all = ["include", "exclude"], help_heading = "Filtering")]
     filter_file: Option<std::path::PathBuf>,
 
+    /// Only remove files whose modification time is at least this old
+    ///
+    /// Accepts human-readable durations (humantime format). Examples: `1y`, `6months`, `30d`,
+    /// `12h`, `30m`, `45s`. NOTE: `M` means months, lowercase `m` means minutes — they are
+    /// different units. Applies to files and symlinks only; directories are always traversed
+    /// and removed if empty afterwards. For symlinks the filter uses the symlink's own
+    /// timestamps (not the target's). When combined with `--created-before`, both conditions
+    /// must hold (AND).
+    #[arg(long, value_name = "DURATION", help_heading = "Filtering")]
+    modified_before: Option<String>,
+
+    /// Only remove files whose creation (birth) time is at least this old
+    ///
+    /// Accepts human-readable durations (humantime format). Examples: `1y`, `6months`, `30d`,
+    /// `12h`, `30m`, `45s`. NOTE: `M` means months, lowercase `m` means minutes — they are
+    /// different units. Applies to files and symlinks only; directories are always traversed
+    /// and removed if empty afterwards. For symlinks the filter uses the symlink's own
+    /// timestamps (not the target's). Some Linux filesystems (and most symlinks) do not
+    /// expose birth time; such entries are logged and skipped rather than removed. Pass
+    /// --fail-early to abort on the first such error instead.
+    #[arg(long, value_name = "DURATION", help_heading = "Filtering")]
+    created_before: Option<String>,
+
     /// Preview mode - show what would be removed without actually removing
     ///
     /// --progress and --summary are suppressed in dry-run mode (use -v to
@@ -150,6 +173,38 @@ struct Args {
     paths: Vec<std::path::PathBuf>,
 }
 
+fn parse_duration_arg(flag: &str, value: &str) -> Result<std::time::Duration> {
+    humantime::parse_duration(value).map_err(|err| {
+        anyhow!(
+            "{} value {:?} is not a valid duration: {}\n\
+             Hint: use suffixes like 1y, 6months, 30d, 12h, 30m, 45s. \
+             Note that 'M' means months and 'm' means minutes.",
+            flag,
+            value,
+            err
+        )
+    })
+}
+
+fn build_time_filter(
+    modified_before: Option<&str>,
+    created_before: Option<&str>,
+) -> Result<Option<common::filter::TimeFilter>> {
+    let modified_before = modified_before
+        .map(|v| parse_duration_arg("--modified-before", v))
+        .transpose()?;
+    let created_before = created_before
+        .map(|v| parse_duration_arg("--created-before", v))
+        .transpose()?;
+    if modified_before.is_none() && created_before.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(common::filter::TimeFilter {
+        modified_before,
+        created_before,
+    }))
+}
+
 #[instrument]
 async fn async_main(args: Args) -> Result<common::rm::Summary> {
     // build filter settings once before the loop
@@ -167,11 +222,16 @@ async fn async_main(args: Args) -> Result<common::rm::Summary> {
     } else {
         None
     };
+    let time_filter = build_time_filter(
+        args.modified_before.as_deref(),
+        args.created_before.as_deref(),
+    )?;
     let mut join_set = tokio::task::JoinSet::new();
     for path in args.paths {
         let settings = common::rm::Settings {
             fail_early: args.fail_early,
             filter: filter.clone(),
+            time_filter: time_filter.clone(),
             dry_run: args.dry_run,
         };
         let do_rm = || async move { common::rm(&path, &settings).await };
@@ -212,7 +272,11 @@ fn main() -> Result<()> {
             args.summary,
             args.verbose,
             false, // rrm has no --overwrite
-            !args.include.is_empty() || !args.exclude.is_empty() || args.filter_file.is_some(),
+            !args.include.is_empty()
+                || !args.exclude.is_empty()
+                || args.filter_file.is_some()
+                || args.modified_before.is_some()
+                || args.created_before.is_some(),
             false, // rrm has no destination
             false, // rrm has no --ignore-existing
         )

--- a/rrm/src/main.rs
+++ b/rrm/src/main.rs
@@ -44,27 +44,37 @@ struct Args {
     #[arg(long, value_name = "PATH", conflicts_with_all = ["include", "exclude"], help_heading = "Filtering")]
     filter_file: Option<std::path::PathBuf>,
 
-    /// Only remove files whose modification time is at least this old
+    /// Only remove entries whose modification time is at least this old
     ///
     /// Accepts human-readable durations (humantime format). Examples: `1y`, `6months`, `30d`,
     /// `12h`, `30m`, `45s`. NOTE: `M` means months, lowercase `m` means minutes — they are
-    /// different units. Applies to files and symlinks only; directories are always traversed
-    /// and removed if empty afterwards. For symlinks the filter uses the symlink's own
-    /// timestamps (not the target's). When combined with `--created-before`, both conditions
-    /// must hold (AND).
+    /// different units. This is an entry filter: it applies independently to each file,
+    /// symlink, and directory. Directories are always traversed regardless of their own
+    /// timestamps; a directory is only removed when its own mtime is old enough AND it
+    /// ends up empty after its children have been processed. A directory left non-empty
+    /// after filtering (because it contained skipped new children) is logged at info and
+    /// left intact — this is not an error. For symlinks the filter uses the symlink's own
+    /// timestamps (not the target's). When combined with `--created-before`, both
+    /// conditions must hold (AND).
     #[arg(long, value_name = "DURATION", help_heading = "Filtering")]
     modified_before: Option<String>,
 
-    /// Only remove files whose creation (birth) time is at least this old
+    /// Only remove entries whose creation (birth) time is at least this old
     ///
     /// Accepts human-readable durations (humantime format). Examples: `1y`, `6months`, `30d`,
     /// `12h`, `30m`, `45s`. NOTE: `M` means months, lowercase `m` means minutes — they are
-    /// different units. Applies to files and symlinks only; directories are always traversed
-    /// and removed if empty afterwards. For symlinks the filter uses the symlink's own
-    /// timestamps (not the target's). Some Linux filesystems (and most symlinks) do not
-    /// expose birth time; such entries are logged and skipped rather than removed. Pass
-    /// --fail-early to abort on the first such error instead.
+    /// different units. This is an entry filter: it applies independently to each file,
+    /// symlink, and directory. Directories are always traversed regardless of their own
+    /// timestamps; a directory is only removed when its own btime is old enough AND it
+    /// ends up empty after its children have been processed. A directory left non-empty
+    /// after filtering is logged at info and left intact — this is not an error. For
+    /// symlinks the filter uses the symlink's own timestamps (not the target's). Some
+    /// Linux filesystems (and most symlinks) do not expose birth time; such entries are
+    /// logged and skipped rather than removed. Pass --fail-early to abort on the first
+    /// such error instead. NOT AVAILABLE on musl builds — rebuild against glibc to use
+    /// this flag.
     #[arg(long, value_name = "DURATION", help_heading = "Filtering")]
+    #[cfg_attr(target_env = "musl", arg(hide = true))]
     created_before: Option<String>,
 
     /// Preview mode - show what would be removed without actually removing
@@ -266,6 +276,15 @@ async fn async_main(args: Args) -> Result<common::rm::Summary> {
 
 fn main() -> Result<()> {
     let args = Args::parse();
+    #[cfg(target_env = "musl")]
+    if args.created_before.is_some() {
+        return Err(anyhow!(
+            "--created-before is not supported on musl builds: birth time (btime) is not \
+             readable via std::fs::Metadata::created() under musl, so every entry would \
+             fail evaluation and be skipped. Use --modified-before instead, or rebuild \
+             rrm against glibc."
+        ));
+    }
     let dry_run_warnings = args.dry_run.map(|_| {
         common::DryRunWarnings::new(
             args.progress || args.progress_type.is_some() || args.progress_delay.is_some(),

--- a/rrm/tests/cli_parsing_tests.rs
+++ b/rrm/tests/cli_parsing_tests.rs
@@ -193,3 +193,74 @@ fn test_progress_delay_duration() {
         .assert()
         .success();
 }
+
+// ============================================================================
+// Time-filter Argument Parsing Tests
+// ============================================================================
+
+// Helpers for duration-accept tests: run against an empty temp dir in dry-run
+// mode so parsing is actually exercised (unlike --help, which short-circuits
+// clap before the duration is forwarded to build_time_filter).
+fn accept_duration(flag: &str, value: &str, dir_name: &str) {
+    let tmp = std::env::temp_dir().join(dir_name);
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir(&tmp).unwrap();
+    Command::cargo_bin("rrm")
+        .unwrap()
+        .args(["--dry-run", "brief", flag, value, tmp.to_str().unwrap()])
+        .assert()
+        .success();
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn accepts_modified_before_year() {
+    accept_duration("--modified-before", "1y", "rrm_accept_mod_year");
+}
+
+#[test]
+fn accepts_modified_before_days() {
+    accept_duration("--modified-before", "30d", "rrm_accept_mod_days");
+}
+
+#[test]
+fn accepts_modified_before_months_uppercase_m() {
+    accept_duration("--modified-before", "6M", "rrm_accept_mod_months");
+}
+
+#[test]
+fn accepts_created_before_year() {
+    accept_duration("--created-before", "1y", "rrm_accept_created_year");
+}
+
+#[test]
+fn accepts_created_before_long_form() {
+    accept_duration("--created-before", "6months", "rrm_accept_created_longform");
+}
+
+#[test]
+fn rejects_invalid_modified_before_duration() {
+    // create a temp directory that won't be removed (parsing fails first)
+    let tmp = std::env::temp_dir().join("rrm_parse_test_dir");
+    let _ = std::fs::create_dir(&tmp);
+    Command::cargo_bin("rrm")
+        .unwrap()
+        .args(["--modified-before", "foo", tmp.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stdout(predicates::str::contains("--modified-before"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn rejects_invalid_created_before_duration() {
+    let tmp = std::env::temp_dir().join("rrm_parse_test_dir2");
+    let _ = std::fs::create_dir(&tmp);
+    Command::cargo_bin("rrm")
+        .unwrap()
+        .args(["--created-before", "not-a-duration", tmp.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stdout(predicates::str::contains("--created-before"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}

--- a/rrm/tests/cli_parsing_tests.rs
+++ b/rrm/tests/cli_parsing_tests.rs
@@ -229,11 +229,13 @@ fn accepts_modified_before_months_uppercase_m() {
 }
 
 #[test]
+#[cfg(not(target_env = "musl"))]
 fn accepts_created_before_year() {
     accept_duration("--created-before", "1y", "rrm_accept_created_year");
 }
 
 #[test]
+#[cfg(not(target_env = "musl"))]
 fn accepts_created_before_long_form() {
     accept_duration("--created-before", "6months", "rrm_accept_created_longform");
 }
@@ -253,6 +255,7 @@ fn rejects_invalid_modified_before_duration() {
 }
 
 #[test]
+#[cfg(not(target_env = "musl"))]
 fn rejects_invalid_created_before_duration() {
     let tmp = std::env::temp_dir().join("rrm_parse_test_dir2");
     let _ = std::fs::create_dir(&tmp);
@@ -262,5 +265,24 @@ fn rejects_invalid_created_before_duration() {
         .assert()
         .failure()
         .stdout(predicates::str::contains("--created-before"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// On musl, --created-before is accepted by clap but rejected at startup because
+/// std::fs::Metadata::created() cannot read btime under musl's stat wrapper.
+#[test]
+#[cfg(target_env = "musl")]
+fn rejects_created_before_on_musl() {
+    let tmp = std::env::temp_dir().join("rrm_musl_created_before");
+    let _ = std::fs::remove_dir_all(&tmp);
+    std::fs::create_dir(&tmp).unwrap();
+    Command::cargo_bin("rrm")
+        .unwrap()
+        .args(["--created-before", "1y", tmp.to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "--created-before is not supported on musl builds",
+        ));
     let _ = std::fs::remove_dir_all(&tmp);
 }


### PR DESCRIPTION
## Summary

Adds an age-based time filter to `rrm` so that entries older than a user-supplied threshold can be removed while newer entries are kept. Thresholds are specified with humantime durations (`30d`, `6months`, etc.) and accept `--modified-before` (mtime), `--created-before` (btime), or both (AND).

The filter is an **entry filter, not a subtree gate**: directories are always traversed so their old children can still be cleaned up. A directory is only removed when its own pre-traversal timestamp satisfies the threshold AND it ends up empty after traversal. A non-empty leftover (old dir still holding skipped new children) is logged at info and left intact — not treated as an error.

On musl `std::fs::Metadata::created()` cannot read btime, so `--created-before` is hidden from `--help` and rejected at startup with a clear error pointing to `--modified-before` or a glibc rebuild. `--modified-before` works on all targets.

## Test plan
- [x] `just ci` (debug + release + doctests + Docker multi-host): 651 tests pass on musl default build
- [x] Unit tests in `common/src/rm.rs::time_filter_tests` cover: old file removed, new file kept, fresh subdir traversed but not removed, fresh root traversed but not removed, old dir with new file leaves non-empty (info log), old empty dir collapses, filter + glob exclude AND, dry-run preview
- [x] `common/src/filter.rs::time_filter_tests` cover the `TimeFilter` matching logic including btime
- [x] `rrm/tests/cli_parsing_tests.rs` covers humantime parsing and error messages; new `rejects_created_before_on_musl` asserts the runtime rejection