### PR TITLE
Specialize progress display per tool

### DIFF
--- a/common/src/cli.rs
+++ b/common/src/cli.rs
@@ -115,15 +115,22 @@ impl CommonArgs {
         self.progress || self.progress_type.is_some() || self.progress_delay.is_some()
     }
     /// Build user-facing [`crate::ProgressSettings`] when any progress flag was
-    /// set, else `None`. For `rcp`'s remote-master and `rcpd`'s remote progress
-    /// modes, build `ProgressSettings` directly instead of using this helper.
+    /// set, else `None`. `kind` selects the tool-specific printer. For `rcp`'s
+    /// remote-master and `rcpd`'s remote progress modes, build `ProgressSettings`
+    /// directly instead of using this helper.
     #[must_use]
-    pub fn user_progress_settings(&self) -> Option<crate::ProgressSettings> {
+    pub fn user_progress_settings(
+        &self,
+        kind: crate::progress::LocalProgressKind,
+    ) -> Option<crate::ProgressSettings> {
         if !self.progress_requested() {
             return None;
         }
         Some(crate::ProgressSettings {
-            progress_type: crate::GeneralProgressType::User(self.progress_type.unwrap_or_default()),
+            progress_type: crate::GeneralProgressType::User {
+                progress_type: self.progress_type.unwrap_or_default(),
+                kind,
+            },
             progress_delay: self.progress_delay.clone(),
         })
     }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -239,7 +239,10 @@ pub enum ProgressType {
 }
 
 pub enum GeneralProgressType {
-    User(ProgressType),
+    User {
+        progress_type: ProgressType,
+        kind: progress::LocalProgressKind,
+    },
     Remote(tokio::sync::mpsc::UnboundedSender<remote_tracing::TracingMessage>),
     RemoteMaster {
         progress_type: ProgressType,
@@ -251,7 +254,10 @@ pub enum GeneralProgressType {
 impl std::fmt::Debug for GeneralProgressType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            GeneralProgressType::User(pt) => write!(f, "User({pt:?})"),
+            GeneralProgressType::User {
+                progress_type,
+                kind,
+            } => write!(f, "User(progress_type: {progress_type:?}, kind: {kind:?})"),
             GeneralProgressType::Remote(_) => write!(f, "Remote(<sender>)"),
             GeneralProgressType::RemoteMaster { progress_type, .. } => {
                 write!(
@@ -273,6 +279,7 @@ fn progress_bar(
     lock: &std::sync::Mutex<bool>,
     cvar: &std::sync::Condvar,
     delay_opt: &Option<std::time::Duration>,
+    kind: progress::LocalProgressKind,
 ) {
     let delay = delay_opt.unwrap_or(std::time::Duration::from_millis(200));
     PBAR.set_style(
@@ -280,7 +287,7 @@ fn progress_bar(
             .unwrap()
             .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
     );
-    let mut prog_printer = progress::ProgressPrinter::new(&PROGRESS);
+    let mut prog_printer = progress::make_local_printer(kind, &PROGRESS);
     let mut is_done = lock.lock().unwrap();
     loop {
         PBAR.set_position(PBAR.position() + 1); // do we need to update?
@@ -304,9 +311,10 @@ fn text_updates(
     lock: &std::sync::Mutex<bool>,
     cvar: &std::sync::Condvar,
     delay_opt: &Option<std::time::Duration>,
+    kind: progress::LocalProgressKind,
 ) {
     let delay = delay_opt.unwrap_or(std::time::Duration::from_secs(10));
-    let mut prog_printer = progress::ProgressPrinter::new(&PROGRESS);
+    let mut prog_printer = progress::make_local_printer(kind, &PROGRESS);
     let mut is_done = lock.lock().unwrap();
     loop {
         eprintln!("=======================");
@@ -434,22 +442,19 @@ impl ProgressTracker {
                         progress_type,
                     );
                 }
-                _ => {
+                GeneralProgressType::User {
+                    progress_type,
+                    kind,
+                } => {
                     let interactive = match progress_type {
-                        GeneralProgressType::User(ProgressType::Auto) => {
-                            std::io::stderr().is_terminal()
-                        }
-                        GeneralProgressType::User(ProgressType::ProgressBar) => true,
-                        GeneralProgressType::User(ProgressType::TextUpdates) => false,
-                        GeneralProgressType::Remote(_)
-                        | GeneralProgressType::RemoteMaster { .. } => {
-                            unreachable!("Invalid progress type: {progress_type:?}")
-                        }
+                        ProgressType::Auto => std::io::stderr().is_terminal(),
+                        ProgressType::ProgressBar => true,
+                        ProgressType::TextUpdates => false,
                     };
                     if interactive {
-                        progress_bar(lock, cvar, &delay_opt);
+                        progress_bar(lock, cvar, &delay_opt, kind);
                     } else {
-                        text_updates(lock, cvar, &delay_opt);
+                        text_updates(lock, cvar, &delay_opt, kind);
                     }
                 }
             }

--- a/common/src/progress.rs
+++ b/common/src/progress.rs
@@ -283,14 +283,80 @@ impl From<&Progress> for SerializableProgress {
     }
 }
 
-pub struct ProgressPrinter<'a> {
+/// Trait implemented by per-tool progress printers.
+///
+/// Each tool has its own printer that only renders sections relevant to what
+/// the tool actually does (e.g. `rrm` has no COPIED section; `rcmp` only shows
+/// OPS). Prefer adding a new specialized printer over extending a shared one.
+pub trait LocalProgressReport: Send {
+    fn print(&mut self) -> anyhow::Result<String>;
+}
+
+/// Selects which tool-specific printer to instantiate for a local progress run.
+#[derive(Copy, Clone, Debug)]
+pub enum LocalProgressKind {
+    Copy,
+    Remove,
+    Link,
+    Compare,
+    Filegen,
+}
+
+fn ops_rates(
+    progress: &Progress,
+    last_ops: u64,
+    last_update: std::time::Instant,
+    now: std::time::Instant,
+) -> (Status, f64, f64) {
+    let ops = progress.ops.get();
+    let total_secs = progress.get_duration().as_secs_f64();
+    let curr_secs = (now - last_update).as_secs_f64();
+    let average = if total_secs > 0.0 {
+        ops.finished as f64 / total_secs
+    } else {
+        0.0
+    };
+    let current = if curr_secs > 0.0 {
+        (ops.finished - last_ops) as f64 / curr_secs
+    } else {
+        0.0
+    };
+    (ops, average, current)
+}
+
+fn bytes_rates(
+    total: u64,
+    last: u64,
+    total_secs: f64,
+    curr_secs: f64,
+) -> (bytesize::ByteSize, bytesize::ByteSize) {
+    let average = if total_secs > 0.0 {
+        total as f64 / total_secs
+    } else {
+        0.0
+    };
+    let current = if curr_secs > 0.0 {
+        (total - last) as f64 / curr_secs
+    } else {
+        0.0
+    };
+    (
+        bytesize::ByteSize(average as u64),
+        bytesize::ByteSize(current as u64),
+    )
+}
+
+/// Progress printer for `rcp` (local copy). Shows COPIED/UNCHANGED/REMOVED/SKIPPED
+/// for files, symlinks, and directories. Hard-link counters are omitted because
+/// `rcp` never creates hard links.
+pub struct CopyProgressPrinter<'a> {
     progress: &'a Progress,
     last_ops: u64,
     last_bytes: u64,
     last_update: std::time::Instant,
 }
 
-impl<'a> ProgressPrinter<'a> {
+impl<'a> CopyProgressPrinter<'a> {
     pub fn new(progress: &'a Progress) -> Self {
         Self {
             progress,
@@ -299,22 +365,20 @@ impl<'a> ProgressPrinter<'a> {
             last_update: std::time::Instant::now(),
         }
     }
+}
 
-    pub fn print(&mut self) -> anyhow::Result<String> {
-        let time_now = std::time::Instant::now();
-        let ops = self.progress.ops.get();
-        let total_duration_secs = self.progress.get_duration().as_secs_f64();
-        let curr_duration_secs = (time_now - self.last_update).as_secs_f64();
-        let average_ops_rate = ops.finished as f64 / total_duration_secs;
-        let current_ops_rate = (ops.finished - self.last_ops) as f64 / curr_duration_secs;
+impl<'a> LocalProgressReport for CopyProgressPrinter<'a> {
+    fn print(&mut self) -> anyhow::Result<String> {
+        let now = std::time::Instant::now();
+        let (ops, avg_ops, cur_ops) =
+            ops_rates(self.progress, self.last_ops, self.last_update, now);
         let bytes = self.progress.bytes_copied.get();
-        let average_bytes_rate = bytes as f64 / total_duration_secs;
-        let current_bytes_rate = (bytes - self.last_bytes) as f64 / curr_duration_secs;
-        // update self
+        let total_secs = self.progress.get_duration().as_secs_f64();
+        let curr_secs = (now - self.last_update).as_secs_f64();
+        let (avg_bytes, cur_bytes) = bytes_rates(bytes, self.last_bytes, total_secs, curr_secs);
         self.last_ops = ops.finished;
         self.last_bytes = bytes;
-        self.last_update = time_now;
-        // nice to have: convert to a table
+        self.last_update = now;
         Ok(format!(
             "---------------------\n\
             OPS:\n\
@@ -329,13 +393,11 @@ impl<'a> ProgressPrinter<'a> {
             files:       {:>10}\n\
             symlinks:    {:>10}\n\
             directories: {:>10}\n\
-            hard-links:  {:>10}\n\
             -----------------------\n\
             UNCHANGED:\n\
             files:       {:>10}\n\
             symlinks:    {:>10}\n\
             directories: {:>10}\n\
-            hard-links:  {:>10}\n\
             -----------------------\n\
             REMOVED:\n\
             bytes:       {:>10}\n\
@@ -348,33 +410,304 @@ impl<'a> ProgressPrinter<'a> {
             symlinks:    {:>10}\n\
             directories: {:>10}\n\
             specials:    {:>10}",
-            ops.started - ops.finished, // pending
-            average_ops_rate,
-            current_ops_rate,
-            // copy
-            bytesize::ByteSize(average_bytes_rate as u64),
-            bytesize::ByteSize(current_bytes_rate as u64),
-            bytesize::ByteSize(self.progress.bytes_copied.get()),
+            ops.started - ops.finished,
+            avg_ops,
+            cur_ops,
+            avg_bytes,
+            cur_bytes,
+            bytesize::ByteSize(bytes),
             self.progress.files_copied.get(),
             self.progress.symlinks_created.get(),
             self.progress.directories_created.get(),
-            self.progress.hard_links_created.get(),
-            // unchanged
             self.progress.files_unchanged.get(),
             self.progress.symlinks_unchanged.get(),
             self.progress.directories_unchanged.get(),
-            self.progress.hard_links_unchanged.get(),
-            // remove
             bytesize::ByteSize(self.progress.bytes_removed.get()),
             self.progress.files_removed.get(),
             self.progress.symlinks_removed.get(),
             self.progress.directories_removed.get(),
-            // skipped
             self.progress.files_skipped.get(),
             self.progress.symlinks_skipped.get(),
             self.progress.directories_skipped.get(),
             self.progress.specials_skipped.get(),
         ))
+    }
+}
+
+/// Progress printer for `rrm`. Only shows REMOVED and SKIPPED — `rrm` never
+/// creates, copies, or leaves entries unchanged.
+pub struct RemoveProgressPrinter<'a> {
+    progress: &'a Progress,
+    last_ops: u64,
+    last_bytes_removed: u64,
+    last_update: std::time::Instant,
+}
+
+impl<'a> RemoveProgressPrinter<'a> {
+    pub fn new(progress: &'a Progress) -> Self {
+        Self {
+            progress,
+            last_ops: progress.ops.get().finished,
+            last_bytes_removed: progress.bytes_removed.get(),
+            last_update: std::time::Instant::now(),
+        }
+    }
+}
+
+impl<'a> LocalProgressReport for RemoveProgressPrinter<'a> {
+    fn print(&mut self) -> anyhow::Result<String> {
+        let now = std::time::Instant::now();
+        let (ops, avg_ops, cur_ops) =
+            ops_rates(self.progress, self.last_ops, self.last_update, now);
+        let bytes_removed = self.progress.bytes_removed.get();
+        let total_secs = self.progress.get_duration().as_secs_f64();
+        let curr_secs = (now - self.last_update).as_secs_f64();
+        let (avg_bytes, cur_bytes) = bytes_rates(
+            bytes_removed,
+            self.last_bytes_removed,
+            total_secs,
+            curr_secs,
+        );
+        self.last_ops = ops.finished;
+        self.last_bytes_removed = bytes_removed;
+        self.last_update = now;
+        Ok(format!(
+            "---------------------\n\
+            OPS:\n\
+            pending: {:>10}\n\
+            average: {:>10.2} items/s\n\
+            current: {:>10.2} items/s\n\
+            -----------------------\n\
+            REMOVED:\n\
+            average: {:>10}/s\n\
+            current: {:>10}/s\n\
+            bytes:       {:>10}\n\
+            files:       {:>10}\n\
+            symlinks:    {:>10}\n\
+            directories: {:>10}\n\
+            -----------------------\n\
+            SKIPPED:\n\
+            files:       {:>10}\n\
+            symlinks:    {:>10}\n\
+            directories: {:>10}",
+            ops.started - ops.finished,
+            avg_ops,
+            cur_ops,
+            avg_bytes,
+            cur_bytes,
+            bytesize::ByteSize(bytes_removed),
+            self.progress.files_removed.get(),
+            self.progress.symlinks_removed.get(),
+            self.progress.directories_removed.get(),
+            self.progress.files_skipped.get(),
+            self.progress.symlinks_skipped.get(),
+            self.progress.directories_skipped.get(),
+        ))
+    }
+}
+
+/// Progress printer for `rlink`. Like [`CopyProgressPrinter`] but also reports
+/// hard-link counters, since `rlink`'s primary output is hard links (with copies
+/// as a fallback for `--update` changes).
+pub struct LinkProgressPrinter<'a> {
+    progress: &'a Progress,
+    last_ops: u64,
+    last_bytes: u64,
+    last_update: std::time::Instant,
+}
+
+impl<'a> LinkProgressPrinter<'a> {
+    pub fn new(progress: &'a Progress) -> Self {
+        Self {
+            progress,
+            last_ops: progress.ops.get().finished,
+            last_bytes: progress.bytes_copied.get(),
+            last_update: std::time::Instant::now(),
+        }
+    }
+}
+
+impl<'a> LocalProgressReport for LinkProgressPrinter<'a> {
+    fn print(&mut self) -> anyhow::Result<String> {
+        let now = std::time::Instant::now();
+        let (ops, avg_ops, cur_ops) =
+            ops_rates(self.progress, self.last_ops, self.last_update, now);
+        let bytes = self.progress.bytes_copied.get();
+        let total_secs = self.progress.get_duration().as_secs_f64();
+        let curr_secs = (now - self.last_update).as_secs_f64();
+        let (avg_bytes, cur_bytes) = bytes_rates(bytes, self.last_bytes, total_secs, curr_secs);
+        self.last_ops = ops.finished;
+        self.last_bytes = bytes;
+        self.last_update = now;
+        Ok(format!(
+            "---------------------\n\
+            OPS:\n\
+            pending: {:>10}\n\
+            average: {:>10.2} items/s\n\
+            current: {:>10.2} items/s\n\
+            -----------------------\n\
+            LINKED / COPIED:\n\
+            average: {:>10}/s\n\
+            current: {:>10}/s\n\
+            bytes:   {:>10}\n\
+            hard-links:  {:>10}\n\
+            files:       {:>10}\n\
+            symlinks:    {:>10}\n\
+            directories: {:>10}\n\
+            -----------------------\n\
+            UNCHANGED:\n\
+            hard-links:  {:>10}\n\
+            files:       {:>10}\n\
+            symlinks:    {:>10}\n\
+            directories: {:>10}\n\
+            -----------------------\n\
+            REMOVED:\n\
+            bytes:       {:>10}\n\
+            files:       {:>10}\n\
+            symlinks:    {:>10}\n\
+            directories: {:>10}\n\
+            -----------------------\n\
+            SKIPPED:\n\
+            files:       {:>10}\n\
+            symlinks:    {:>10}\n\
+            directories: {:>10}\n\
+            specials:    {:>10}",
+            ops.started - ops.finished,
+            avg_ops,
+            cur_ops,
+            avg_bytes,
+            cur_bytes,
+            bytesize::ByteSize(bytes),
+            self.progress.hard_links_created.get(),
+            self.progress.files_copied.get(),
+            self.progress.symlinks_created.get(),
+            self.progress.directories_created.get(),
+            self.progress.hard_links_unchanged.get(),
+            self.progress.files_unchanged.get(),
+            self.progress.symlinks_unchanged.get(),
+            self.progress.directories_unchanged.get(),
+            bytesize::ByteSize(self.progress.bytes_removed.get()),
+            self.progress.files_removed.get(),
+            self.progress.symlinks_removed.get(),
+            self.progress.directories_removed.get(),
+            self.progress.files_skipped.get(),
+            self.progress.symlinks_skipped.get(),
+            self.progress.directories_skipped.get(),
+            self.progress.specials_skipped.get(),
+        ))
+    }
+}
+
+/// Progress printer for `rcmp`. Compare operations only drive the ops counter —
+/// they don't copy, remove, or modify anything — so only OPS is shown.
+pub struct CompareProgressPrinter<'a> {
+    progress: &'a Progress,
+    last_ops: u64,
+    last_update: std::time::Instant,
+}
+
+impl<'a> CompareProgressPrinter<'a> {
+    pub fn new(progress: &'a Progress) -> Self {
+        Self {
+            progress,
+            last_ops: progress.ops.get().finished,
+            last_update: std::time::Instant::now(),
+        }
+    }
+}
+
+impl<'a> LocalProgressReport for CompareProgressPrinter<'a> {
+    fn print(&mut self) -> anyhow::Result<String> {
+        let now = std::time::Instant::now();
+        let (ops, avg_ops, cur_ops) =
+            ops_rates(self.progress, self.last_ops, self.last_update, now);
+        self.last_ops = ops.finished;
+        self.last_update = now;
+        Ok(format!(
+            "---------------------\n\
+            OPS:\n\
+            pending: {:>10}\n\
+            compared: {:>9}\n\
+            average: {:>10.2} items/s\n\
+            current: {:>10.2} items/s",
+            ops.started - ops.finished,
+            ops.finished,
+            avg_ops,
+            cur_ops,
+        ))
+    }
+}
+
+/// Progress printer for `filegen`. Shows a GENERATED section instead of COPIED,
+/// because `filegen` creates files and directories rather than copying them.
+pub struct FilegenProgressPrinter<'a> {
+    progress: &'a Progress,
+    last_ops: u64,
+    last_bytes: u64,
+    last_update: std::time::Instant,
+}
+
+impl<'a> FilegenProgressPrinter<'a> {
+    pub fn new(progress: &'a Progress) -> Self {
+        Self {
+            progress,
+            last_ops: progress.ops.get().finished,
+            last_bytes: progress.bytes_copied.get(),
+            last_update: std::time::Instant::now(),
+        }
+    }
+}
+
+impl<'a> LocalProgressReport for FilegenProgressPrinter<'a> {
+    fn print(&mut self) -> anyhow::Result<String> {
+        let now = std::time::Instant::now();
+        let (ops, avg_ops, cur_ops) =
+            ops_rates(self.progress, self.last_ops, self.last_update, now);
+        let bytes = self.progress.bytes_copied.get();
+        let total_secs = self.progress.get_duration().as_secs_f64();
+        let curr_secs = (now - self.last_update).as_secs_f64();
+        let (avg_bytes, cur_bytes) = bytes_rates(bytes, self.last_bytes, total_secs, curr_secs);
+        self.last_ops = ops.finished;
+        self.last_bytes = bytes;
+        self.last_update = now;
+        Ok(format!(
+            "---------------------\n\
+            OPS:\n\
+            pending: {:>10}\n\
+            average: {:>10.2} items/s\n\
+            current: {:>10.2} items/s\n\
+            -----------------------\n\
+            GENERATED:\n\
+            average: {:>10}/s\n\
+            current: {:>10}/s\n\
+            bytes:       {:>10}\n\
+            files:       {:>10}\n\
+            directories: {:>10}",
+            ops.started - ops.finished,
+            avg_ops,
+            cur_ops,
+            avg_bytes,
+            cur_bytes,
+            bytesize::ByteSize(bytes),
+            self.progress.files_copied.get(),
+            self.progress.directories_created.get(),
+        ))
+    }
+}
+
+/// Construct the tool-specific printer for the given [`LocalProgressKind`],
+/// borrowing the global [`Progress`] for its lifetime.
+#[must_use]
+pub fn make_local_printer<'a>(
+    kind: LocalProgressKind,
+    progress: &'a Progress,
+) -> Box<dyn LocalProgressReport + 'a> {
+    match kind {
+        LocalProgressKind::Copy => Box::new(CopyProgressPrinter::new(progress)),
+        LocalProgressKind::Remove => Box::new(RemoveProgressPrinter::new(progress)),
+        LocalProgressKind::Link => Box::new(LinkProgressPrinter::new(progress)),
+        LocalProgressKind::Compare => Box::new(CompareProgressPrinter::new(progress)),
+        LocalProgressKind::Filegen => Box::new(FilegenProgressPrinter::new(progress)),
     }
 }
 
@@ -825,6 +1158,75 @@ mod tests {
         for (i, counter) in counters.iter().enumerate() {
             assert_eq!(counter.get(), (i + 1) as u64 * 100);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn copy_printer_omits_hard_links() -> Result<()> {
+        let progress = Progress::new();
+        let mut printer = CopyProgressPrinter::new(&progress);
+        let output = printer.print()?;
+        assert!(output.contains("COPIED:"));
+        assert!(output.contains("UNCHANGED:"));
+        assert!(output.contains("REMOVED:"));
+        assert!(output.contains("SKIPPED:"));
+        assert!(!output.contains("hard-links"));
+        Ok(())
+    }
+
+    #[test]
+    fn remove_printer_hides_copy_and_unchanged() -> Result<()> {
+        let progress = Progress::new();
+        let mut printer = RemoveProgressPrinter::new(&progress);
+        let output = printer.print()?;
+        assert!(output.contains("REMOVED:"));
+        assert!(output.contains("SKIPPED:"));
+        assert!(!output.contains("COPIED:"));
+        assert!(!output.contains("UNCHANGED:"));
+        assert!(!output.contains("hard-links"));
+        assert!(!output.contains("specials:"));
+        Ok(())
+    }
+
+    #[test]
+    fn link_printer_shows_hard_links() -> Result<()> {
+        let progress = Progress::new();
+        let mut printer = LinkProgressPrinter::new(&progress);
+        let output = printer.print()?;
+        assert!(output.contains("LINKED / COPIED:"));
+        assert!(output.contains("UNCHANGED:"));
+        assert!(output.contains("REMOVED:"));
+        assert!(output.contains("SKIPPED:"));
+        assert!(output.contains("hard-links"));
+        Ok(())
+    }
+
+    #[test]
+    fn compare_printer_only_shows_ops() -> Result<()> {
+        let progress = Progress::new();
+        let mut printer = CompareProgressPrinter::new(&progress);
+        let output = printer.print()?;
+        assert!(output.contains("OPS:"));
+        assert!(!output.contains("COPIED:"));
+        assert!(!output.contains("UNCHANGED:"));
+        assert!(!output.contains("REMOVED:"));
+        assert!(!output.contains("SKIPPED:"));
+        assert!(!output.contains("GENERATED:"));
+        Ok(())
+    }
+
+    #[test]
+    fn filegen_printer_shows_generated() -> Result<()> {
+        let progress = Progress::new();
+        let mut printer = FilegenProgressPrinter::new(&progress);
+        let output = printer.print()?;
+        assert!(output.contains("OPS:"));
+        assert!(output.contains("GENERATED:"));
+        assert!(!output.contains("COPIED:"));
+        assert!(!output.contains("UNCHANGED:"));
+        assert!(!output.contains("REMOVED:"));
+        assert!(!output.contains("SKIPPED:"));
+        assert!(!output.contains("symlinks:"));
         Ok(())
     }
 }

--- a/filegen/src/main.rs
+++ b/filegen/src/main.rs
@@ -183,9 +183,10 @@ fn main() -> Result<(), anyhow::Error> {
     // implying --progress (unlike rrm/rlink). preserve that behavior here.
     let progress = if args.common.progress || args.common.progress_type.is_some() {
         Some(common::ProgressSettings {
-            progress_type: common::GeneralProgressType::User(
-                args.common.progress_type.unwrap_or_default(),
-            ),
+            progress_type: common::GeneralProgressType::User {
+                progress_type: args.common.progress_type.unwrap_or_default(),
+                kind: common::progress::LocalProgressKind::Filegen,
+            },
             progress_delay: args.common.progress_delay.clone(),
         })
     } else {

--- a/rcmp/src/main.rs
+++ b/rcmp/src/main.rs
@@ -195,9 +195,10 @@ fn main() -> Result<()> {
     // --progress (unlike rrm/rlink). preserve that behavior here.
     let progress = if args.common.progress || args.common.progress_type.is_some() {
         Some(common::ProgressSettings {
-            progress_type: common::GeneralProgressType::User(
-                args.common.progress_type.unwrap_or_default(),
-            ),
+            progress_type: common::GeneralProgressType::User {
+                progress_type: args.common.progress_type.unwrap_or_default(),
+                kind: common::progress::LocalProgressKind::Compare,
+            },
             progress_delay: args.common.progress_delay.clone(),
         })
     } else {

--- a/rcp/src/bin/rcp.rs
+++ b/rcp/src/bin/rcp.rs
@@ -1095,7 +1095,10 @@ fn main() -> Result<(), anyhow::Error> {
                     get_progress_snapshot: Box::new(remote::tracelog::get_latest_progress_snapshot),
                 }
             } else {
-                common::GeneralProgressType::User(args.common.progress_type.unwrap_or_default())
+                common::GeneralProgressType::User {
+                    progress_type: args.common.progress_type.unwrap_or_default(),
+                    kind: common::progress::LocalProgressKind::Copy,
+                }
             },
             progress_delay: args.common.progress_delay,
         })

--- a/rlink/src/main.rs
+++ b/rlink/src/main.rs
@@ -279,7 +279,8 @@ fn main() -> Result<()> {
     let progress = if is_dry_run {
         None
     } else {
-        args.common.user_progress_settings()
+        args.common
+            .user_progress_settings(common::progress::LocalProgressKind::Link)
     };
     let res = common::run(progress, output, runtime, throttle, tracing, func);
     if let Some(warnings) = dry_run_warnings {

--- a/rrm/src/main.rs
+++ b/rrm/src/main.rs
@@ -249,7 +249,8 @@ fn main() -> Result<()> {
     let progress = if is_dry_run {
         None
     } else {
-        args.common.user_progress_settings()
+        args.common
+            .user_progress_settings(common::progress::LocalProgressKind::Remove)
     };
     let res = common::run(progress, output, runtime, throttle, tracing, func);
     if let Some(warnings) = dry_run_warnings {


### PR DESCRIPTION
## Summary

- Replace the single generic `ProgressPrinter` with one printer per tool so the output stays true to what the tool actually does.
- `rcmp` no longer shows `COPIED` / `UNCHANGED` / `REMOVED` / `SKIPPED` — it only drives the ops counter, so only OPS is displayed (plus a `compared:` total).
- `rrm` no longer shows `COPIED` / `UNCHANGED`.
- `rcp` drops the always-zero hard-links rows (rcp never creates hard links); `rlink` keeps them.
- `filegen` replaces `COPIED` with `GENERATED` and only shows the counters it actually updates (bytes, files, directories).
- `GeneralProgressType::User` becomes a struct variant carrying the tool's `LocalProgressKind`, so the dispatch point in `ProgressTracker` instantiates the right printer. Each tool's `main.rs` passes its matching kind.
- Adds a per-printer test verifying the right sections appear and irrelevant ones stay hidden.

## Test plan

- [x] `just lint`
- [x] `just doc`
- [x] `just test` (661 passed)
- [x] `just test-release` (666 passed)
- [x] `just doctest`
- [x] Ran each tool with `--progress-type=TextUpdates` and confirmed the displayed sections match what the tool does