### PR TITLE
Code quality refactor: shared primitives, CommonArgs, simpler lib::run

### DIFF
--- a/common/src/cli.rs
+++ b/common/src/cli.rs
@@ -3,13 +3,15 @@
 //! Each binary flattens [`CommonArgs`] into its own clap struct via
 //! `#[command(flatten)]`. Tool-specific arguments live in the binary itself.
 //!
-//! `chunk_size` is intentionally NOT in this struct: rcp/rcpd parse it as
-//! `bytesize::ByteSize` (to accept "16MiB" etc.), while rrm/rlink/rcmp/filegen
-//! parse it as a bare `u64`. Each binary keeps its own field.
-//!
-//! `summary` is also kept per-binary: rcpd never prints a summary (it streams
-//! results back to the master), so giving it a no-op `--summary` flag would
-//! mislead users.
+//! Fields intentionally NOT in this struct, so each binary can document them
+//! accurately:
+//! - `chunk_size` — rcp/rcpd parse as `bytesize::ByteSize` (e.g. "16MiB"),
+//!   others as bare `u64`.
+//! - `summary` — rcpd streams results to the master and never prints a summary.
+//! - `max_open_files` — filegen falls back to physical CPU cores instead of
+//!   80% of the system rlimit, because random-data generation is CPU-bound.
+//! - `quiet` — rcmp's `--quiet` also suppresses stdout differences (not just
+//!   error output), so its help text differs from the other tools.
 
 #[derive(Debug, Clone, clap::Args)]
 pub struct CommonArgs {
@@ -32,13 +34,7 @@ pub struct CommonArgs {
     /// Verbose level (implies "summary"): -v INFO / -vv DEBUG / -vvv TRACE (default: ERROR)
     #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, help_heading = "Progress & output")]
     pub verbose: u8,
-    /// Quiet mode, don't report errors
-    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
-    pub quiet: bool,
     // Performance & throttling
-    /// Maximum number of open files (0 = no limit, unspecified = 80% of system limit)
-    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
-    pub max_open_files: Option<usize>,
     /// Throttle the number of operations per second (0 = no throttle)
     #[arg(
         long,
@@ -77,12 +73,13 @@ pub struct CommonArgs {
 }
 
 impl CommonArgs {
-    /// Build a [`crate::OutputConfig`] from these args plus the binary's
-    /// per-instance `print_summary` decision.
+    /// Build a [`crate::OutputConfig`]. `quiet` and `print_summary` are
+    /// supplied by the caller (each binary owns its own `--quiet` and
+    /// `--summary` flags so it can document binary-specific semantics).
     #[must_use]
-    pub fn output_config(&self, print_summary: bool) -> crate::OutputConfig {
+    pub fn output_config(&self, quiet: bool, print_summary: bool) -> crate::OutputConfig {
         crate::OutputConfig {
-            quiet: self.quiet,
+            quiet,
             verbose: self.verbose,
             print_summary,
             ..Default::default()
@@ -96,13 +93,17 @@ impl CommonArgs {
             max_blocking_threads: self.max_blocking_threads,
         }
     }
-    /// Build a [`crate::ThrottleConfig`] from these args. `chunk_size` is
-    /// supplied by the caller because each binary parses it as a different
-    /// type at the CLI layer.
+    /// Build a [`crate::ThrottleConfig`]. `max_open_files` and `chunk_size`
+    /// are supplied by the caller (filegen has its own `--max-open-files`
+    /// default; chunk_size has different parser types per binary).
     #[must_use]
-    pub fn throttle_config(&self, chunk_size: u64) -> crate::ThrottleConfig {
+    pub fn throttle_config(
+        &self,
+        max_open_files: Option<usize>,
+        chunk_size: u64,
+    ) -> crate::ThrottleConfig {
         crate::ThrottleConfig {
-            max_open_files: self.max_open_files,
+            max_open_files,
             ops_throttle: self.ops_throttle,
             iops_throttle: self.iops_throttle,
             chunk_size,

--- a/common/src/cli.rs
+++ b/common/src/cli.rs
@@ -1,0 +1,129 @@
+//! Common CLI arguments shared by every RCP binary.
+//!
+//! Each binary flattens [`CommonArgs`] into its own clap struct via
+//! `#[command(flatten)]`. Tool-specific arguments live in the binary itself.
+//!
+//! `chunk_size` is intentionally NOT in this struct: rcp/rcpd parse it as
+//! `bytesize::ByteSize` (to accept "16MiB" etc.), while rrm/rlink/rcmp/filegen
+//! parse it as a bare `u64`. Each binary keeps its own field.
+//!
+//! `summary` is also kept per-binary: rcpd never prints a summary (it streams
+//! results back to the master), so giving it a no-op `--summary` flag would
+//! mislead users.
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct CommonArgs {
+    // Progress & output
+    /// Show progress
+    #[arg(long, help_heading = "Progress & output")]
+    pub progress: bool,
+    /// Set the type of progress display
+    ///
+    /// If specified, --progress flag is implied.
+    #[arg(long, value_name = "TYPE", help_heading = "Progress & output")]
+    pub progress_type: Option<crate::ProgressType>,
+    /// Set delay between progress updates
+    ///
+    /// Default is 200ms for interactive mode (`ProgressBar`) and 10s for non-interactive
+    /// mode (`TextUpdates`). If specified, --progress flag is implied. Accepts
+    /// human-readable durations like "200ms", "10s", "5min".
+    #[arg(long, value_name = "DELAY", help_heading = "Progress & output")]
+    pub progress_delay: Option<String>,
+    /// Verbose level (implies "summary"): -v INFO / -vv DEBUG / -vvv TRACE (default: ERROR)
+    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, help_heading = "Progress & output")]
+    pub verbose: u8,
+    /// Quiet mode, don't report errors
+    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
+    pub quiet: bool,
+    // Performance & throttling
+    /// Maximum number of open files (0 = no limit, unspecified = 80% of system limit)
+    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
+    pub max_open_files: Option<usize>,
+    /// Throttle the number of operations per second (0 = no throttle)
+    #[arg(
+        long,
+        default_value = "0",
+        value_name = "N",
+        help_heading = "Performance & throttling"
+    )]
+    pub ops_throttle: usize,
+    /// Limit I/O operations per second (0 = no throttle)
+    ///
+    /// Requires --chunk-size to calculate I/O operations per file: ((`file_size` - 1) / `chunk_size`) + 1
+    #[arg(
+        long,
+        default_value = "0",
+        value_name = "N",
+        help_heading = "Performance & throttling"
+    )]
+    pub iops_throttle: usize,
+    // Advanced settings
+    /// Number of worker threads (0 = number of CPU cores)
+    #[arg(
+        long,
+        default_value = "0",
+        value_name = "N",
+        help_heading = "Advanced settings"
+    )]
+    pub max_workers: usize,
+    /// Number of blocking worker threads (0 = Tokio default of 512)
+    #[arg(
+        long,
+        default_value = "0",
+        value_name = "N",
+        help_heading = "Advanced settings"
+    )]
+    pub max_blocking_threads: usize,
+}
+
+impl CommonArgs {
+    /// Build a [`crate::OutputConfig`] from these args plus the binary's
+    /// per-instance `print_summary` decision.
+    #[must_use]
+    pub fn output_config(&self, print_summary: bool) -> crate::OutputConfig {
+        crate::OutputConfig {
+            quiet: self.quiet,
+            verbose: self.verbose,
+            print_summary,
+            ..Default::default()
+        }
+    }
+    /// Build a [`crate::RuntimeConfig`] from these args.
+    #[must_use]
+    pub fn runtime_config(&self) -> crate::RuntimeConfig {
+        crate::RuntimeConfig {
+            max_workers: self.max_workers,
+            max_blocking_threads: self.max_blocking_threads,
+        }
+    }
+    /// Build a [`crate::ThrottleConfig`] from these args. `chunk_size` is
+    /// supplied by the caller because each binary parses it as a different
+    /// type at the CLI layer.
+    #[must_use]
+    pub fn throttle_config(&self, chunk_size: u64) -> crate::ThrottleConfig {
+        crate::ThrottleConfig {
+            max_open_files: self.max_open_files,
+            ops_throttle: self.ops_throttle,
+            iops_throttle: self.iops_throttle,
+            chunk_size,
+        }
+    }
+    /// Returns true if any progress-related flag was set.
+    #[must_use]
+    pub fn progress_requested(&self) -> bool {
+        self.progress || self.progress_type.is_some() || self.progress_delay.is_some()
+    }
+    /// Build user-facing [`crate::ProgressSettings`] when any progress flag was
+    /// set, else `None`. For `rcp`'s remote-master and `rcpd`'s remote progress
+    /// modes, build `ProgressSettings` directly instead of using this helper.
+    #[must_use]
+    pub fn user_progress_settings(&self) -> Option<crate::ProgressSettings> {
+        if !self.progress_requested() {
+            return None;
+        }
+        Some(crate::ProgressSettings {
+            progress_type: crate::GeneralProgressType::User(self.progress_type.unwrap_or_default()),
+            progress_delay: self.progress_delay.clone(),
+        })
+    }
+}

--- a/common/src/copy.rs
+++ b/common/src/copy.rs
@@ -13,30 +13,9 @@ use crate::rm;
 use crate::rm::{Settings as RmSettings, Summary as RmSummary};
 use crate::walk::{self, EntryKind};
 
-/// Error type for copy operations that preserves operation summary even on failure.
-///
-/// # Logging Convention
-/// When logging this error, use `{:#}` or `{:?}` format to preserve the error chain:
-/// ```ignore
-/// tracing::error!("operation failed: {:#}", &error); // ✅ Shows full chain
-/// tracing::error!("operation failed: {:?}", &error); // ✅ Shows full chain
-/// ```
-/// The Display implementation also shows the full chain, but workspace linting enforces `{:#}`
-/// for consistency.
-#[derive(Debug, thiserror::Error)]
-#[error("{source:#}")]
-pub struct Error {
-    #[source]
-    pub source: anyhow::Error,
-    pub summary: Summary,
-}
-
-impl Error {
-    #[must_use]
-    pub fn new(source: anyhow::Error, summary: Summary) -> Self {
-        Error { source, summary }
-    }
-}
+/// Error type for copy operations. See [`crate::error::OperationError`] for
+/// logging conventions and rationale.
+pub type Error = crate::error::OperationError<Summary>;
 
 /// Filter condition for overwrite operations.
 ///

--- a/common/src/copy.rs
+++ b/common/src/copy.rs
@@ -7,11 +7,11 @@ use tracing::instrument;
 
 use crate::config::DryRunMode;
 use crate::filecmp;
-use crate::filter::{FilterResult, FilterSettings};
 use crate::preserve;
 use crate::progress;
 use crate::rm;
 use crate::rm::{Settings as RmSettings, Summary as RmSummary};
+use crate::walk::{self, EntryKind};
 
 /// Error type for copy operations that preserves operation summary even on failure.
 ///
@@ -80,20 +80,23 @@ pub struct Settings {
     pub dry_run: Option<crate::config::DryRunMode>,
 }
 
-/// Check if a path should be filtered out
-fn should_skip_entry(
-    filter: &Option<FilterSettings>,
-    relative_path: &std::path::Path,
-    is_dir: bool,
-) -> Option<FilterResult> {
-    if let Some(ref f) = filter {
-        let result = f.should_include(relative_path, is_dir);
-        match result {
-            FilterResult::Included => None,
-            _ => Some(result),
-        }
-    } else {
-        None
+/// Summary with the appropriate `*_skipped` counter set to 1 for the given entry kind.
+/// Special files count as `files_skipped` to match the historical mapping used
+/// when filters skip an entry (`specials_skipped` is reserved for `--skip-specials`).
+fn skipped_summary_for(kind: EntryKind) -> Summary {
+    match kind {
+        EntryKind::Dir => Summary {
+            directories_skipped: 1,
+            ..Default::default()
+        },
+        EntryKind::Symlink => Summary {
+            symlinks_skipped: 1,
+            ..Default::default()
+        },
+        EntryKind::File | EntryKind::Special => Summary {
+            files_skipped: 1,
+            ..Default::default()
+        },
     }
 }
 
@@ -124,7 +127,7 @@ pub enum EmptyDirAction {
 /// * `is_root` - whether this is the root (user-specified) source directory
 /// * `is_dry_run` - whether we're in dry-run mode
 pub fn check_empty_dir_cleanup(
-    filter: Option<&FilterSettings>,
+    filter: Option<&crate::filter::FilterSettings>,
     we_created_dir: bool,
     anything_copied: bool,
     relative_path: &std::path::Path,
@@ -382,37 +385,12 @@ pub async fn copy(
             match result {
                 crate::filter::FilterResult::Included => {}
                 result => {
+                    let kind = EntryKind::from_metadata(&src_metadata);
                     if let Some(mode) = settings.dry_run {
-                        let entry_type = if src_metadata.is_dir() {
-                            "directory"
-                        } else if src_metadata.is_symlink() {
-                            "symlink"
-                        } else {
-                            "file"
-                        };
-                        crate::dry_run::report_skip(src, &result, mode, entry_type);
+                        crate::dry_run::report_skip(src, &result, mode, kind.label_long());
                     }
-                    // return summary with skipped count
-                    let skipped_summary = if src_metadata.is_dir() {
-                        prog_track.directories_skipped.inc();
-                        Summary {
-                            directories_skipped: 1,
-                            ..Default::default()
-                        }
-                    } else if src_metadata.is_symlink() {
-                        prog_track.symlinks_skipped.inc();
-                        Summary {
-                            symlinks_skipped: 1,
-                            ..Default::default()
-                        }
-                    } else {
-                        prog_track.files_skipped.inc();
-                        Summary {
-                            files_skipped: 1,
-                            ..Default::default()
-                        }
-                    };
-                    return Ok(skipped_summary);
+                    kind.inc_skipped(prog_track);
+                    return Ok(skipped_summary_for(kind));
                 }
             }
         }
@@ -801,42 +779,24 @@ async fn copy_internal(
         let dst_path = dst.join(entry_name);
         // check entry type for filter matching and skip counting
         let entry_file_type = entry.file_type().await.ok();
-        let entry_is_dir = entry_file_type.map(|ft| ft.is_dir()).unwrap_or(false);
-        let entry_is_symlink = entry_file_type.map(|ft| ft.is_symlink()).unwrap_or(false);
+        let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
+        let entry_is_dir = entry_kind == EntryKind::Dir;
         // compute relative path from source_root for filter matching
         let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
         // apply filter if configured
-        if let Some(skip_result) = should_skip_entry(&settings.filter, relative_path, entry_is_dir)
+        if let Some(skip_result) =
+            walk::should_skip_entry(&settings.filter, relative_path, entry_is_dir)
         {
             if let Some(mode) = settings.dry_run {
-                let entry_type = if entry_is_dir {
-                    "dir"
-                } else if entry_is_symlink {
-                    "symlink"
-                } else {
-                    "file"
-                };
-                crate::dry_run::report_skip(&entry_path, &skip_result, mode, entry_type);
+                crate::dry_run::report_skip(&entry_path, &skip_result, mode, entry_kind.label());
             }
             tracing::debug!("skipping {:?} due to filter", &entry_path);
-            // increment skipped counters
-            if entry_is_dir {
-                copy_summary.directories_skipped += 1;
-                prog_track.directories_skipped.inc();
-            } else if entry_is_symlink {
-                copy_summary.symlinks_skipped += 1;
-                prog_track.symlinks_skipped.inc();
-            } else {
-                copy_summary.files_skipped += 1;
-                prog_track.files_skipped.inc();
-            }
+            copy_summary = copy_summary + skipped_summary_for(entry_kind);
+            entry_kind.inc_skipped(prog_track);
             continue;
         }
         // skip special files (sockets, FIFOs, devices) when --skip-specials is set
-        let is_special = entry_file_type
-            .as_ref()
-            .is_some_and(|ft| !ft.is_dir() && !ft.is_symlink() && !ft.is_file());
-        if settings.skip_specials && is_special {
+        if settings.skip_specials && entry_kind == EntryKind::Special {
             tracing::debug!("skipping special file {:?}", &entry_path);
             if let Some(mode) = settings.dry_run {
                 match mode {
@@ -2710,6 +2670,7 @@ mod copy_tests {
 
     mod empty_dir_cleanup_tests {
         use super::*;
+        use crate::filter::FilterSettings;
         use std::path::Path;
         #[test]
         fn test_check_empty_dir_cleanup_no_filter() {
@@ -3597,6 +3558,7 @@ mod copy_tests {
     }
     mod dry_run_tests {
         use super::*;
+        use crate::filter::FilterSettings;
         /// Test that dry-run mode for directories doesn't create the destination
         /// and doesn't try to set metadata on non-existent directories.
         #[tokio::test]

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -1,0 +1,29 @@
+//! Generic error type for tree-walking operations that preserves the partial
+//! summary (work that completed before the error) alongside the error chain.
+//!
+//! Each operation (copy, link, rm, filegen) wraps this with a per-operation
+//! `Summary` via a type alias.
+//!
+//! # Logging Convention
+//! When logging this error, use `{:#}` or `{:?}` format to preserve the error chain:
+//! ```ignore
+//! tracing::error!("operation failed: {:#}", &error); // ✅ Shows full chain
+//! tracing::error!("operation failed: {:?}", &error); // ✅ Shows full chain
+//! ```
+//! The Display implementation also shows the full chain, but workspace linting enforces `{:#}`
+//! for consistency.
+
+#[derive(Debug, thiserror::Error)]
+#[error("{source:#}")]
+pub struct OperationError<S> {
+    #[source]
+    pub source: anyhow::Error,
+    pub summary: S,
+}
+
+impl<S> OperationError<S> {
+    #[must_use]
+    pub fn new(source: anyhow::Error, summary: S) -> Self {
+        OperationError { source, summary }
+    }
+}

--- a/common/src/filegen.rs
+++ b/common/src/filegen.rs
@@ -4,30 +4,9 @@ use tracing::instrument;
 
 use crate::progress;
 
-/// Error type for filegen operations that preserves operation summary even on failure.
-///
-/// # Logging Convention
-/// When logging this error, use `{:#}` or `{:?}` format to preserve the error chain:
-/// ```ignore
-/// tracing::error!("operation failed: {:#}", &error); // ✅ Shows full chain
-/// tracing::error!("operation failed: {:?}", &error); // ✅ Shows full chain
-/// ```
-/// The Display implementation also shows the full chain, but workspace linting enforces `{:#}`
-/// for consistency.
-#[derive(Debug, thiserror::Error)]
-#[error("{source:#}")]
-pub struct Error {
-    #[source]
-    pub source: anyhow::Error,
-    pub summary: Summary,
-}
-
-impl Error {
-    #[must_use]
-    pub fn new(source: anyhow::Error, summary: Summary) -> Self {
-        Error { source, summary }
-    }
-}
+/// Error type for filegen operations. See [`crate::error::OperationError`] for
+/// logging conventions and rationale.
+pub type Error = crate::error::OperationError<Summary>;
 
 #[derive(Copy, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct Summary {

--- a/common/src/filter.rs
+++ b/common/src/filter.rs
@@ -358,6 +358,38 @@ impl FilterSettings {
             .with_context(|| format!("failed to read filter file: {:?}", path))?;
         Self::parse_content(&content)
     }
+    /// Build filter settings from CLI arguments. Either reads patterns from a
+    /// filter file, builds them from --include/--exclude lists, or returns
+    /// `None` when no filtering was requested.
+    ///
+    /// The file path and the include/exclude lists are mutually exclusive: the
+    /// CLI layer enforces this via clap's `conflicts_with_all`, and this helper
+    /// returns an error if a non-clap caller passes both.
+    pub fn from_args(
+        filter_file: Option<&std::path::Path>,
+        include: &[String],
+        exclude: &[String],
+    ) -> Result<Option<Self>, anyhow::Error> {
+        if filter_file.is_some() && (!include.is_empty() || !exclude.is_empty()) {
+            return Err(anyhow!(
+                "filter_file is mutually exclusive with include/exclude patterns"
+            ));
+        }
+        if let Some(path) = filter_file {
+            return Ok(Some(Self::from_file(path)?));
+        }
+        if include.is_empty() && exclude.is_empty() {
+            return Ok(None);
+        }
+        let mut settings = Self::new();
+        for p in include {
+            settings.add_include(p)?;
+        }
+        for p in exclude {
+            settings.add_exclude(p)?;
+        }
+        Ok(Some(settings))
+    }
     /// Parse filter settings from a string (filter file format)
     pub fn parse_content(content: &str) -> Result<Self, anyhow::Error> {
         let mut settings = Self::new();
@@ -1288,6 +1320,101 @@ mod tests {
                     Some(TimeSkipReason::TooNewBoth)
                 );
             }
+        }
+    }
+    mod from_args_tests {
+        use super::*;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        /// RAII guard that writes a uniquely-named filter file under the
+        /// system temp dir and removes it when dropped. /tmp policies vary
+        /// (systemd-tmpfiles often runs weekly, never on some hosts), so
+        /// explicit cleanup keeps tests from leaving junk behind.
+        struct TempFilterFile {
+            path: std::path::PathBuf,
+        }
+        impl TempFilterFile {
+            fn new(content: &str) -> Self {
+                let n = SEQ.fetch_add(1, Ordering::Relaxed);
+                let path = std::env::temp_dir()
+                    .join(format!("rcp-from-args-test-{}-{n}.txt", std::process::id()));
+                std::fs::write(&path, content).unwrap();
+                Self { path }
+            }
+            fn path(&self) -> &std::path::Path {
+                &self.path
+            }
+        }
+        impl Drop for TempFilterFile {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_file(&self.path);
+            }
+        }
+        #[test]
+        fn returns_none_when_nothing_specified() {
+            let result = FilterSettings::from_args(None, &[], &[]).unwrap();
+            assert!(result.is_none());
+        }
+        #[test]
+        fn builds_from_include_only() {
+            let include = vec!["*.rs".to_string(), "Cargo.toml".to_string()];
+            let settings = FilterSettings::from_args(None, &include, &[])
+                .unwrap()
+                .expect("should return Some when include is non-empty");
+            assert_eq!(settings.includes.len(), 2);
+            assert!(settings.excludes.is_empty());
+        }
+        #[test]
+        fn builds_from_exclude_only() {
+            let exclude = vec!["*.log".to_string(), "target/".to_string()];
+            let settings = FilterSettings::from_args(None, &[], &exclude)
+                .unwrap()
+                .expect("should return Some when exclude is non-empty");
+            assert!(settings.includes.is_empty());
+            assert_eq!(settings.excludes.len(), 2);
+        }
+        #[test]
+        fn builds_from_include_and_exclude() {
+            let include = vec!["*.rs".to_string()];
+            let exclude = vec!["target/".to_string()];
+            let settings = FilterSettings::from_args(None, &include, &exclude)
+                .unwrap()
+                .expect("should return Some");
+            assert_eq!(settings.includes.len(), 1);
+            assert_eq!(settings.excludes.len(), 1);
+        }
+        #[test]
+        fn loads_from_filter_file() {
+            let file = TempFilterFile::new("--include *.rs\n--exclude target/\n");
+            let settings = FilterSettings::from_args(Some(file.path()), &[], &[])
+                .unwrap()
+                .expect("should return Some when filter file is read");
+            assert_eq!(settings.includes.len(), 1);
+            assert_eq!(settings.excludes.len(), 1);
+        }
+        #[test]
+        fn errors_when_filter_file_combined_with_include() {
+            let file = TempFilterFile::new("--include *.rs\n");
+            let include = vec!["*.txt".to_string()];
+            let err = FilterSettings::from_args(Some(file.path()), &include, &[]).unwrap_err();
+            assert!(err.to_string().contains("mutually exclusive"));
+        }
+        #[test]
+        fn errors_when_filter_file_combined_with_exclude() {
+            let file = TempFilterFile::new("--include *.rs\n");
+            let exclude = vec!["*.log".to_string()];
+            let err = FilterSettings::from_args(Some(file.path()), &[], &exclude).unwrap_err();
+            assert!(err.to_string().contains("mutually exclusive"));
+        }
+        #[test]
+        fn propagates_invalid_include_pattern() {
+            let include = vec!["".to_string()];
+            assert!(FilterSettings::from_args(None, &include, &[]).is_err());
+        }
+        #[test]
+        fn propagates_missing_filter_file() {
+            let path = std::path::PathBuf::from("/nonexistent/path/filters.txt");
+            assert!(FilterSettings::from_args(Some(&path), &[], &[]).is_err());
         }
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -823,47 +823,70 @@ pub fn generate_trace_filename(prefix: &str, identifier: &str, extension: &str) 
     format!("{prefix}-{identifier}-{hostname}-{pid}-{timestamp}.{extension}")
 }
 
-#[instrument(skip(func))] // "func" is not Debug printable
-pub fn run<Fut, Summary, Error>(
-    progress: Option<ProgressSettings>,
-    output: OutputConfig,
-    runtime: RuntimeConfig,
-    throttle: ThrottleConfig,
-    tracing_config: TracingConfig,
-    func: impl FnOnce() -> Fut,
-) -> Option<Summary>
-// we return an Option rather than a Result to indicate that callers of this function should NOT print the error
-where
-    Summary: std::fmt::Display,
-    Error: std::fmt::Display + std::fmt::Debug,
-    Fut: std::future::Future<Output = Result<Summary, Error>>,
-{
-    // force initialization of PROGRESS to set start_time at the beginning of the run
-    // (for remote master operations, PROGRESS is otherwise only accessed at the end in
-    // print_runtime_stats(), leading to near-zero walltime)
-    let _ = get_progress();
-    // validate configuration
-    if let Err(e) = throttle.validate() {
-        eprintln!("Configuration error: {e}");
-        return None;
+/// Build the verbose-level [`tracing_subscriber::EnvFilter`] used by every
+/// non-profile tracing layer (file, fmt, remote). Excludes noisy deps that are
+/// rarely useful when debugging rcp.
+fn build_verbose_env_filter(verbose: u8) -> tracing_subscriber::EnvFilter {
+    let level_directive = match verbose {
+        0 => "error".parse().unwrap(),
+        1 => "info".parse().unwrap(),
+        2 => "debug".parse().unwrap(),
+        _ => "trace".parse().unwrap(),
+    };
+    tracing_subscriber::EnvFilter::from_default_env()
+        .add_directive(level_directive)
+        .add_directive("tokio=info".parse().unwrap())
+        .add_directive("runtime=info".parse().unwrap())
+        .add_directive("quinn=warn".parse().unwrap())
+        .add_directive("rustls=warn".parse().unwrap())
+        .add_directive("h2=warn".parse().unwrap())
+}
+
+/// Build the [`tracing_subscriber::EnvFilter`] used by chrome/flame profile
+/// layers. Profiling layers don't share the verbose-level filter because they
+/// have their own `--profile-level`. Returns the formatted filter string —
+/// callers re-parse it per layer because EnvFilter isn't Clone.
+fn build_profile_filter_str(profile_level: Option<&str>) -> String {
+    let level_str = profile_level.unwrap_or("trace");
+    let valid_levels = ["trace", "debug", "info", "warn", "error", "off"];
+    if !valid_levels.contains(&level_str.to_lowercase().as_str()) {
+        eprintln!(
+            "Invalid --profile-level '{level_str}'. Valid values: trace, debug, info, warn, error, off"
+        );
+        std::process::exit(1);
     }
-    // unpack configs for internal use
-    let OutputConfig {
-        quiet,
-        verbose,
-        print_summary,
-        suppress_runtime_stats,
-    } = output;
-    let RuntimeConfig {
-        max_workers,
-        max_blocking_threads,
-    } = runtime;
-    let ThrottleConfig {
-        max_open_files,
-        ops_throttle,
-        iops_throttle,
-        chunk_size: _,
-    } = throttle;
+    format!("tokio=off,quinn=off,h2=off,hyper=off,rustls=off,{level_str}")
+}
+
+/// Guards from chrome/flame tracing layers that must outlive the runtime to
+/// flush traces on shutdown. Hold the returned struct for the lifetime of the
+/// run.
+#[allow(dead_code)] // fields are kept alive only for their Drop side-effects
+struct TracingGuards {
+    chrome: Option<tracing_chrome::FlushGuard>,
+    flame: Option<tracing_flame::FlushGuard<std::io::BufWriter<std::fs::File>>>,
+}
+
+/// Install the global [`tracing_subscriber`] registry from a [`TracingConfig`].
+/// Caller must hold the returned [`TracingGuards`] until the run finishes so
+/// that chrome/flame traces are flushed before the file handles close.
+///
+/// In quiet mode this is a no-op (the subscriber is never installed).
+fn install_tracing_subscriber(
+    quiet: bool,
+    verbose: u8,
+    tracing_config: TracingConfig,
+) -> TracingGuards {
+    if quiet {
+        assert!(
+            verbose == 0,
+            "Quiet mode and verbose mode are mutually exclusive"
+        );
+        return TracingGuards {
+            chrome: None,
+            flame: None,
+        };
+    }
     let TracingConfig {
         remote_layer: remote_tracing_layer,
         debug_log_file,
@@ -874,59 +897,29 @@ where
         tokio_console,
         tokio_console_port,
     } = tracing_config;
-    // guards must be kept alive for the duration of the run to ensure traces are flushed
-    let mut _chrome_guard: Option<tracing_chrome::FlushGuard> = None;
-    let mut _flame_guard: Option<tracing_flame::FlushGuard<std::io::BufWriter<std::fs::File>>> =
-        None;
-    if quiet {
-        assert!(
-            verbose == 0,
-            "Quiet mode and verbose mode are mutually exclusive"
-        );
+    let file_layer = debug_log_file.map(|log_file_path| {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_file_path)
+            .unwrap_or_else(|e| {
+                panic!("Failed to create debug log file at '{log_file_path}': {e}")
+            });
+        tracing_subscriber::fmt::layer()
+            .with_target(true)
+            .with_line_number(true)
+            .with_thread_ids(true)
+            .with_timer(LocalTimeFormatter)
+            .with_ansi(false)
+            .with_writer(file)
+            .with_filter(build_verbose_env_filter(verbose))
+    });
+    // fmt_layer for local console output (when not using remote tracing)
+    let fmt_layer = if remote_tracing_layer.is_some() {
+        None
     } else {
-        // helper to create the verbose-level filter consistently
-        let make_env_filter = || {
-            let level_directive = match verbose {
-                0 => "error".parse().unwrap(),
-                1 => "info".parse().unwrap(),
-                2 => "debug".parse().unwrap(),
-                _ => "trace".parse().unwrap(),
-            };
-            // filter out noisy dependencies - they're extremely verbose at DEBUG/TRACE level
-            // and not useful for debugging rcp
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive(level_directive)
-                .add_directive("tokio=info".parse().unwrap())
-                .add_directive("runtime=info".parse().unwrap())
-                .add_directive("quinn=warn".parse().unwrap())
-                .add_directive("rustls=warn".parse().unwrap())
-                .add_directive("h2=warn".parse().unwrap())
-        };
-        let file_layer = if let Some(ref log_file_path) = debug_log_file {
-            let file = std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(log_file_path)
-                .unwrap_or_else(|e| {
-                    panic!("Failed to create debug log file at '{log_file_path}': {e}")
-                });
-            let file_layer = tracing_subscriber::fmt::layer()
-                .with_target(true)
-                .with_line_number(true)
-                .with_thread_ids(true)
-                .with_timer(LocalTimeFormatter)
-                .with_ansi(false)
-                .with_writer(file)
-                .with_filter(make_env_filter());
-            Some(file_layer)
-        } else {
-            None
-        };
-        // fmt_layer for local console output (when not using remote tracing)
-        let fmt_layer = if remote_tracing_layer.is_some() {
-            None
-        } else {
-            let fmt_layer = tracing_subscriber::fmt::layer()
+        Some(
+            tracing_subscriber::fmt::layer()
                 .with_target(true)
                 .with_line_number(true)
                 .with_span_events(if verbose > 2 {
@@ -937,102 +930,87 @@ where
                 .with_timer(LocalTimeFormatter)
                 .pretty()
                 .with_writer(ProgWriter::new)
-                .with_filter(make_env_filter());
-            Some(fmt_layer)
-        };
-        // apply env_filter to remote_tracing_layer so it respects verbose level
-        let remote_tracing_layer =
-            remote_tracing_layer.map(|layer| layer.with_filter(make_env_filter()));
-        let console_layer = if tokio_console {
-            let console_port = tokio_console_port.unwrap_or(6669);
-            let retention_seconds: u64 =
-                read_env_or_default("RCP_TOKIO_TRACING_CONSOLE_RETENTION_SECONDS", 60);
-            eprintln!("Tokio console server listening on 127.0.0.1:{console_port}");
-            let console_layer = console_subscriber::ConsoleLayer::builder()
-                .retention(std::time::Duration::from_secs(retention_seconds))
-                .server_addr(([127, 0, 0, 1], console_port))
-                .spawn();
-            Some(console_layer)
-        } else {
-            None
-        };
-        // build profile filter for chrome/flame layers
-        // uses EnvFilter to capture spans from our crates at the specified level
-        // while excluding noisy dependencies like tokio, quinn, h2, etc.
-        let profiling_enabled = chrome_trace_prefix.is_some() || flamegraph_prefix.is_some();
-        let profile_filter_str = if profiling_enabled {
-            let level_str = profile_level.as_deref().unwrap_or("trace");
-            // validate level is a known tracing level
-            let valid_levels = ["trace", "debug", "info", "warn", "error", "off"];
-            if !valid_levels.contains(&level_str.to_lowercase().as_str()) {
-                eprintln!(
-                    "Invalid --profile-level '{}'. Valid values: trace, debug, info, warn, error, off",
-                    level_str
-                );
-                std::process::exit(1);
+                .with_filter(build_verbose_env_filter(verbose)),
+        )
+    };
+    // apply env_filter to remote_tracing_layer so it respects verbose level
+    let remote_tracing_layer =
+        remote_tracing_layer.map(|layer| layer.with_filter(build_verbose_env_filter(verbose)));
+    let console_layer = tokio_console.then(|| {
+        let console_port = tokio_console_port.unwrap_or(6669);
+        let retention_seconds: u64 =
+            read_env_or_default("RCP_TOKIO_TRACING_CONSOLE_RETENTION_SECONDS", 60);
+        eprintln!("Tokio console server listening on 127.0.0.1:{console_port}");
+        console_subscriber::ConsoleLayer::builder()
+            .retention(std::time::Duration::from_secs(retention_seconds))
+            .server_addr(([127, 0, 0, 1], console_port))
+            .spawn()
+    });
+    // chrome/flame share a profile filter; build the string once and re-parse
+    // per layer (EnvFilter isn't Clone).
+    let profile_filter_str = (chrome_trace_prefix.is_some() || flamegraph_prefix.is_some())
+        .then(|| build_profile_filter_str(profile_level.as_deref()));
+    let make_profile_filter =
+        || tracing_subscriber::EnvFilter::new(profile_filter_str.as_ref().unwrap());
+    let mut chrome_guard = None;
+    let chrome_layer = chrome_trace_prefix.as_ref().map(|prefix| {
+        let filename = generate_trace_filename(prefix, &trace_identifier, "json");
+        eprintln!("Chrome trace will be written to: {filename}");
+        let (layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
+            .file(&filename)
+            .include_args(true)
+            .build();
+        chrome_guard = Some(guard);
+        layer.with_filter(make_profile_filter())
+    });
+    let mut flame_guard = None;
+    let flame_layer = flamegraph_prefix.as_ref().and_then(|prefix| {
+        let filename = generate_trace_filename(prefix, &trace_identifier, "folded");
+        eprintln!("Flamegraph data will be written to: {filename}");
+        match tracing_flame::FlameLayer::with_file(&filename) {
+            Ok((layer, guard)) => {
+                flame_guard = Some(guard);
+                Some(layer.with_filter(make_profile_filter()))
             }
-            // exclude noisy deps, include everything else at the profile level
-            Some(format!(
-                "tokio=off,quinn=off,h2=off,hyper=off,rustls=off,{}",
-                level_str
-            ))
-        } else {
-            None
-        };
-        // helper to create profile filter (already validated above)
-        let make_profile_filter =
-            || tracing_subscriber::EnvFilter::new(profile_filter_str.as_ref().unwrap());
-        // chrome tracing layer (produces JSON viewable in Perfetto UI)
-        let chrome_layer = if let Some(ref prefix) = chrome_trace_prefix {
-            let filename = generate_trace_filename(prefix, &trace_identifier, "json");
-            eprintln!("Chrome trace will be written to: {filename}");
-            let (layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
-                .file(&filename)
-                .include_args(true)
-                .build();
-            _chrome_guard = Some(guard);
-            Some(layer.with_filter(make_profile_filter()))
-        } else {
-            None
-        };
-        // flamegraph layer (produces folded stacks for inferno)
-        let flame_layer = if let Some(ref prefix) = flamegraph_prefix {
-            let filename = generate_trace_filename(prefix, &trace_identifier, "folded");
-            eprintln!("Flamegraph data will be written to: {filename}");
-            match tracing_flame::FlameLayer::with_file(&filename) {
-                Ok((layer, guard)) => {
-                    _flame_guard = Some(guard);
-                    Some(layer.with_filter(make_profile_filter()))
-                }
-                Err(e) => {
-                    eprintln!("Failed to create flamegraph layer: {e}");
-                    None
-                }
+            Err(e) => {
+                eprintln!("Failed to create flamegraph layer: {e}");
+                None
             }
-        } else {
-            None
-        };
-        tracing_subscriber::registry()
-            .with(file_layer)
-            .with(fmt_layer)
-            .with(remote_tracing_layer)
-            .with(console_layer)
-            .with(chrome_layer)
-            .with(flame_layer)
-            .init();
+        }
+    });
+    tracing_subscriber::registry()
+        .with(file_layer)
+        .with(fmt_layer)
+        .with(remote_tracing_layer)
+        .with(console_layer)
+        .with(chrome_layer)
+        .with(flame_layer)
+        .init();
+    TracingGuards {
+        chrome: chrome_guard,
+        flame: flame_guard,
     }
+}
+
+/// Build a multi-threaded tokio runtime configured per `runtime`, and apply
+/// the `max_open_files` limit from `throttle`. Falls back to ~80% of the
+/// system rlimit (capped at 4096) when `max_open_files` is unset.
+fn build_tokio_runtime(
+    runtime: &RuntimeConfig,
+    throttle: &ThrottleConfig,
+) -> tokio::runtime::Runtime {
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
-    if max_workers > 0 {
-        builder.worker_threads(max_workers);
+    if runtime.max_workers > 0 {
+        builder.worker_threads(runtime.max_workers);
     }
-    if max_blocking_threads > 0 {
-        builder.max_blocking_threads(max_blocking_threads);
+    if runtime.max_blocking_threads > 0 {
+        builder.max_blocking_threads(runtime.max_blocking_threads);
     }
     if !sysinfo::set_open_files_limit(usize::MAX) {
         tracing::info!("Failed to update the open files limit (expected on non-linux targets)");
     }
-    let set_max_open_files = max_open_files.unwrap_or_else(|| {
+    let set_max_open_files = throttle.max_open_files.unwrap_or_else(|| {
         let limit = get_max_open_files().expect(
             "We failed to query rlimit, if this is expected try specifying --max-open-files",
         ) as usize;
@@ -1046,7 +1024,12 @@ where
     } else {
         tracing::info!("Not applying any limit to max open files!");
     }
-    let runtime = builder.build().expect("Failed to create runtime");
+    builder.build().expect("Failed to create runtime")
+}
+
+/// Spawn the ops/iops throttle replenisher tasks onto `runtime` if the
+/// throttles are enabled.
+fn spawn_throttle_replenishers(runtime: &tokio::runtime::Runtime, throttle: &ThrottleConfig) {
     fn get_replenish_interval(replenish: usize) -> (usize, std::time::Duration) {
         let mut replenish = replenish;
         let mut interval = std::time::Duration::from_secs(1);
@@ -1056,18 +1039,53 @@ where
         }
         (replenish, interval)
     }
-    if ops_throttle > 0 {
-        let (replenish, interval) = get_replenish_interval(ops_throttle);
+    if throttle.ops_throttle > 0 {
+        let (replenish, interval) = get_replenish_interval(throttle.ops_throttle);
         throttle::init_ops_tokens(replenish);
         runtime.spawn(throttle::run_ops_replenish_thread(replenish, interval));
     }
-    if iops_throttle > 0 {
-        let (replenish, interval) = get_replenish_interval(iops_throttle);
+    if throttle.iops_throttle > 0 {
+        let (replenish, interval) = get_replenish_interval(throttle.iops_throttle);
         throttle::init_iops_tokens(replenish);
         runtime.spawn(throttle::run_iops_replenish_thread(replenish, interval));
     }
+}
+
+#[instrument(skip(func))] // "func" is not Debug printable
+pub fn run<Fut, Summary, Error>(
+    progress: Option<ProgressSettings>,
+    output: OutputConfig,
+    runtime_config: RuntimeConfig,
+    throttle_config: ThrottleConfig,
+    tracing_config: TracingConfig,
+    func: impl FnOnce() -> Fut,
+) -> Option<Summary>
+// we return an Option rather than a Result to indicate that callers of this function should NOT print the error
+where
+    Summary: std::fmt::Display,
+    Error: std::fmt::Display + std::fmt::Debug,
+    Fut: std::future::Future<Output = Result<Summary, Error>>,
+{
+    // force initialization of PROGRESS to set start_time at the beginning of the run
+    // (for remote master operations, PROGRESS is otherwise only accessed at the end in
+    // print_runtime_stats(), leading to near-zero walltime)
+    let _ = get_progress();
+    if let Err(e) = throttle_config.validate() {
+        eprintln!("Configuration error: {e}");
+        return None;
+    }
+    let OutputConfig {
+        quiet,
+        verbose,
+        print_summary,
+        suppress_runtime_stats,
+    } = output;
+    // tracing guards must outlive the runtime so chrome/flame traces flush
+    let _tracing_guards = install_tracing_subscriber(quiet, verbose, tracing_config);
+    let runtime = build_tokio_runtime(&runtime_config, &throttle_config);
+    spawn_throttle_replenishers(&runtime, &throttle_config);
     let res = {
-        let _progress = progress.map(|settings| {
+        let _progress_tracker = progress.map(|settings| {
             tracing::debug!("Requesting progress updates {settings:?}");
             let delay = settings.progress_delay.map(|delay_str| {
                 humantime::parse_duration(&delay_str)

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -124,6 +124,7 @@ pub mod version;
 pub mod filecmp;
 pub mod progress;
 mod testutils;
+pub mod walk;
 
 pub use config::{
     DryRunMode, DryRunWarnings, OutputConfig, RuntimeConfig, ThrottleConfig, TracingConfig,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -108,6 +108,7 @@ use tracing::instrument;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
 
+pub mod cli;
 pub mod cmp;
 pub mod config;
 pub mod copy;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -112,6 +112,7 @@ pub mod cmp;
 pub mod config;
 pub mod copy;
 pub mod dry_run;
+pub mod error;
 pub mod error_collector;
 pub mod filegen;
 pub mod filter;

--- a/common/src/link.rs
+++ b/common/src/link.rs
@@ -13,30 +13,9 @@ use crate::progress;
 use crate::rm;
 use crate::walk::{self, EntryKind};
 
-/// Error type for link operations that preserves operation summary even on failure.
-///
-/// # Logging Convention
-/// When logging this error, use `{:#}` or `{:?}` format to preserve the error chain:
-/// ```ignore
-/// tracing::error!("operation failed: {:#}", &error); // ✅ Shows full chain
-/// tracing::error!("operation failed: {:?}", &error); // ✅ Shows full chain
-/// ```
-/// The Display implementation also shows the full chain, but workspace linting enforces `{:#}`
-/// for consistency.
-#[derive(Debug, thiserror::Error)]
-#[error("{source:#}")]
-pub struct Error {
-    #[source]
-    pub source: anyhow::Error,
-    pub summary: Summary,
-}
-
-impl Error {
-    #[must_use]
-    pub fn new(source: anyhow::Error, summary: Summary) -> Self {
-        Error { source, summary }
-    }
-}
+/// Error type for link operations. See [`crate::error::OperationError`] for
+/// logging conventions and rationale.
+pub type Error = crate::error::OperationError<Summary>;
 
 #[derive(Debug, Clone)]
 pub struct Settings {

--- a/common/src/link.rs
+++ b/common/src/link.rs
@@ -8,10 +8,10 @@ use crate::copy::{
     check_empty_dir_cleanup, EmptyDirAction, Settings as CopySettings, Summary as CopySummary,
 };
 use crate::filecmp;
-use crate::filter::{FilterResult, FilterSettings};
 use crate::preserve;
 use crate::progress;
 use crate::rm;
+use crate::walk::{self, EntryKind};
 
 /// Error type for link operations that preserves operation summary even on failure.
 ///
@@ -51,20 +51,27 @@ pub struct Settings {
     pub preserve: preserve::Settings,
 }
 
-/// Check if a path should be filtered out
-fn should_skip_entry(
-    filter: &Option<FilterSettings>,
-    relative_path: &std::path::Path,
-    is_dir: bool,
-) -> Option<FilterResult> {
-    if let Some(ref f) = filter {
-        let result = f.should_include(relative_path, is_dir);
-        match result {
-            FilterResult::Included => None,
-            _ => Some(result),
-        }
-    } else {
-        None
+/// Summary with the appropriate `*_skipped` counter set to 1 for the given entry kind.
+/// Special files count as `files_skipped` to match the historical mapping used
+/// when filters skip an entry (`specials_skipped` is reserved for `--skip-specials`).
+fn skipped_summary_for(kind: EntryKind) -> Summary {
+    let copy_summary = match kind {
+        EntryKind::Dir => CopySummary {
+            directories_skipped: 1,
+            ..Default::default()
+        },
+        EntryKind::Symlink => CopySummary {
+            symlinks_skipped: 1,
+            ..Default::default()
+        },
+        EntryKind::File | EntryKind::Special => CopySummary {
+            files_skipped: 1,
+            ..Default::default()
+        },
+    };
+    Summary {
+        copy_summary,
+        ..Default::default()
     }
 }
 
@@ -184,46 +191,12 @@ pub async fn link(
             match result {
                 crate::filter::FilterResult::Included => {}
                 result => {
+                    let kind = EntryKind::from_metadata(&src_metadata);
                     if let Some(mode) = settings.dry_run {
-                        let entry_type = if src_metadata.is_dir() {
-                            "directory"
-                        } else if src_metadata.file_type().is_symlink() {
-                            "symlink"
-                        } else {
-                            "file"
-                        };
-                        crate::dry_run::report_skip(src, &result, mode, entry_type);
+                        crate::dry_run::report_skip(src, &result, mode, kind.label_long());
                     }
-                    // return summary with skipped count
-                    let skipped_summary = if src_metadata.is_dir() {
-                        prog_track.directories_skipped.inc();
-                        Summary {
-                            copy_summary: CopySummary {
-                                directories_skipped: 1,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }
-                    } else if src_metadata.file_type().is_symlink() {
-                        prog_track.symlinks_skipped.inc();
-                        Summary {
-                            copy_summary: CopySummary {
-                                symlinks_skipped: 1,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }
-                    } else {
-                        prog_track.files_skipped.inc();
-                        Summary {
-                            copy_summary: CopySummary {
-                                files_skipped: 1,
-                                ..Default::default()
-                            },
-                            ..Default::default()
-                        }
-                    };
-                    return Ok(skipped_summary);
+                    kind.inc_skipped(prog_track);
+                    return Ok(skipped_summary_for(kind));
                 }
             }
         }
@@ -564,42 +537,25 @@ async fn link_internal(
         let entry_name = entry_path.file_name().unwrap();
         // check entry type for filter matching and dry-run reporting
         let entry_file_type = src_entry.file_type().await.ok();
-        let entry_is_dir = entry_file_type.map(|ft| ft.is_dir()).unwrap_or(false);
-        let entry_is_symlink = entry_file_type.map(|ft| ft.is_symlink()).unwrap_or(false);
+        let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
+        let entry_is_dir = entry_kind == EntryKind::Dir;
+        let entry_is_symlink = entry_kind == EntryKind::Symlink;
         // compute relative path from source_root for filter matching
         let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
         // apply filter if configured
-        if let Some(skip_result) = should_skip_entry(&settings.filter, relative_path, entry_is_dir)
+        if let Some(skip_result) =
+            walk::should_skip_entry(&settings.filter, relative_path, entry_is_dir)
         {
             if let Some(mode) = settings.dry_run {
-                let entry_type = if entry_is_dir {
-                    "dir"
-                } else if entry_is_symlink {
-                    "symlink"
-                } else {
-                    "file"
-                };
-                crate::dry_run::report_skip(&entry_path, &skip_result, mode, entry_type);
+                crate::dry_run::report_skip(&entry_path, &skip_result, mode, entry_kind.label());
             }
             tracing::debug!("skipping {:?} due to filter", &entry_path);
-            // increment skipped counters
-            if entry_is_dir {
-                link_summary.copy_summary.directories_skipped += 1;
-                prog_track.directories_skipped.inc();
-            } else if entry_is_symlink {
-                link_summary.copy_summary.symlinks_skipped += 1;
-                prog_track.symlinks_skipped.inc();
-            } else {
-                link_summary.copy_summary.files_skipped += 1;
-                prog_track.files_skipped.inc();
-            }
+            link_summary = link_summary + skipped_summary_for(entry_kind);
+            entry_kind.inc_skipped(prog_track);
             continue;
         }
         // skip special files (sockets, FIFOs, devices) when --skip-specials is set
-        let is_special = entry_file_type
-            .as_ref()
-            .is_some_and(|ft| !ft.is_dir() && !ft.is_symlink() && !ft.is_file());
-        if settings.copy_settings.skip_specials && is_special {
+        if settings.copy_settings.skip_specials && entry_kind == EntryKind::Special {
             tracing::debug!("skipping special file {:?}", &entry_path);
             if let Some(mode) = settings.dry_run {
                 match mode {
@@ -625,14 +581,7 @@ async fn link_internal(
         let update_path = update.as_ref().map(|s| s.join(entry_name));
         // handle dry-run mode for link operations
         if let Some(_mode) = settings.dry_run {
-            let entry_type = if entry_is_dir {
-                "dir"
-            } else if entry_is_symlink {
-                "symlink"
-            } else {
-                "file"
-            };
-            crate::dry_run::report_action("link", &entry_path, Some(&dst_path), entry_type);
+            crate::dry_run::report_action("link", &entry_path, Some(&dst_path), entry_kind.label());
             // for directories in dry-run, still need to recurse to show all entries
             if entry_is_dir {
                 let settings = settings.clone();

--- a/common/src/rm.rs
+++ b/common/src/rm.rs
@@ -3,8 +3,9 @@ use async_recursion::async_recursion;
 use std::os::unix::fs::PermissionsExt;
 use tracing::instrument;
 
-use crate::filter::{FilterResult, FilterSettings, TimeFilter};
+use crate::filter::TimeFilter;
 use crate::progress;
+use crate::walk::{self, EntryKind};
 
 /// Error type for remove operations that preserves operation summary even on failure.
 ///
@@ -59,20 +60,23 @@ fn is_unsupported_io_error(err: &anyhow::Error) -> bool {
     })
 }
 
-/// Check if a path should be filtered out
-fn should_skip_entry(
-    filter: &Option<FilterSettings>,
-    relative_path: &std::path::Path,
-    is_dir: bool,
-) -> Option<FilterResult> {
-    if let Some(ref f) = filter {
-        let result = f.should_include(relative_path, is_dir);
-        match result {
-            FilterResult::Included => None,
-            _ => Some(result),
-        }
-    } else {
-        None
+/// Summary with the appropriate `*_skipped` counter set to 1 for the given entry kind.
+/// Special files count as `files_skipped` to match the historical mapping used
+/// when filters skip an entry.
+fn skipped_summary_for(kind: EntryKind) -> Summary {
+    match kind {
+        EntryKind::Dir => Summary {
+            directories_skipped: 1,
+            ..Default::default()
+        },
+        EntryKind::Symlink => Summary {
+            symlinks_skipped: 1,
+            ..Default::default()
+        },
+        EntryKind::File | EntryKind::Special => Summary {
+            files_skipped: 1,
+            ..Default::default()
+        },
     }
 }
 
@@ -145,37 +149,12 @@ pub async fn rm(
             match result {
                 crate::filter::FilterResult::Included => {}
                 result => {
+                    let kind = EntryKind::from_metadata(&path_metadata);
                     if let Some(mode) = settings.dry_run {
-                        let entry_type = if path_metadata.is_dir() {
-                            "directory"
-                        } else if path_metadata.file_type().is_symlink() {
-                            "symlink"
-                        } else {
-                            "file"
-                        };
-                        crate::dry_run::report_skip(path, &result, mode, entry_type);
+                        crate::dry_run::report_skip(path, &result, mode, kind.label_long());
                     }
-                    // return summary with skipped count
-                    let skipped_summary = if path_metadata.is_dir() {
-                        prog_track.directories_skipped.inc();
-                        Summary {
-                            directories_skipped: 1,
-                            ..Default::default()
-                        }
-                    } else if path_metadata.file_type().is_symlink() {
-                        prog_track.symlinks_skipped.inc();
-                        Summary {
-                            symlinks_skipped: 1,
-                            ..Default::default()
-                        }
-                    } else {
-                        prog_track.files_skipped.inc();
-                        Summary {
-                            files_skipped: 1,
-                            ..Default::default()
-                        }
-                    };
-                    return Ok(skipped_summary);
+                    kind.inc_skipped(prog_track);
+                    return Ok(skipped_summary_for(kind));
                 }
             }
         }
@@ -323,35 +302,25 @@ async fn rm_internal(
         let entry_path = entry.path();
         // check entry type for filter matching and skip counting
         let entry_file_type = entry.file_type().await.ok();
-        let entry_is_dir = entry_file_type.map(|ft| ft.is_dir()).unwrap_or(false);
-        let entry_is_symlink = entry_file_type.map(|ft| ft.is_symlink()).unwrap_or(false);
+        let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
+        let entry_is_dir = entry_kind == EntryKind::Dir;
         // compute relative path from source_root for filter matching
         let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
         // apply filter if configured
-        if let Some(skip_result) = should_skip_entry(&settings.filter, relative_path, entry_is_dir)
+        if let Some(skip_result) =
+            walk::should_skip_entry(&settings.filter, relative_path, entry_is_dir)
         {
             if let Some(mode) = settings.dry_run {
-                let entry_type = if entry_is_dir {
-                    "dir"
-                } else if entry_is_symlink {
-                    "symlink"
-                } else {
-                    "file"
-                };
-                crate::dry_run::report_skip(&entry_path, &skip_result, mode, entry_type);
+                crate::dry_run::report_skip(&entry_path, &skip_result, mode, entry_kind.label());
             }
             tracing::debug!("skipping {:?} due to filter", &entry_path);
             // increment skipped counters - will be added to rm_summary below
-            if entry_is_dir {
-                skipped_dirs += 1;
-                prog_track.directories_skipped.inc();
-            } else if entry_is_symlink {
-                skipped_symlinks += 1;
-                prog_track.symlinks_skipped.inc();
-            } else {
-                skipped_files += 1;
-                prog_track.files_skipped.inc();
+            match entry_kind {
+                EntryKind::Dir => skipped_dirs += 1,
+                EntryKind::Symlink => skipped_symlinks += 1,
+                EntryKind::File | EntryKind::Special => skipped_files += 1,
             }
+            entry_kind.inc_skipped(prog_track);
             continue;
         }
         let settings = settings.clone();
@@ -1042,6 +1011,7 @@ mod tests {
     }
     mod dry_run_tests {
         use super::*;
+        use crate::filter::FilterSettings;
         /// Test that dry-run mode doesn't modify permissions on read-only directories.
         #[tokio::test]
         #[traced_test]

--- a/common/src/rm.rs
+++ b/common/src/rm.rs
@@ -7,29 +7,9 @@ use crate::filter::TimeFilter;
 use crate::progress;
 use crate::walk::{self, EntryKind};
 
-/// Error type for remove operations that preserves operation summary even on failure.
-///
-/// # Logging Convention
-/// When logging this error, use `{:#}` or `{:?}` format to preserve the error chain:
-/// ```ignore
-/// tracing::error!("operation failed: {:#}", &error); // ✅ Shows full chain
-/// tracing::error!("operation failed: {:?}", &error); // ✅ Shows full chain
-/// ```
-/// The Display implementation also shows the full chain, but workspace linting enforces `{:#}`
-/// for consistency.
-#[derive(Debug, thiserror::Error)]
-#[error("{source:#}")]
-pub struct Error {
-    #[source]
-    pub source: anyhow::Error,
-    pub summary: Summary,
-}
-
-impl Error {
-    fn new(source: anyhow::Error, summary: Summary) -> Self {
-        Error { source, summary }
-    }
-}
+/// Error type for remove operations. See [`crate::error::OperationError`] for
+/// logging conventions and rationale.
+pub type Error = crate::error::OperationError<Summary>;
 
 #[derive(Debug, Clone)]
 pub struct Settings {

--- a/common/src/walk.rs
+++ b/common/src/walk.rs
@@ -1,0 +1,105 @@
+//! Shared primitives for directory-walking operations (copy, link, rm).
+//!
+//! [`EntryKind`] classifies a directory entry by file type, and exposes the
+//! per-type bits (dry-run label, skipped-counter increment) so callers don't
+//! re-implement the dispatch.
+
+use crate::filter::{FilterResult, FilterSettings};
+use crate::progress::Progress;
+
+/// Classification of a filesystem entry by type.
+///
+/// `Special` covers sockets, FIFOs, block/character devices — anything that
+/// isn't a regular file, directory, or symlink. When a caller has only a best
+/// effort `Option<FileType>` (e.g. `entry.file_type().await.ok()`), an unknown
+/// type is treated as `File` to match historical behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EntryKind {
+    File,
+    Dir,
+    Symlink,
+    Special,
+}
+
+impl EntryKind {
+    /// Classify from a `Metadata` (root-level entries, where we always have full metadata).
+    #[must_use]
+    pub fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        if metadata.is_dir() {
+            Self::Dir
+        } else if metadata.is_symlink() {
+            Self::Symlink
+        } else if metadata.is_file() {
+            Self::File
+        } else {
+            Self::Special
+        }
+    }
+    /// Classify from an `Option<FileType>`. Unknown types (`None`) are treated
+    /// as `File` to match historical behavior across copy/link/rm: when
+    /// `entry.file_type()` fails, callers proceed as if the entry were a
+    /// regular file.
+    #[must_use]
+    pub fn from_file_type(file_type: Option<&std::fs::FileType>) -> Self {
+        match file_type {
+            Some(ft) if ft.is_dir() => Self::Dir,
+            Some(ft) if ft.is_symlink() => Self::Symlink,
+            Some(ft) if ft.is_file() => Self::File,
+            Some(_) => Self::Special,
+            None => Self::File,
+        }
+    }
+    /// Short dry-run label used during directory iteration (`"dir"`, `"symlink"`, `"file"`).
+    /// `Special` maps to `"file"` to match historical behavior — the old bool-triplet
+    /// dispatch in copy/link/rm fell through `is_dir`/`is_symlink` to "file" for any
+    /// other type. The explicit `--skip-specials` path uses its own literal "special"
+    /// string and does not call this helper.
+    #[must_use]
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Dir => "dir",
+            Self::Symlink => "symlink",
+            Self::File | Self::Special => "file",
+        }
+    }
+    /// Long dry-run label used at the root level (`"directory"` instead of `"dir"`).
+    /// `Special` maps to `"file"` for the same reason as [`Self::label`].
+    #[must_use]
+    pub fn label_long(self) -> &'static str {
+        match self {
+            Self::Dir => "directory",
+            Self::Symlink => "symlink",
+            Self::File | Self::Special => "file",
+        }
+    }
+    /// Increment the skipped counter that matches this entry kind. Special
+    /// files count as `files_skipped` — `specials_skipped` is reserved for
+    /// the explicit `--skip-specials` path, not filter skips.
+    pub fn inc_skipped(self, prog: &Progress) {
+        match self {
+            Self::Dir => prog.directories_skipped.inc(),
+            Self::Symlink => prog.symlinks_skipped.inc(),
+            Self::File | Self::Special => prog.files_skipped.inc(),
+        }
+    }
+}
+
+/// Decide whether an entry should be skipped by the filter, returning the
+/// `FilterResult` that caused the skip. Returns `None` if there is no filter
+/// or the entry is included.
+#[must_use]
+pub fn should_skip_entry(
+    filter: &Option<FilterSettings>,
+    relative_path: &std::path::Path,
+    is_dir: bool,
+) -> Option<FilterResult> {
+    if let Some(ref f) = filter {
+        let result = f.should_include(relative_path, is_dir);
+        match result {
+            FilterResult::Included => None,
+            _ => Some(result),
+        }
+    } else {
+        None
+    }
+}

--- a/filegen/src/main.rs
+++ b/filegen/src/main.rs
@@ -83,74 +83,9 @@ struct Args {
     #[arg(long, help_heading = "Generation options")]
     leaf_files: bool,
 
-    // Progress & output
-    /// Show progress
-    #[arg(long, help_heading = "Progress & output")]
-    progress: bool,
-
-    /// Toggles the type of progress to show
-    ///
-    /// If specified, --progress flag is implied.
-    ///
-    /// Options are: `ProgressBar` (animated progress bar), `TextUpdates` (appropriate for logging), Auto (default, will
-    /// choose between `ProgressBar` or `TextUpdates` depending on the type of terminal attached to stderr)
-    #[arg(long, value_name = "TYPE", help_heading = "Progress & output")]
-    progress_type: Option<common::ProgressType>,
-
-    /// Sets the delay between progress updates
-    ///
-    /// - For the interactive (--progress-type=ProgressBar), the default is 200ms.
-    /// - For the non-interactive (--progress-type=TextUpdates), the default is 10s.
-    ///
-    /// If specified, --progress flag is implied.
-    ///
-    /// This option accepts a human readable duration, e.g. "200ms", "10s", "5min" etc.
-    #[arg(long, value_name = "DELAY", help_heading = "Progress & output")]
-    progress_delay: Option<String>,
-
-    /// Verbose level (implies "summary"): -v INFO / -vv DEBUG / -vvv TRACE (default: ERROR)
-    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, help_heading = "Progress & output")]
-    verbose: u8,
-
     /// Print summary at the end
     #[arg(long, help_heading = "Progress & output")]
     summary: bool,
-
-    /// Quiet mode, don't report errors
-    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
-    quiet: bool,
-
-    // Performance & throttling
-    /// Maximum number of open files (concurrent file writes)
-    ///
-    /// Since filegen's random data generation is CPU-intensive, the default is set to the number
-    /// of physical CPU cores. This optimizes performance by matching concurrency to compute
-    /// capacity rather than allowing excessive parallelism that would cause CPU contention.
-    ///
-    /// Set to 0 for no limit. Increase if using slow storage where I/O latency dominates.
-    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
-    max_open_files: Option<usize>,
-
-    /// Throttle the number of operations per second, 0 means no throttle
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    ops_throttle: usize,
-
-    /// Throttle the number of I/O operations per second, 0 means no throttle
-    ///
-    /// I/O is calculated based on provided chunk size -- number of I/O operations for a file is calculated as:
-    /// ((file size - 1) / chunk size) + 1
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    iops_throttle: usize,
 
     /// Chunk size used to calculate number of I/O per file
     ///
@@ -163,24 +98,12 @@ struct Args {
     )]
     chunk_size: u64,
 
-    // Advanced settings
-    /// Number of worker threads, 0 means number of cores
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_workers: usize,
-
-    /// Number of blocking worker threads, 0 means Tokio runtime default (512)
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_blocking_threads: usize,
+    // note: filegen's --max-open-files default differs from the common help text
+    // (it falls back to physical CPU cores rather than 80% of the system limit,
+    // because random-data generation is CPU-bound). The fallback is applied in
+    // main(); see also the "filegen Performance" section in README.md.
+    #[command(flatten)]
+    common: common::cli::CommonArgs,
 }
 
 #[instrument]
@@ -223,29 +146,19 @@ fn main() -> Result<(), anyhow::Error> {
         let args = args.clone();
         || async_main(args)
     };
-    let output = common::OutputConfig {
-        quiet: args.quiet,
-        verbose: args.verbose,
-        print_summary: args.summary,
-        ..Default::default()
-    };
-    let runtime = common::RuntimeConfig {
-        max_workers: args.max_workers,
-        max_blocking_threads: args.max_blocking_threads,
-    };
+    let output = args.common.output_config(args.summary);
+    let runtime = args.common.runtime_config();
     // filegen's random data generation is CPU-intensive, so we default to
     // available parallelism rather than 80% of RLIMIT_NOFILE used by other tools.
     // use 1 as absolute minimum to avoid accidentally disabling limits.
-    let max_open_files = args.max_open_files.unwrap_or_else(|| {
+    let max_open_files = args.common.max_open_files.unwrap_or_else(|| {
         std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(1)
     });
     let throttle = common::ThrottleConfig {
         max_open_files: Some(max_open_files),
-        ops_throttle: args.ops_throttle,
-        iops_throttle: args.iops_throttle,
-        chunk_size: args.chunk_size,
+        ..args.common.throttle_config(args.chunk_size)
     };
     let tracing = common::TracingConfig {
         remote_layer: None,
@@ -257,23 +170,19 @@ fn main() -> Result<(), anyhow::Error> {
         tokio_console: false,
         tokio_console_port: None,
     };
-    let res = common::run(
-        if args.progress || args.progress_type.is_some() {
-            Some(common::ProgressSettings {
-                progress_type: common::GeneralProgressType::User(
-                    args.progress_type.unwrap_or_default(),
-                ),
-                progress_delay: args.progress_delay,
-            })
-        } else {
-            None
-        },
-        output,
-        runtime,
-        throttle,
-        tracing,
-        func,
-    );
+    // note: filegen historically does not treat --progress-delay alone as
+    // implying --progress (unlike rrm/rlink). preserve that behavior here.
+    let progress = if args.common.progress || args.common.progress_type.is_some() {
+        Some(common::ProgressSettings {
+            progress_type: common::GeneralProgressType::User(
+                args.common.progress_type.unwrap_or_default(),
+            ),
+            progress_delay: args.common.progress_delay.clone(),
+        })
+    } else {
+        None
+    };
+    let res = common::run(progress, output, runtime, throttle, tracing, func);
     if res.is_none() {
         std::process::exit(1);
     }

--- a/filegen/src/main.rs
+++ b/filegen/src/main.rs
@@ -87,6 +87,20 @@ struct Args {
     #[arg(long, help_heading = "Progress & output")]
     summary: bool,
 
+    /// Quiet mode, don't report errors
+    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
+    quiet: bool,
+
+    /// Maximum number of open files (concurrent file writes)
+    ///
+    /// Since filegen's random data generation is CPU-intensive, the default is set to the number
+    /// of physical CPU cores. This optimizes performance by matching concurrency to compute
+    /// capacity rather than allowing excessive parallelism that would cause CPU contention.
+    ///
+    /// Set to 0 for no limit. Increase if using slow storage where I/O latency dominates.
+    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
+    max_open_files: Option<usize>,
+
     /// Chunk size used to calculate number of I/O per file
     ///
     /// Modifying this setting to a value > 0 is REQUIRED when using --iops-throttle.
@@ -98,10 +112,6 @@ struct Args {
     )]
     chunk_size: u64,
 
-    // note: filegen's --max-open-files default differs from the common help text
-    // (it falls back to physical CPU cores rather than 80% of the system limit,
-    // because random-data generation is CPU-bound). The fallback is applied in
-    // main(); see also the "filegen Performance" section in README.md.
     #[command(flatten)]
     common: common::cli::CommonArgs,
 }
@@ -146,20 +156,19 @@ fn main() -> Result<(), anyhow::Error> {
         let args = args.clone();
         || async_main(args)
     };
-    let output = args.common.output_config(args.summary);
+    let output = args.common.output_config(args.quiet, args.summary);
     let runtime = args.common.runtime_config();
     // filegen's random data generation is CPU-intensive, so we default to
     // available parallelism rather than 80% of RLIMIT_NOFILE used by other tools.
     // use 1 as absolute minimum to avoid accidentally disabling limits.
-    let max_open_files = args.common.max_open_files.unwrap_or_else(|| {
+    let max_open_files = args.max_open_files.unwrap_or_else(|| {
         std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(1)
     });
-    let throttle = common::ThrottleConfig {
-        max_open_files: Some(max_open_files),
-        ..args.common.throttle_config(args.chunk_size)
-    };
+    let throttle = args
+        .common
+        .throttle_config(Some(max_open_files), args.chunk_size);
     let tracing = common::TracingConfig {
         remote_layer: None,
         debug_log_file: None,

--- a/rcmp/src/main.rs
+++ b/rcmp/src/main.rs
@@ -88,42 +88,10 @@ struct Args {
     #[arg(long, value_name = "PATH", conflicts_with_all = ["include", "exclude"], help_heading = "Filtering")]
     filter_file: Option<std::path::PathBuf>,
 
-    // Progress & output
-    /// Show progress
-    #[arg(long, help_heading = "Progress & output")]
-    progress: bool,
-
-    /// Set the type of progress display
-    ///
-    /// If specified, --progress flag is implied.
-    #[arg(long, value_name = "TYPE", help_heading = "Progress & output")]
-    progress_type: Option<common::ProgressType>,
-
-    /// Sets the delay between progress updates
-    ///
-    /// - For the interactive (--progress-type=ProgressBar), the default is 200ms.
-    /// - For the non-interactive (--progress-type=TextUpdates), the default is 10s.
-    ///
-    /// If specified, --progress flag is implied.
-    ///
-    /// This option accepts a human readable duration, e.g. "200ms", "10s", "5min" etc.
-    #[arg(long, value_name = "DELAY", help_heading = "Progress & output")]
-    progress_delay: Option<String>,
-
-    /// Verbose level (implies "summary"): -v INFO / -vv DEBUG / -vvv TRACE (default: ERROR)
-    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, help_heading = "Progress & output")]
-    verbose: u8,
-
     /// Print summary at the end
     #[arg(long, help_heading = "Progress & output")]
     summary: bool,
 
-    /// Quiet mode, suppress stdout output (errors and differences)
-    ///
-    /// Without --log, differences are printed to stdout. This flag suppresses that.
-    /// When used with --log, differences are still written to the log file.
-    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
-    quiet: bool,
     /// Output format for differences and summary
     #[arg(
         long,
@@ -132,32 +100,6 @@ struct Args {
         help_heading = "Progress & output"
     )]
     output_format: common::cmp::OutputFormat,
-
-    // Performance & throttling
-    /// Maximum number of open files, 0 means no limit, leaving unspecified means using 80% of max open files system limit
-    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
-    max_open_files: Option<usize>,
-
-    /// Throttle the number of operations per second, 0 means no throttle
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    ops_throttle: usize,
-
-    /// Throttle the number of I/O operations per second, 0 means no throttle
-    ///
-    /// I/O is calculated based on provided chunk size -- number of I/O operations for a file is calculated as:
-    /// ((file size - 1) / chunk size) + 1
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    iops_throttle: usize,
 
     /// Chunk size used to calculate number of I/O per file
     ///
@@ -170,24 +112,8 @@ struct Args {
     )]
     chunk_size: u64,
 
-    // Advanced settings
-    /// Number of worker threads, 0 means number of cores
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_workers: usize,
-
-    /// Number of blocking worker threads, 0 means Tokio runtime default (512)
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_blocking_threads: usize,
+    #[command(flatten)]
+    common: common::cli::CommonArgs,
 
     // ARGUMENTS
     /// File or directory to compare
@@ -207,7 +133,7 @@ async fn async_main(args: Args) -> Result<common::cmp::FormattedSummary> {
         &args.exclude,
     )?;
     // output to stdout if no log file and not quiet
-    let use_stdout = args.log.is_none() && !args.quiet;
+    let use_stdout = args.log.is_none() && !args.common.quiet;
     let log_handle =
         common::cmp::LogWriter::new(args.log.as_deref(), use_stdout, args.output_format).await?;
     let summary = common::cmp(
@@ -237,21 +163,11 @@ fn main() -> Result<()> {
         || async_main(args)
     };
     let output = common::OutputConfig {
-        quiet: args.quiet,
-        verbose: args.verbose,
-        print_summary: args.summary,
         suppress_runtime_stats: matches!(args.output_format, common::cmp::OutputFormat::Json),
+        ..args.common.output_config(args.summary)
     };
-    let runtime = common::RuntimeConfig {
-        max_workers: args.max_workers,
-        max_blocking_threads: args.max_blocking_threads,
-    };
-    let throttle = common::ThrottleConfig {
-        max_open_files: args.max_open_files,
-        ops_throttle: args.ops_throttle,
-        iops_throttle: args.iops_throttle,
-        chunk_size: args.chunk_size,
-    };
+    let runtime = args.common.runtime_config();
+    let throttle = args.common.throttle_config(args.chunk_size);
     let tracing = common::TracingConfig {
         remote_layer: None,
         debug_log_file: None,
@@ -262,23 +178,19 @@ fn main() -> Result<()> {
         tokio_console: false,
         tokio_console_port: None,
     };
-    let res = common::run(
-        if args.progress || args.progress_type.is_some() {
-            Some(common::ProgressSettings {
-                progress_type: common::GeneralProgressType::User(
-                    args.progress_type.unwrap_or_default(),
-                ),
-                progress_delay: args.progress_delay,
-            })
-        } else {
-            None
-        },
-        output,
-        runtime,
-        throttle,
-        tracing,
-        func,
-    );
+    // note: rcmp historically does not treat --progress-delay alone as implying
+    // --progress (unlike rrm/rlink). preserve that behavior here.
+    let progress = if args.common.progress || args.common.progress_type.is_some() {
+        Some(common::ProgressSettings {
+            progress_type: common::GeneralProgressType::User(
+                args.common.progress_type.unwrap_or_default(),
+            ),
+            progress_delay: args.common.progress_delay.clone(),
+        })
+    } else {
+        None
+    };
+    let res = common::run(progress, output, runtime, throttle, tracing, func);
     match res {
         Some(formatted) => {
             if args.no_check {

--- a/rcmp/src/main.rs
+++ b/rcmp/src/main.rs
@@ -92,6 +92,13 @@ struct Args {
     #[arg(long, help_heading = "Progress & output")]
     summary: bool,
 
+    /// Quiet mode, suppress stdout output (errors and differences)
+    ///
+    /// Without --log, differences are printed to stdout. This flag suppresses that.
+    /// When used with --log, differences are still written to the log file.
+    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
+    quiet: bool,
+
     /// Output format for differences and summary
     #[arg(
         long,
@@ -100,6 +107,10 @@ struct Args {
         help_heading = "Progress & output"
     )]
     output_format: common::cmp::OutputFormat,
+
+    /// Maximum number of open files (0 = no limit, unspecified = 80% of system limit)
+    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
+    max_open_files: Option<usize>,
 
     /// Chunk size used to calculate number of I/O per file
     ///
@@ -133,7 +144,7 @@ async fn async_main(args: Args) -> Result<common::cmp::FormattedSummary> {
         &args.exclude,
     )?;
     // output to stdout if no log file and not quiet
-    let use_stdout = args.log.is_none() && !args.common.quiet;
+    let use_stdout = args.log.is_none() && !args.quiet;
     let log_handle =
         common::cmp::LogWriter::new(args.log.as_deref(), use_stdout, args.output_format).await?;
     let summary = common::cmp(
@@ -164,10 +175,12 @@ fn main() -> Result<()> {
     };
     let output = common::OutputConfig {
         suppress_runtime_stats: matches!(args.output_format, common::cmp::OutputFormat::Json),
-        ..args.common.output_config(args.summary)
+        ..args.common.output_config(args.quiet, args.summary)
     };
     let runtime = args.common.runtime_config();
-    let throttle = args.common.throttle_config(args.chunk_size);
+    let throttle = args
+        .common
+        .throttle_config(args.max_open_files, args.chunk_size);
     let tracing = common::TracingConfig {
         remote_layer: None,
         debug_log_file: None,

--- a/rcmp/src/main.rs
+++ b/rcmp/src/main.rs
@@ -201,20 +201,11 @@ struct Args {
 
 async fn async_main(args: Args) -> Result<common::cmp::FormattedSummary> {
     // build filter settings from CLI arguments
-    let filter = if let Some(ref path) = args.filter_file {
-        Some(common::filter::FilterSettings::from_file(path)?)
-    } else if !args.include.is_empty() || !args.exclude.is_empty() {
-        let mut filter_settings = common::filter::FilterSettings::new();
-        for p in &args.include {
-            filter_settings.add_include(p)?;
-        }
-        for p in &args.exclude {
-            filter_settings.add_exclude(p)?;
-        }
-        Some(filter_settings)
-    } else {
-        None
-    };
+    let filter = common::filter::FilterSettings::from_args(
+        args.filter_file.as_deref(),
+        &args.include,
+        &args.exclude,
+    )?;
     // output to stdout if no log file and not quiet
     let use_stdout = args.log.is_none() && !args.quiet;
     let log_handle =

--- a/rcp/src/bin/rcp.rs
+++ b/rcp/src/bin/rcp.rs
@@ -672,20 +672,11 @@ async fn run_rcpd_master(
         }
     });
     // build filter settings from CLI arguments for source-side filtering
-    let filter = if let Some(ref path) = args.filter_file {
-        Some(common::filter::FilterSettings::from_file(path)?)
-    } else if !args.include.is_empty() || !args.exclude.is_empty() {
-        let mut settings = common::filter::FilterSettings::new();
-        for p in &args.include {
-            settings.add_include(p)?;
-        }
-        for p in &args.exclude {
-            settings.add_exclude(p)?;
-        }
-        Some(settings)
-    } else {
-        None
-    };
+    let filter = common::filter::FilterSettings::from_args(
+        args.filter_file.as_deref(),
+        &args.include,
+        &args.exclude,
+    )?;
     // send MasterHello to source rcpd (include dest fingerprint for mutual TLS)
     {
         let _span = tracing::trace_span!("send_master_hello_to_source").entered();
@@ -1018,27 +1009,12 @@ async fn async_main(args: Args) -> anyhow::Result<common::copy::Summary> {
         })
         .collect::<anyhow::Result<Vec<(std::path::PathBuf, std::path::PathBuf)>>>()?;
     // build filter settings from CLI arguments
-    let filter = if let Some(ref path) = args.filter_file {
-        Some(
-            common::filter::FilterSettings::from_file(path)
-                .map_err(|err| common::copy::Error::new(err, Default::default()))?,
-        )
-    } else if !args.include.is_empty() || !args.exclude.is_empty() {
-        let mut settings = common::filter::FilterSettings::new();
-        for p in &args.include {
-            settings
-                .add_include(p)
-                .map_err(|err| common::copy::Error::new(err, Default::default()))?;
-        }
-        for p in &args.exclude {
-            settings
-                .add_exclude(p)
-                .map_err(|err| common::copy::Error::new(err, Default::default()))?;
-        }
-        Some(settings)
-    } else {
-        None
-    };
+    let filter = common::filter::FilterSettings::from_args(
+        args.filter_file.as_deref(),
+        &args.include,
+        &args.exclude,
+    )
+    .map_err(|err| common::copy::Error::new(err, Default::default()))?;
     let settings = common::copy::Settings {
         dereference: args.dereference,
         fail_early: args.fail_early,

--- a/rcp/src/bin/rcp.rs
+++ b/rcp/src/bin/rcp.rs
@@ -146,6 +146,14 @@ struct Args {
     #[arg(long, help_heading = "Progress & output")]
     summary: bool,
 
+    /// Quiet mode, don't report errors
+    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
+    quiet: bool,
+
+    /// Maximum number of open files (0 = no limit, unspecified = 80% of system limit)
+    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
+    max_open_files: Option<usize>,
+
     /// Chunk size for calculating I/O operations per file
     ///
     /// Required when using --iops-throttle (must be > 0)
@@ -388,7 +396,7 @@ async fn run_rcpd_master(
         fail_early: args.fail_early,
         max_workers: args.common.max_workers,
         max_blocking_threads: args.common.max_blocking_threads,
-        max_open_files: args.common.max_open_files,
+        max_open_files: args.max_open_files,
         ops_throttle: args.common.ops_throttle,
         iops_throttle: args.common.iops_throttle,
         chunk_size: args.chunk_size.0 as usize,
@@ -1062,9 +1070,13 @@ fn main() -> Result<(), anyhow::Error> {
         let args = args.clone();
         || async_main(args)
     };
-    let output = args.common.output_config(!is_dry_run && args.summary);
+    let output = args
+        .common
+        .output_config(args.quiet, !is_dry_run && args.summary);
     let runtime = args.common.runtime_config();
-    let throttle = args.common.throttle_config(args.chunk_size.0);
+    let throttle = args
+        .common
+        .throttle_config(args.max_open_files, args.chunk_size.0);
     let tracing = common::TracingConfig {
         remote_layer: None,
         debug_log_file: None,

--- a/rcp/src/bin/rcp.rs
+++ b/rcp/src/bin/rcp.rs
@@ -142,59 +142,9 @@ struct Args {
     #[arg(long, value_name = "MODE", help_heading = "Filtering")]
     dry_run: Option<common::DryRunMode>,
 
-    // Progress & output
-    /// Show progress
-    #[arg(long, help_heading = "Progress & output")]
-    progress: bool,
-
-    /// Set the type of progress display
-    ///
-    /// If specified, --progress flag is implied.
-    #[arg(long, value_name = "TYPE", help_heading = "Progress & output")]
-    progress_type: Option<common::ProgressType>,
-
-    /// Set delay between progress updates
-    ///
-    /// Default is 200ms for interactive mode (`ProgressBar`) and 10s for non-interactive mode (`TextUpdates`). If specified, --progress flag is implied. Accepts human-readable durations like "200ms", "10s", "5min".
-    #[arg(long, value_name = "DELAY", help_heading = "Progress & output")]
-    progress_delay: Option<String>,
-
     /// Print summary at the end
     #[arg(long, help_heading = "Progress & output")]
     summary: bool,
-
-    /// Verbose level (implies "summary"): -v INFO / -vv DEBUG / -vvv TRACE (default: ERROR)
-    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, help_heading = "Progress & output")]
-    verbose: u8,
-
-    /// Quiet mode, don't report errors
-    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
-    quiet: bool,
-
-    // Performance & throttling
-    /// Maximum number of open files (0 = no limit, unspecified = 80% of system limit)
-    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
-    max_open_files: Option<usize>,
-
-    /// Throttle the number of operations per second, 0 means no throttle
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    ops_throttle: usize,
-
-    /// Limit I/O operations per second (0 = no throttle)
-    ///
-    /// Requires --chunk-size to calculate I/O operations per file: ((`file_size` - 1) / `chunk_size`) + 1
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    iops_throttle: usize,
 
     /// Chunk size for calculating I/O operations per file
     ///
@@ -207,24 +157,8 @@ struct Args {
     )]
     chunk_size: bytesize::ByteSize,
 
-    // Advanced settings
-    /// Number of worker threads (0 = number of CPU cores)
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_workers: usize,
-
-    /// Number of blocking worker threads (0 = Tokio default of 512)
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_blocking_threads: usize,
+    #[command(flatten)]
+    common: common::cli::CommonArgs,
 
     // Remote copy options
     /// IP address to bind the master TCP server to
@@ -450,13 +384,13 @@ async fn run_rcpd_master(
         None
     };
     let rcpd_config = remote::protocol::RcpdConfig {
-        verbose: args.verbose,
+        verbose: args.common.verbose,
         fail_early: args.fail_early,
-        max_workers: args.max_workers,
-        max_blocking_threads: args.max_blocking_threads,
-        max_open_files: args.max_open_files,
-        ops_throttle: args.ops_throttle,
-        iops_throttle: args.iops_throttle,
+        max_workers: args.common.max_workers,
+        max_blocking_threads: args.common.max_blocking_threads,
+        max_open_files: args.common.max_open_files,
+        ops_throttle: args.common.ops_throttle,
+        iops_throttle: args.common.iops_throttle,
         chunk_size: args.chunk_size.0 as usize,
         dereference: args.dereference,
         overwrite: args.overwrite,
@@ -466,8 +400,8 @@ async fn run_rcpd_master(
         skip_specials: args.skip_specials,
         debug_log_prefix: args.rcpd_debug_log_prefix.clone(),
         port_ranges: args.port_ranges.clone(),
-        progress: args.progress,
-        progress_delay: args.progress_delay.clone(),
+        progress: args.common.progress,
+        progress_delay: args.common.progress_delay.clone(),
         remote_copy_conn_timeout_sec: args.remote_copy_conn_timeout_sec,
         network_profile: args.network_profile,
         buffer_size: args.remote_copy_buffer_size.map(|b| b.0 as usize),
@@ -1114,9 +1048,9 @@ fn main() -> Result<(), anyhow::Error> {
     let is_remote_operation = has_remote_paths(&args);
     let dry_run_warnings = args.dry_run.map(|_| {
         common::DryRunWarnings::new(
-            args.progress || args.progress_type.is_some() || args.progress_delay.is_some(),
+            args.common.progress_requested(),
             args.summary,
-            args.verbose,
+            args.common.verbose,
             args.overwrite,
             !args.include.is_empty() || !args.exclude.is_empty() || args.filter_file.is_some(),
             true,
@@ -1128,22 +1062,9 @@ fn main() -> Result<(), anyhow::Error> {
         let args = args.clone();
         || async_main(args)
     };
-    let output = common::OutputConfig {
-        quiet: args.quiet,
-        verbose: args.verbose,
-        print_summary: if is_dry_run { false } else { args.summary },
-        ..Default::default()
-    };
-    let runtime = common::RuntimeConfig {
-        max_workers: args.max_workers,
-        max_blocking_threads: args.max_blocking_threads,
-    };
-    let throttle = common::ThrottleConfig {
-        max_open_files: args.max_open_files,
-        ops_throttle: args.ops_throttle,
-        iops_throttle: args.iops_throttle,
-        chunk_size: args.chunk_size.0,
-    };
+    let output = args.common.output_config(!is_dry_run && args.summary);
+    let runtime = args.common.runtime_config();
+    let throttle = args.common.throttle_config(args.chunk_size.0);
     let tracing = common::TracingConfig {
         remote_layer: None,
         debug_log_file: None,
@@ -1154,32 +1075,22 @@ fn main() -> Result<(), anyhow::Error> {
         tokio_console: args.tokio_console,
         tokio_console_port: args.tokio_console_port,
     };
-    let res = common::run(
-        if !is_dry_run
-            && (args.progress || args.progress_type.is_some() || args.progress_delay.is_some())
-        {
-            Some(common::ProgressSettings {
-                progress_type: if is_remote_operation {
-                    common::GeneralProgressType::RemoteMaster {
-                        progress_type: args.progress_type.unwrap_or_default(),
-                        get_progress_snapshot: Box::new(
-                            remote::tracelog::get_latest_progress_snapshot,
-                        ),
-                    }
-                } else {
-                    common::GeneralProgressType::User(args.progress_type.unwrap_or_default())
-                },
-                progress_delay: args.progress_delay,
-            })
-        } else {
-            None
-        },
-        output,
-        runtime,
-        throttle,
-        tracing,
-        func,
-    );
+    let progress = if !is_dry_run && args.common.progress_requested() {
+        Some(common::ProgressSettings {
+            progress_type: if is_remote_operation {
+                common::GeneralProgressType::RemoteMaster {
+                    progress_type: args.common.progress_type.unwrap_or_default(),
+                    get_progress_snapshot: Box::new(remote::tracelog::get_latest_progress_snapshot),
+                }
+            } else {
+                common::GeneralProgressType::User(args.common.progress_type.unwrap_or_default())
+            },
+            progress_delay: args.common.progress_delay,
+        })
+    } else {
+        None
+    };
+    let res = common::run(progress, output, runtime, throttle, tracing, func);
     if let Some(warnings) = dry_run_warnings {
         warnings.print();
     }

--- a/rcp/src/bin/rcpd.rs
+++ b/rcp/src/bin/rcpd.rs
@@ -72,49 +72,6 @@ struct Args {
     dereference: bool,
 
     // Progress & output
-    /// Show progress
-    #[arg(long, help_heading = "Progress & output")]
-    progress: bool,
-
-    /// Set delay between progress updates
-    ///
-    /// Default is 200ms for interactive mode (`ProgressBar`) and 10s for non-interactive mode (`TextUpdates`). If specified, --progress flag is implied. Accepts human-readable durations like "200ms", "10s", "5min".
-    #[arg(long, value_name = "DELAY", help_heading = "Progress & output")]
-    progress_delay: Option<String>,
-
-    /// Verbose level (implies "summary"): -v INFO / -vv DEBUG / -vvv TRACE (default: ERROR)
-    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, help_heading = "Progress & output")]
-    verbose: u8,
-
-    /// Quiet mode, don't report errors
-    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
-    quiet: bool,
-
-    // Performance & throttling
-    /// Maximum number of open files (0 = no limit, unspecified = 80% of system limit)
-    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
-    max_open_files: Option<usize>,
-
-    /// Throttle the number of operations per second (0 = no throttle)
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    ops_throttle: usize,
-
-    /// Limit I/O operations per second (0 = no throttle)
-    ///
-    /// Requires --chunk-size to calculate I/O operations per file: ((`file_size` - 1) / `chunk_size`) + 1
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    iops_throttle: usize,
-
     /// Chunk size for calculating I/O operations per file
     ///
     /// Required when using --iops-throttle (must be > 0)
@@ -126,24 +83,12 @@ struct Args {
     )]
     chunk_size: u64,
 
-    // Advanced settings
-    /// Number of worker threads (0 = number of CPU cores)
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_workers: usize,
-
-    /// Number of blocking worker threads (0 = Tokio default of 512)
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_blocking_threads: usize,
+    // note: rcpd never reads --progress-type or --summary from the master CLI
+    // (master sets progress mode out-of-band via control messages and never
+    // asks rcpd for a summary). Those flags are accepted as no-ops via
+    // CommonArgs to keep the shared definition simple.
+    #[command(flatten)]
+    common: common::cli::CommonArgs,
 
     // Remote copy options
     /// IP address to bind TCP server to (set by master, internal use only)
@@ -736,22 +681,10 @@ fn main() -> Result<(), anyhow::Error> {
         println!("rcpd: Debug logging to file: {filename}");
         filename
     });
-    let output = common::OutputConfig {
-        quiet: args.quiet,
-        verbose: args.verbose,
-        print_summary: false,
-        ..Default::default()
-    };
-    let runtime = common::RuntimeConfig {
-        max_workers: args.max_workers,
-        max_blocking_threads: args.max_blocking_threads,
-    };
-    let throttle = common::ThrottleConfig {
-        max_open_files: args.max_open_files,
-        ops_throttle: args.ops_throttle,
-        iops_throttle: args.iops_throttle,
-        chunk_size: args.chunk_size,
-    };
+    // rcpd never prints a user-facing summary (results stream to master).
+    let output = args.common.output_config(false);
+    let runtime = args.common.runtime_config();
+    let throttle = args.common.throttle_config(args.chunk_size);
     let tracing = common::TracingConfig {
         remote_layer: Some(tracing_layer),
         debug_log_file,
@@ -762,21 +695,23 @@ fn main() -> Result<(), anyhow::Error> {
         tokio_console: args.tokio_console,
         tokio_console_port: args.tokio_console_port,
     };
-    let res = common::run(
-        if args.progress {
-            Some(common::ProgressSettings {
-                progress_type: common::GeneralProgressType::Remote(tracing_sender),
-                progress_delay: args.progress_delay,
-            })
-        } else {
-            None
-        },
-        output,
-        runtime,
-        throttle,
-        tracing,
-        func,
-    );
+    // rcpd's progress is always Remote (streamed to master), regardless of
+    // --progress-type — that flag is ignored on this binary. The master
+    // controls progress mode by setting --progress (and optionally
+    // --progress-delay) together; --progress-delay alone does not enable
+    // remote progress here because the master never sends it without
+    // --progress (see RcpdConfig::to_args). This intentionally diverges from
+    // CommonArgs's "--progress-delay implies --progress" doc, which targets
+    // user-facing tools.
+    let progress = if args.common.progress {
+        Some(common::ProgressSettings {
+            progress_type: common::GeneralProgressType::Remote(tracing_sender),
+            progress_delay: args.common.progress_delay,
+        })
+    } else {
+        None
+    };
+    let res = common::run(progress, output, runtime, throttle, tracing, func);
     if res.is_none() {
         std::process::exit(1);
     }

--- a/rcp/src/bin/rcpd.rs
+++ b/rcp/src/bin/rcpd.rs
@@ -71,7 +71,14 @@ struct Args {
     #[arg(short = 'L', long, help_heading = "Copy options")]
     dereference: bool,
 
-    // Progress & output
+    /// Quiet mode, don't report errors
+    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
+    quiet: bool,
+
+    /// Maximum number of open files (0 = no limit, unspecified = 80% of system limit)
+    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
+    max_open_files: Option<usize>,
+
     /// Chunk size for calculating I/O operations per file
     ///
     /// Required when using --iops-throttle (must be > 0)
@@ -83,10 +90,9 @@ struct Args {
     )]
     chunk_size: u64,
 
-    // note: rcpd never reads --progress-type or --summary from the master CLI
-    // (master sets progress mode out-of-band via control messages and never
-    // asks rcpd for a summary). Those flags are accepted as no-ops via
-    // CommonArgs to keep the shared definition simple.
+    // note: rcpd never reads --progress-type from the master CLI (master sets
+    // progress mode out-of-band via control messages). The flag is accepted as
+    // a no-op via CommonArgs to keep the shared definition simple.
     #[command(flatten)]
     common: common::cli::CommonArgs,
 
@@ -682,9 +688,11 @@ fn main() -> Result<(), anyhow::Error> {
         filename
     });
     // rcpd never prints a user-facing summary (results stream to master).
-    let output = args.common.output_config(false);
+    let output = args.common.output_config(args.quiet, false);
     let runtime = args.common.runtime_config();
-    let throttle = args.common.throttle_config(args.chunk_size);
+    let throttle = args
+        .common
+        .throttle_config(args.max_open_files, args.chunk_size);
     let tracing = common::TracingConfig {
         remote_layer: Some(tracing_layer),
         debug_log_file,

--- a/rcp/src/source.rs
+++ b/rcp/src/source.rs
@@ -10,15 +10,7 @@ fn progress() -> &'static common::progress::Progress {
 /// special files (sockets, FIFOs, devices) that are filtered out count as files_skipped,
 /// matching local copy behavior. specials_skipped is only for --skip-specials.
 fn count_skipped(metadata: &std::fs::Metadata) {
-    let p = progress();
-    if metadata.is_dir() {
-        p.directories_skipped.inc();
-    } else if metadata.is_symlink() {
-        p.symlinks_skipped.inc();
-    } else {
-        // regular files and special files (sockets, FIFOs, devices)
-        p.files_skipped.inc();
-    }
+    common::walk::EntryKind::from_metadata(metadata).inc_skipped(progress());
 }
 
 /// Collected child entry from a directory pre-read.

--- a/rlink/src/main.rs
+++ b/rlink/src/main.rs
@@ -263,20 +263,11 @@ async fn async_main(args: Args) -> Result<common::link::Summary> {
     }
     let result = common::link(&args.src, &dst, &args.update, {
         // build filter settings from CLI arguments
-        let filter = if let Some(ref path) = args.filter_file {
-            Some(common::filter::FilterSettings::from_file(path)?)
-        } else if !args.include.is_empty() || !args.exclude.is_empty() {
-            let mut filter_settings = common::filter::FilterSettings::new();
-            for p in &args.include {
-                filter_settings.add_include(p)?;
-            }
-            for p in &args.exclude {
-                filter_settings.add_exclude(p)?;
-            }
-            Some(filter_settings)
-        } else {
-            None
-        };
+        let filter = common::filter::FilterSettings::from_args(
+            args.filter_file.as_deref(),
+            &args.include,
+            &args.exclude,
+        )?;
         &common::link::Settings {
             copy_settings: common::copy::Settings {
                 dereference: false, // currently not supported

--- a/rlink/src/main.rs
+++ b/rlink/src/main.rs
@@ -121,6 +121,14 @@ struct Args {
     #[arg(long, help_heading = "Progress & output")]
     summary: bool,
 
+    /// Quiet mode, don't report errors
+    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
+    quiet: bool,
+
+    /// Maximum number of open files (0 = no limit, unspecified = 80% of system limit)
+    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
+    max_open_files: Option<usize>,
+
     /// Chunk size for calculating I/O operations per file
     ///
     /// Required when using --iops-throttle (must be > 0)
@@ -254,9 +262,13 @@ fn main() -> Result<()> {
         let args = args.clone();
         || async_main(args)
     };
-    let output = args.common.output_config(!is_dry_run && args.summary);
+    let output = args
+        .common
+        .output_config(args.quiet, !is_dry_run && args.summary);
     let runtime = args.common.runtime_config();
-    let throttle = args.common.throttle_config(args.chunk_size);
+    let throttle = args
+        .common
+        .throttle_config(args.max_open_files, args.chunk_size);
     let tracing = common::TracingConfig {
         remote_layer: None,
         debug_log_file: None,

--- a/rlink/src/main.rs
+++ b/rlink/src/main.rs
@@ -117,59 +117,9 @@ struct Args {
     #[arg(long, value_name = "MODE", help_heading = "Filtering")]
     dry_run: Option<common::DryRunMode>,
 
-    // Progress & output
-    /// Show progress
-    #[arg(long, help_heading = "Progress & output")]
-    progress: bool,
-
-    /// Set the type of progress display
-    ///
-    /// If specified, --progress flag is implied.
-    #[arg(long, value_name = "TYPE", help_heading = "Progress & output")]
-    progress_type: Option<common::ProgressType>,
-
-    /// Set delay between progress updates
-    ///
-    /// Default is 200ms for interactive mode (`ProgressBar`) and 10s for non-interactive mode (`TextUpdates`). If specified, --progress flag is implied. Accepts human-readable durations like "200ms", "10s", "5min".
-    #[arg(long, value_name = "DELAY", help_heading = "Progress & output")]
-    progress_delay: Option<String>,
-
     /// Print summary at the end
     #[arg(long, help_heading = "Progress & output")]
     summary: bool,
-
-    /// Verbose level (implies "summary"): -v INFO / -vv DEBUG / -vvv TRACE (default: ERROR)
-    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, help_heading = "Progress & output")]
-    verbose: u8,
-
-    /// Quiet mode, don't report errors
-    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
-    quiet: bool,
-
-    // Performance & throttling
-    /// Maximum number of open files (0 = no limit, unspecified = 80% of system limit)
-    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
-    max_open_files: Option<usize>,
-
-    /// Throttle the number of operations per second (0 = no throttle)
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    ops_throttle: usize,
-
-    /// Limit I/O operations per second (0 = no throttle)
-    ///
-    /// Requires --chunk-size to calculate I/O operations per file: ((`file_size` - 1) / `chunk_size`) + 1
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    iops_throttle: usize,
 
     /// Chunk size for calculating I/O operations per file
     ///
@@ -182,24 +132,8 @@ struct Args {
     )]
     chunk_size: u64,
 
-    // Advanced settings
-    /// Number of worker threads (0 = number of CPU cores)
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_workers: usize,
-
-    /// Number of blocking worker threads (0 = Tokio default of 512)
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_blocking_threads: usize,
+    #[command(flatten)]
+    common: common::cli::CommonArgs,
 
     // ARGUMENTS
     /// Directory with contents we want to update into `dst`
@@ -306,9 +240,9 @@ fn main() -> Result<()> {
     let args = Args::parse();
     let dry_run_warnings = args.dry_run.map(|_| {
         common::DryRunWarnings::new(
-            args.progress || args.progress_type.is_some() || args.progress_delay.is_some(),
+            args.common.progress_requested(),
             args.summary,
-            args.verbose,
+            args.common.verbose,
             args.overwrite,
             !args.include.is_empty() || !args.exclude.is_empty() || args.filter_file.is_some(),
             true,
@@ -320,22 +254,9 @@ fn main() -> Result<()> {
         let args = args.clone();
         || async_main(args)
     };
-    let output = common::OutputConfig {
-        quiet: args.quiet,
-        verbose: args.verbose,
-        print_summary: if is_dry_run { false } else { args.summary },
-        ..Default::default()
-    };
-    let runtime = common::RuntimeConfig {
-        max_workers: args.max_workers,
-        max_blocking_threads: args.max_blocking_threads,
-    };
-    let throttle = common::ThrottleConfig {
-        max_open_files: args.max_open_files,
-        ops_throttle: args.ops_throttle,
-        iops_throttle: args.iops_throttle,
-        chunk_size: args.chunk_size,
-    };
+    let output = args.common.output_config(!is_dry_run && args.summary);
+    let runtime = args.common.runtime_config();
+    let throttle = args.common.throttle_config(args.chunk_size);
     let tracing = common::TracingConfig {
         remote_layer: None,
         debug_log_file: None,
@@ -346,25 +267,12 @@ fn main() -> Result<()> {
         tokio_console: false,
         tokio_console_port: None,
     };
-    let res = common::run(
-        if !is_dry_run
-            && (args.progress || args.progress_type.is_some() || args.progress_delay.is_some())
-        {
-            Some(common::ProgressSettings {
-                progress_type: common::GeneralProgressType::User(
-                    args.progress_type.unwrap_or_default(),
-                ),
-                progress_delay: args.progress_delay,
-            })
-        } else {
-            None
-        },
-        output,
-        runtime,
-        throttle,
-        tracing,
-        func,
-    );
+    let progress = if is_dry_run {
+        None
+    } else {
+        args.common.user_progress_settings()
+    };
+    let res = common::run(progress, output, runtime, throttle, tracing, func);
     if let Some(warnings) = dry_run_warnings {
         warnings.print();
     }

--- a/rrm/src/main.rs
+++ b/rrm/src/main.rs
@@ -88,6 +88,14 @@ struct Args {
     #[arg(long, help_heading = "Progress & output")]
     summary: bool,
 
+    /// Quiet mode, don't report errors
+    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
+    quiet: bool,
+
+    /// Maximum number of open files, 0 means no limit, leaving unspecified means using 80% of max open files system limit
+    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
+    max_open_files: Option<usize>,
+
     /// Chunk size used to calculate number of I/O per file
     ///
     /// Modifying this setting to a value > 0 is REQUIRED when using --iops-throttle.
@@ -221,9 +229,13 @@ fn main() -> Result<()> {
         let args = args.clone();
         || async_main(args)
     };
-    let output = args.common.output_config(!is_dry_run && args.summary);
+    let output = args
+        .common
+        .output_config(args.quiet, !is_dry_run && args.summary);
     let runtime = args.common.runtime_config();
-    let throttle = args.common.throttle_config(args.chunk_size);
+    let throttle = args
+        .common
+        .throttle_config(args.max_open_files, args.chunk_size);
     let tracing = common::TracingConfig {
         remote_layer: None,
         debug_log_file: None,

--- a/rrm/src/main.rs
+++ b/rrm/src/main.rs
@@ -218,20 +218,11 @@ fn build_time_filter(
 #[instrument]
 async fn async_main(args: Args) -> Result<common::rm::Summary> {
     // build filter settings once before the loop
-    let filter = if let Some(ref path) = args.filter_file {
-        Some(common::filter::FilterSettings::from_file(path)?)
-    } else if !args.include.is_empty() || !args.exclude.is_empty() {
-        let mut filter_settings = common::filter::FilterSettings::new();
-        for p in &args.include {
-            filter_settings.add_include(p)?;
-        }
-        for p in &args.exclude {
-            filter_settings.add_exclude(p)?;
-        }
-        Some(filter_settings)
-    } else {
-        None
-    };
+    let filter = common::filter::FilterSettings::from_args(
+        args.filter_file.as_deref(),
+        &args.include,
+        &args.exclude,
+    )?;
     let time_filter = build_time_filter(
         args.modified_before.as_deref(),
         args.created_before.as_deref(),

--- a/rrm/src/main.rs
+++ b/rrm/src/main.rs
@@ -84,68 +84,9 @@ struct Args {
     #[arg(long, value_name = "MODE", help_heading = "Filtering")]
     dry_run: Option<common::DryRunMode>,
 
-    // Progress & output
-    /// Show progress
-    #[arg(long, help_heading = "Progress & output")]
-    progress: bool,
-
-    /// Toggles the type of progress to show
-    ///
-    /// If specified, --progress flag is implied.
-    ///
-    /// Options are: `ProgressBar` (animated progress bar), `TextUpdates` (appropriate for logging), Auto (default, will
-    /// choose between `ProgressBar` or `TextUpdates` depending on the type of terminal attached to stderr)
-    #[arg(long, value_name = "TYPE", help_heading = "Progress & output")]
-    progress_type: Option<common::ProgressType>,
-
-    /// Sets the delay between progress updates
-    ///
-    /// - For the interactive (--progress-type=ProgressBar), the default is 200ms.
-    /// - For the non-interactive (--progress-type=TextUpdates), the default is 10s.
-    ///
-    /// If specified, --progress flag is implied.
-    ///
-    /// This option accepts a human readable duration, e.g. "200ms", "10s", "5min" etc.
-    #[arg(long, value_name = "DELAY", help_heading = "Progress & output")]
-    progress_delay: Option<String>,
-
-    /// Verbose level (implies "summary"): -v INFO / -vv DEBUG / -vvv TRACE (default: ERROR)
-    #[arg(short = 'v', long = "verbose", action = clap::ArgAction::Count, help_heading = "Progress & output")]
-    verbose: u8,
-
     /// Print summary at the end
     #[arg(long, help_heading = "Progress & output")]
     summary: bool,
-
-    /// Quiet mode, don't report errors
-    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
-    quiet: bool,
-
-    // Performance & throttling
-    /// Maximum number of open files, 0 means no limit, leaving unspecified means using 80% of max open files system limit
-    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
-    max_open_files: Option<usize>,
-
-    /// Throttle the number of operations per second, 0 means no throttle
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    ops_throttle: usize,
-
-    /// Throttle the number of I/O operations per second, 0 means no throttle
-    ///
-    /// I/O is calculated based on provided chunk size -- number of I/O operations for a file is calculated as:
-    /// ((file size - 1) / chunk size) + 1
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Performance & throttling"
-    )]
-    iops_throttle: usize,
 
     /// Chunk size used to calculate number of I/O per file
     ///
@@ -158,24 +99,8 @@ struct Args {
     )]
     chunk_size: u64,
 
-    // Advanced settings
-    /// Number of worker threads, 0 means number of cores
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_workers: usize,
-
-    /// Number of blocking worker threads, 0 means Tokio runtime default (512)
-    #[arg(
-        long,
-        default_value = "0",
-        value_name = "N",
-        help_heading = "Advanced settings"
-    )]
-    max_blocking_threads: usize,
+    #[command(flatten)]
+    common: common::cli::CommonArgs,
 
     // ARGUMENTS
     /// Path(s) to remove
@@ -278,9 +203,9 @@ fn main() -> Result<()> {
     }
     let dry_run_warnings = args.dry_run.map(|_| {
         common::DryRunWarnings::new(
-            args.progress || args.progress_type.is_some() || args.progress_delay.is_some(),
+            args.common.progress_requested(),
             args.summary,
-            args.verbose,
+            args.common.verbose,
             false, // rrm has no --overwrite
             !args.include.is_empty()
                 || !args.exclude.is_empty()
@@ -296,22 +221,9 @@ fn main() -> Result<()> {
         let args = args.clone();
         || async_main(args)
     };
-    let output = common::OutputConfig {
-        quiet: args.quiet,
-        verbose: args.verbose,
-        print_summary: if is_dry_run { false } else { args.summary },
-        ..Default::default()
-    };
-    let runtime = common::RuntimeConfig {
-        max_workers: args.max_workers,
-        max_blocking_threads: args.max_blocking_threads,
-    };
-    let throttle = common::ThrottleConfig {
-        max_open_files: args.max_open_files,
-        ops_throttle: args.ops_throttle,
-        iops_throttle: args.iops_throttle,
-        chunk_size: args.chunk_size,
-    };
+    let output = args.common.output_config(!is_dry_run && args.summary);
+    let runtime = args.common.runtime_config();
+    let throttle = args.common.throttle_config(args.chunk_size);
     let tracing = common::TracingConfig {
         remote_layer: None,
         debug_log_file: None,
@@ -322,25 +234,12 @@ fn main() -> Result<()> {
         tokio_console: false,
         tokio_console_port: None,
     };
-    let res = common::run(
-        if !is_dry_run
-            && (args.progress || args.progress_type.is_some() || args.progress_delay.is_some())
-        {
-            Some(common::ProgressSettings {
-                progress_type: common::GeneralProgressType::User(
-                    args.progress_type.unwrap_or_default(),
-                ),
-                progress_delay: args.progress_delay,
-            })
-        } else {
-            None
-        },
-        output,
-        runtime,
-        throttle,
-        tracing,
-        func,
-    );
+    let progress = if is_dry_run {
+        None
+    } else {
+        args.common.user_progress_settings()
+    };
+    let res = common::run(progress, output, runtime, throttle, tracing, func);
     if let Some(warnings) = dry_run_warnings {
         warnings.print();
     }


### PR DESCRIPTION
## Summary

Six small commits that pay down duplication identified during a code-quality pass. No behavior changes; every commit was validated with `just ci` (lint + debug tests + release tests + Docker multi-host tests).

| Commit | What | Net LOC |
|---|---|---|
| `5a06298` | Extract `EntryKind` enum + `should_skip_entry` into `common::walk`; eliminate three identical helpers and four ad-hoc bool-triplet dispatches across copy/link/rm + `rcp::source::count_skipped` | -129 |
| `95efbf0` | `FilterSettings::from_args` helper; remove 5 duplicates (incl. one duplicated *within* `rcp.rs`) | -27 |
| `d7d9795` | Generic `OperationError<S>` in `common::error`; replace four identical `Error { source, summary }` definitions in copy/link/rm/filegen | -82 |
| `691bff1` | `CommonArgs` (clap `#[command(flatten)]`) for the 10 args repeated in every binary, plus `output_config` / `runtime_config` / `throttle_config` / `user_progress_settings` builders | -402 |
| `184e778` | Split the 273-line `lib::run()` into `install_tracing_subscriber` / `build_tokio_runtime` / `spawn_throttle_replenishers`; deduplicate the verbose env-filter and profile-filter constructors | ~0 (restructure) |
| `7914f29` | Follow-up: pull `max_open_files` and `quiet` back out of `CommonArgs` because filegen's CPU-cores fallback and rcmp's broader quiet semantics need binary-specific help text | +67 |

**Total: -490 lines across 16 files.**

## Notes on small CLI surface changes

- `rcpd` now accepts `--progress-type` as a no-op; the master never sets it and rcpd's progress is always Remote. Documented inline. rcpd is daemon-launched via SSH, never invoked by humans, so the misleading help text is low-risk.
- `filegen`'s `--max-open-files` doc was preserved verbatim; the CPU-cores fallback still applies in `main()`.
- `rcmp`'s `--quiet` doc was preserved verbatim (also suppresses stdout differences).
- `rcmp` and `filegen` historically don't treat `--progress-delay` alone as implying `--progress` (unlike rrm/rlink). Behavior preserved with inline comments at the call sites.

## Test plan
- [x] `just ci` green on each commit (lint + debug + release + Docker multi-host)
- [x] CLI parsing tests pass (108 across rrm/rlink/rcmp/filegen)
- [x] Help text manually reviewed for filegen, rcmp, rcpd