### PR TITLE
Fix --auto-meta-throttle pinning cwnd at the floor on real filesystems

### DIFF
--- a/common/src/auto_meta.rs
+++ b/common/src/auto_meta.rs
@@ -508,9 +508,7 @@ mod tests {
         /// Reset the global throttle + sample-sink state after a test so
         /// a subsequent test sees a clean slate regardless of ordering.
         async fn reset_globals() {
-            throttle::set_max_ops_in_flight(throttle::Resource::SrcWalk, 0);
             throttle::set_max_ops_in_flight(throttle::Resource::SrcMeta, 0);
-            throttle::set_max_ops_in_flight(throttle::Resource::DstWalk, 0);
             throttle::set_max_ops_in_flight(throttle::Resource::DstMeta, 0);
             throttle::disable_ops_throttle();
             congestion::clear_sample_sink();

--- a/common/src/cli.rs
+++ b/common/src/cli.rs
@@ -98,10 +98,10 @@ pub struct CommonArgs {
         help_heading = "Congestion control"
     )]
     pub auto_meta_max_cwnd: u32,
-    /// Latency inflation ratio below which cwnd grows (ewma / min_latency)
+    /// Latency inflation ratio below which cwnd grows (ewma / baseline)
     #[arg(
         long,
-        default_value = "1.1",
+        default_value = "1.3",
         value_name = "F",
         help_heading = "Congestion control (advanced)"
     )]
@@ -109,7 +109,7 @@ pub struct CommonArgs {
     /// Latency inflation ratio above which cwnd shrinks
     #[arg(
         long,
-        default_value = "1.5",
+        default_value = "2.5",
         value_name = "F",
         help_heading = "Congestion control (advanced)"
     )]
@@ -138,8 +138,8 @@ pub struct CommonArgs {
         help_heading = "Congestion control (advanced)"
     )]
     pub auto_meta_decrease_step: u32,
-    /// Max age of the min-latency baseline (e.g. "10s") before it is
-    /// discarded and re-established from new samples
+    /// Max age (e.g. "10s") of samples in the baseline window before
+    /// they are discarded and the baseline is re-established from new samples
     #[arg(
         long,
         default_value = "10s",

--- a/common/src/cmp.rs
+++ b/common/src/cmp.rs
@@ -374,9 +374,20 @@ async fn expand_missing_tree(
     settings: &Settings,
 ) -> Result<Summary> {
     let _prog_guard = prog_track.ops.guard();
-    let metadata = tokio::fs::symlink_metadata(existing_path)
-        .await
-        .with_context(|| format!("failed reading metadata from {:?}", &existing_path))?;
+    // The side we probe against is fully determined by which tree is
+    // missing: `DstMissing` means we're enumerating src, `SrcMissing`
+    // means we're enumerating dst. `Same` / `Different` are never
+    // passed in (the only two call sites pass the `*Missing` variants),
+    // but be defensive and default to source.
+    let side = match result {
+        CompareResult::DstMissing => congestion::Side::Source,
+        CompareResult::SrcMissing => congestion::Side::Destination,
+        CompareResult::Same | CompareResult::Different => congestion::Side::Source,
+    };
+    let metadata =
+        crate::walk::run_metadata_probed(side, tokio::fs::symlink_metadata(existing_path))
+            .await
+            .with_context(|| format!("failed reading metadata from {:?}", &existing_path))?;
     let existing_obj_type = obj_type(&metadata);
     let mut summary = Summary::default();
     summary.mismatch[existing_obj_type][result] += 1;
@@ -424,7 +435,7 @@ async fn expand_missing_tree(
     let errors = crate::error_collector::ErrorCollector::default();
     loop {
         let Some((entry, entry_file_type)) =
-            crate::walk::next_entry_probed(&mut entries, congestion::Side::Source, || {
+            crate::walk::next_entry_probed(&mut entries, side, || {
                 format!("failed traversing directory {:?}", &existing_path)
             })
             .await?
@@ -509,9 +520,12 @@ async fn cmp_internal(
     let _prog_guard = prog_track.ops.guard();
     tracing::debug!("reading source metadata");
     // it is impossible for src not exist other than user passing invalid path (which is an error)
-    let src_metadata = tokio::fs::symlink_metadata(src)
-        .await
-        .with_context(|| format!("failed reading metadata from {:?}", &src))?;
+    let src_metadata = crate::walk::run_metadata_probed(
+        congestion::Side::Source,
+        tokio::fs::symlink_metadata(src),
+    )
+    .await
+    .with_context(|| format!("failed reading metadata from {:?}", &src))?;
     // apply filter to root item (when src == source_root, this is the initial call)
     if src == source_root
         && let Some(filter) = &settings.filter
@@ -536,7 +550,12 @@ async fn cmp_internal(
         cmp_summary.src_bytes += src_metadata.len();
     }
     let dst_metadata = {
-        match tokio::fs::symlink_metadata(dst).await {
+        let probed = crate::walk::run_metadata_probed(
+            congestion::Side::Destination,
+            tokio::fs::symlink_metadata(dst),
+        )
+        .await;
+        match probed {
             Ok(metadata) => metadata,
             Err(err) => {
                 if err.kind() == std::io::ErrorKind::NotFound {
@@ -707,9 +726,12 @@ async fn cmp_internal(
         }
         tracing::debug!("found a new entry in the 'dst' directory");
         let dst_path = dst.join(entry_name);
-        let dst_entry_metadata = tokio::fs::symlink_metadata(&dst_path)
-            .await
-            .with_context(|| format!("failed reading metadata from {:?}", &dst_path))?;
+        let dst_entry_metadata = crate::walk::run_metadata_probed(
+            congestion::Side::Destination,
+            tokio::fs::symlink_metadata(&dst_path),
+        )
+        .await
+        .with_context(|| format!("failed reading metadata from {:?}", &dst_path))?;
         let dst_obj_type = obj_type(&dst_entry_metadata);
         if settings.expand_missing && dst_entry_metadata.is_dir() {
             match expand_missing_tree(

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -91,8 +91,10 @@ impl ThrottleConfig {
                 return Err("auto-meta-ewma-alpha must be in [0.0, 1.0]".to_string());
             }
             // alpha and beta are latency-inflation ratios; values <= 1.0 are
-            // nonsensical since the EWMA-to-baseline ratio is >= 1.0 by
-            // construction (baseline = running minimum).
+            // nonsensical since the EWMA-to-baseline ratio normally rides at
+            // or above 1.0 (baseline = p10 of recent samples, EWMA = mean of
+            // all recent samples; mean >= p10 by definition modulo sample
+            // ordering effects).
             if auto.alpha <= 1.0 {
                 return Err("auto-meta-alpha must be > 1.0".to_string());
             }
@@ -249,8 +251,8 @@ mod auto_meta_validation_tests {
             initial_cwnd: 1,
             min_cwnd: 1,
             max_cwnd: 4096,
-            alpha: 1.1,
-            beta: 1.5,
+            alpha: 1.3,
+            beta: 2.5,
             ewma_alpha: 0.3,
             increase_step: 1,
             decrease_step: 1,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1096,22 +1096,19 @@ fn spawn_throttle_replenishers(runtime: &tokio::runtime::Runtime, throttle: &Thr
 }
 
 /// Wire up the adaptive metadata-ops control loops — one per
-/// (side × class) [`throttle::Resource`] pair (4 in total):
+/// [`throttle::Resource`] (source and destination metadata):
 ///
-/// 1. Seed every per-resource `OPS_IN_FLIGHT_LIMIT_*` semaphore with the
+/// 1. Seed both per-resource `OPS_IN_FLIGHT_LIMIT_*` semaphores with the
 ///    controller's initial cwnd so the first probe on any resource
 ///    finds a permit available.
-/// 2. Install one `RoutingSink` that fans walk and metadata samples out
-///    to four independent `ControlUnit<VegasController>`s — one per
-///    `(Walk|Metadata) × (Source|Destination)`. Splitting walk vs.
-///    metadata keeps cache-warm directory iteration from dragging the
-///    real-syscall baseline up; splitting source vs. destination keeps
-///    a saturated source from dragging the destination's cwnd down.
-/// 3. Spawn one combined adapter/monitor task per resource. Only one
-///    of the four (the destination metadata controller, by convention)
-///    drives the global ops-throttle rate gate — the global
-///    `OPS_THROTTLE` is shared, so multiple writers would fight. The
-///    other three apply only their concurrency caps.
+/// 2. Install one `RoutingSink` that fans metadata samples out to two
+///    independent `ControlUnit<VegasController>`s — one per
+///    [`congestion::Side`]. Splitting source vs. destination keeps a
+///    saturated source from dragging the destination's cwnd down.
+/// 3. Spawn one combined adapter/monitor task per resource. Only the
+///    destination metadata controller drives the global ops-throttle
+///    rate gate — the global `OPS_THROTTLE` is shared, so multiple
+///    writers would fight. The other applies only its concurrency cap.
 /// 4. Each adapter exits cleanly when its control unit stops
 ///    publishing decisions, so they don't leak as unbounded background
 ///    loops.
@@ -1124,32 +1121,23 @@ fn spawn_auto_meta_throttle(runtime: &tokio::runtime::Runtime, auto: AutoMetaThr
         .clamp(auto.min_cwnd.max(1), auto.max_cwnd.max(1));
     // Seed every resource with the same initial cwnd; each then adapts
     // independently from there.
-    for resource in [
-        throttle::Resource::SrcWalk,
-        throttle::Resource::SrcMeta,
-        throttle::Resource::DstWalk,
-        throttle::Resource::DstMeta,
-    ] {
+    for resource in [throttle::Resource::SrcMeta, throttle::Resource::DstMeta] {
         throttle::set_max_ops_in_flight(resource, initial_cwnd as usize);
     }
     let mut builder = congestion::RoutingSinkBuilder::new();
-    let walk_src_rx = builder.walk_receiver(congestion::Side::Source);
-    let walk_dst_rx = builder.walk_receiver(congestion::Side::Destination);
     let metadata_src_rx = builder.metadata_receiver(congestion::Side::Source);
     let metadata_dst_rx = builder.metadata_receiver(congestion::Side::Destination);
     let sink = std::sync::Arc::new(builder.build());
     congestion::install_sample_sink(sink.clone());
-    // Four controllers — one per resource. Only the DstMeta adapter
-    // drives the global rate gate to avoid four writers fighting over a
+    // Two controllers — one per resource. Only the DstMeta adapter
+    // drives the global rate gate to avoid two writers fighting over a
     // single shared `OPS_THROTTLE`.
     let resources: [(
         &'static str,
         throttle::Resource,
         tokio::sync::mpsc::Receiver<congestion::Sample>,
         bool,
-    ); 4] = [
-        ("walk-src", throttle::Resource::SrcWalk, walk_src_rx, false),
-        ("walk-dst", throttle::Resource::DstWalk, walk_dst_rx, false),
+    ); 2] = [
         (
             "meta-src",
             throttle::Resource::SrcMeta,
@@ -1187,8 +1175,8 @@ fn spawn_auto_meta_throttle(runtime: &tokio::runtime::Runtime, auto: AutoMetaThr
         ));
     }
     tracing::info!(
-        "auto-meta-throttle enabled (per-resource controllers: walk-src, walk-dst, \
-         meta-src, meta-dst): initial_cwnd={}, max_cwnd={}, alpha={}, beta={}, tick={:?}",
+        "auto-meta-throttle enabled (per-resource controllers: meta-src, meta-dst): \
+         initial_cwnd={}, max_cwnd={}, alpha={}, beta={}, tick={:?}",
         auto.initial_cwnd,
         auto.max_cwnd,
         auto.alpha,
@@ -1280,12 +1268,7 @@ where
 fn reset_process_throttle_state() {
     congestion::clear_sample_sink();
     observability::clear();
-    for resource in [
-        throttle::Resource::SrcWalk,
-        throttle::Resource::SrcMeta,
-        throttle::Resource::DstWalk,
-        throttle::Resource::DstMeta,
-    ] {
+    for resource in [throttle::Resource::SrcMeta, throttle::Resource::DstMeta] {
         throttle::set_max_ops_in_flight(resource, 0);
     }
     throttle::disable_ops_throttle();

--- a/common/src/observability.rs
+++ b/common/src/observability.rs
@@ -60,33 +60,62 @@ pub fn clear() {
         .clear();
 }
 
+/// Width (in display chars) of every right-aligned numeric column in
+/// the rendered panel. Wide enough to fit the realistic worst cases
+/// without truncation: `999.9µs`, `1234.5×`, `999.9k`.
+const FIELD_WIDTH: usize = 7;
+
+/// Section separator drawn above the auto-meta panel. Matches the
+/// dashed style used elsewhere in the progress printers so the panel
+/// reads as just another section break rather than free-floating text.
+const SEPARATOR: &str = "-----------------------";
+
 /// Render the registered units as a multi-line block suitable for
-/// appending to the progress display. Returns an empty string if no
-/// units are registered (so non-adaptive runs render an unmodified
-/// progress bar).
+/// appending to the progress display. Returns an empty string when
+/// either (a) no units are registered (non-adaptive run) or (b) every
+/// registered unit has zero samples — typically a brief startup window
+/// before the first probe lands, or a unit class that the current tool
+/// never exercises (e.g. `meta-src` for `filegen`, which only ever
+/// touches the destination side).
 ///
-/// The format is one fixed-width line per unit:
+/// The format is one fixed-width line per unit, prefixed by a dashed
+/// separator so the panel sits visually apart from the COPIED/REMOVED/
+/// SKIPPED sections above it:
 ///
 /// ```text
-/// walk-src cwnd=42  base=0.8ms  ewma=2.1ms  ratio=2.6×  samples=1.2k
+/// -----------------------
+/// meta-src  cwnd=  42  base=  0.8ms  ewma=  2.1ms  ratio=   2.6×  samples=   1.2k
 /// ```
 ///
 /// Unit labels are padded to a uniform width so columns align even
-/// across mixed `walk-` / `meta-` names. Each line begins with a
-/// newline so it composes cleanly when appended to an existing
-/// message.
+/// when the registry grows beyond `meta-src` / `meta-dst`. Numeric
+/// columns are right-aligned to a uniform fixed width.
 #[must_use]
 pub fn render_lines() -> String {
     let units = registered_units();
     if units.is_empty() {
         return String::new();
     }
-    let label_width = units.iter().map(|u| u.label.len()).max().unwrap_or(0);
+    // Snapshot once per render so a probe completing mid-render can't
+    // make a row appear/disappear between the empty check and the loop.
+    let snapshots: Vec<(&'static str, ControllerSnapshot)> = units
+        .iter()
+        .map(|u| (u.label, *u.snapshot_rx.borrow()))
+        .collect();
+    let visible: Vec<(&'static str, ControllerSnapshot)> = snapshots
+        .into_iter()
+        .filter(|(_, snap)| snap.samples_seen > 0)
+        .collect();
+    if visible.is_empty() {
+        return String::new();
+    }
+    let label_width = visible.iter().map(|(l, _)| l.len()).max().unwrap_or(0);
     let mut out = String::new();
-    for unit in &units {
-        let snap = *unit.snapshot_rx.borrow();
+    out.push('\n');
+    out.push_str(SEPARATOR);
+    for (label, snap) in &visible {
         out.push('\n');
-        out.push_str(&format_unit_line(unit.label, label_width, snap));
+        out.push_str(&format_unit_line(label, label_width, *snap));
     }
     out
 }
@@ -102,9 +131,10 @@ fn format_unit_line(label: &str, label_width: usize, snap: ControllerSnapshot) -
         format!("{ratio:.1}×")
     };
     format!(
-        "{label:<width$}  cwnd={cwnd:<4}  base={base}  ewma={ewma}  ratio={ratio:<5}  samples={samples}",
+        "{label:<lwidth$}  cwnd={cwnd:>4}  base={base:>fwidth$}  ewma={ewma:>fwidth$}  ratio={ratio:>fwidth$}  samples={samples:>fwidth$}",
         label = label,
-        width = label_width,
+        lwidth = label_width,
+        fwidth = FIELD_WIDTH,
         cwnd = snap.cwnd,
         base = format_duration(snap.min_latency),
         ewma = format_duration(snap.ewma_latency),
@@ -113,12 +143,12 @@ fn format_unit_line(label: &str, label_width: usize, snap: ControllerSnapshot) -
     )
 }
 
-/// Compact, uniform-width latency formatter. Picks the unit so the
-/// number stays in 1–3 digits ("0.8ms", "12ms", "1.4s") to keep
-/// columns roughly aligned.
+/// Compact latency formatter. Picks the unit so the number stays in
+/// 1–4 chars (`58`, `1.7`, `33.5`, `999.9`); the outer format string
+/// pads the result to [`FIELD_WIDTH`] so consecutive rows line up.
 fn format_duration(d: std::time::Duration) -> String {
     if d.is_zero() {
-        return String::from("  —  ");
+        return String::from("—");
     }
     let nanos = d.as_nanos();
     if nanos < 1_000 {
@@ -219,27 +249,124 @@ mod tests {
         register_unit("meta-dst", rx_b);
         let out = render_lines();
         let lines: Vec<&str> = out.split('\n').filter(|s| !s.is_empty()).collect();
-        assert_eq!(lines.len(), 2);
-        assert!(lines[0].contains("walk-src"));
-        assert!(lines[0].contains("cwnd=8"));
+        // Separator + 2 unit rows.
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0], SEPARATOR);
+        assert!(lines[1].contains("walk-src"));
+        // cwnd is right-aligned to 4 chars; numeric columns to FIELD_WIDTH.
+        assert!(lines[1].contains("cwnd=   8"));
         // EWMA / min_latency = 2ms / 800µs = 2.5×
-        assert!(lines[0].contains("ratio=2.5×"));
-        assert!(lines[0].contains("samples=1.2k"));
-        assert!(lines[1].contains("meta-dst"));
-        assert!(lines[1].contains("cwnd=16"));
-        assert!(lines[1].contains("samples=5.7k"));
+        assert!(lines[1].contains("ratio=   2.5×"));
+        assert!(lines[1].contains("samples=   1.2k"));
+        assert!(lines[2].contains("meta-dst"));
+        assert!(lines[2].contains("cwnd=  16"));
+        assert!(lines[2].contains("samples=   5.7k"));
+        clear();
+    }
+
+    #[test]
+    fn render_lines_skips_units_with_zero_samples() {
+        // Tools that don't exercise a side (e.g. rrm never walks the
+        // destination tree) leave that controller's `samples_seen` at
+        // zero. We don't show the row at all rather than render a
+        // permanent placeholder of dashes.
+        let _g = GUARD.lock().unwrap();
+        clear();
+        let (_tx_a, rx_a) = tokio::sync::watch::channel(ControllerSnapshot {
+            cwnd: 8,
+            min_latency: std::time::Duration::from_micros(800),
+            ewma_latency: std::time::Duration::from_millis(2),
+            samples_seen: 1234,
+        });
+        let (_tx_b, rx_b) = tokio::sync::watch::channel(ControllerSnapshot {
+            cwnd: 1,
+            min_latency: std::time::Duration::ZERO,
+            ewma_latency: std::time::Duration::ZERO,
+            samples_seen: 0,
+        });
+        register_unit("walk-src", rx_a);
+        register_unit("walk-dst", rx_b);
+        let out = render_lines();
+        assert!(out.contains("walk-src"));
+        assert!(!out.contains("walk-dst"));
+        clear();
+    }
+
+    #[test]
+    fn render_lines_is_empty_when_all_units_have_zero_samples() {
+        // At startup, before any probes have completed, every controller
+        // reports samples_seen = 0. The panel shouldn't render a bare
+        // separator with nothing under it.
+        let _g = GUARD.lock().unwrap();
+        clear();
+        let (_tx, rx) = tokio::sync::watch::channel(ControllerSnapshot::default());
+        register_unit("walk-src", rx);
+        assert_eq!(render_lines(), "");
         clear();
     }
 
     #[test]
     fn render_lines_shows_em_dash_when_baseline_unset() {
+        // It's possible (briefly) for a unit to have samples_seen > 0
+        // but the published snapshot's min_latency still at zero, if the
+        // snapshot was captured between on_sample and the first
+        // sample-bearing on_tick. Guard against the resulting 0/0 by
+        // emitting "—" for ratio.
         let _g = GUARD.lock().unwrap();
         clear();
-        let (_tx, rx) = tokio::sync::watch::channel(ControllerSnapshot::default());
+        let (_tx, rx) = tokio::sync::watch::channel(ControllerSnapshot {
+            cwnd: 1,
+            min_latency: std::time::Duration::ZERO,
+            ewma_latency: std::time::Duration::ZERO,
+            samples_seen: 1,
+        });
         register_unit("walk-src", rx);
         let out = render_lines();
-        // ratio is "—" when no baseline yet, prevents a 0/0 division.
-        assert!(out.contains("ratio=—"));
+        assert!(out.contains("ratio="));
+        assert!(out.contains("—"));
+        clear();
+    }
+
+    #[test]
+    fn render_lines_columns_are_aligned_across_rows() {
+        // Regression: durations like "58ns" (4 chars) and "33.5µs" (6
+        // chars) used to land in unpadded columns, so consecutive rows
+        // were visually misaligned. With FIELD_WIDTH right-alignment,
+        // each "key=" anchor must start at the same display-column on
+        // every rendered row. We compare char counts rather than byte
+        // offsets so the multi-byte `µ` doesn't confuse the check.
+        let _g = GUARD.lock().unwrap();
+        clear();
+        let (_tx_a, rx_a) = tokio::sync::watch::channel(ControllerSnapshot {
+            cwnd: 1,
+            min_latency: std::time::Duration::from_nanos(58),
+            ewma_latency: std::time::Duration::from_micros(33),
+            samples_seen: 629_000,
+        });
+        let (_tx_b, rx_b) = tokio::sync::watch::channel(ControllerSnapshot {
+            cwnd: 1,
+            min_latency: std::time::Duration::from_micros(1700),
+            ewma_latency: std::time::Duration::from_micros(3500),
+            samples_seen: 64_600,
+        });
+        register_unit("walk-src", rx_a);
+        register_unit("meta-src", rx_b);
+        let out = render_lines();
+        let row_lines: Vec<&str> = out
+            .split('\n')
+            .filter(|s| !s.is_empty() && *s != SEPARATOR)
+            .collect();
+        assert_eq!(row_lines.len(), 2);
+        let char_offset = |row: &str, key: &str| -> Option<usize> {
+            let byte = row.find(key)?;
+            Some(row[..byte].chars().count())
+        };
+        for key in ["cwnd=", "base=", "ewma=", "ratio=", "samples="] {
+            let col_a = char_offset(row_lines[0], key);
+            let col_b = char_offset(row_lines[1], key);
+            assert_eq!(col_a, col_b, "{key} column misaligned: {row_lines:?}");
+            assert!(col_a.is_some(), "{key} missing from row: {row_lines:?}");
+        }
         clear();
     }
 }

--- a/common/src/walk.rs
+++ b/common/src/walk.rs
@@ -4,10 +4,11 @@
 //! per-type bits (dry-run label, skipped-counter increment) so callers don't
 //! re-implement the dispatch.
 //!
-//! [`next_entry_probed`] wraps `tokio::fs::ReadDir::next_entry` with the full
-//! per-entry throttle + congestion-probe prologue so copy/link/rm share a
-//! single source of truth for the "probe after permit, permit before
-//! children" invariant.
+//! [`next_entry_probed`] wraps `tokio::fs::ReadDir::next_entry` (plus the
+//! follow-up `file_type()` lookup) with the static ops rate gate so
+//! copy/link/rm share a single source of truth for walk iteration. The
+//! walk path is deliberately not congestion-probed — see the function's
+//! own docs for why.
 
 use crate::filter::{FilterResult, FilterSettings};
 use crate::progress::Progress;
@@ -99,69 +100,44 @@ fn meta_resource(side: congestion::Side) -> throttle::Resource {
     }
 }
 
-/// Resolve the [`throttle::Resource`] for directory iteration
-/// (`getdents` + cached `file_type`) on the given [`congestion::Side`].
-fn walk_resource(side: congestion::Side) -> throttle::Resource {
-    match side {
-        congestion::Side::Source => throttle::Resource::SrcWalk,
-        congestion::Side::Destination => throttle::Resource::DstWalk,
-    }
-}
-
-/// Pull the next directory entry with the full per-entry throttle + probe
-/// prologue applied:
+/// Pull the next directory entry, gated only by the static ops rate
+/// gate.
+///
+/// Walks are deliberately not probed: `tokio::fs::ReadDir::next_entry`
+/// returns buffered entries from a prior `getdents` batch without
+/// entering the kernel, so most "walk probes" don't measure filesystem
+/// service time at all. The resulting bimodal latency distribution
+/// (cache hit vs. real `getdents`) collapses any baseline a controller
+/// could derive from it. The fix is to probe only the per-file
+/// metadata syscalls that follow the walk, where each sample reflects
+/// real filesystem work.
+///
+/// The prologue is therefore just:
 ///
 /// 1. Await the static ops rate gate.
-/// 2. Acquire the dynamic ops-in-flight permit on the walk resource for
-///    the given [`congestion::Side`] (a no-op when that resource's cap is not
-///    configured).
-/// 3. Start a walk-class [`congestion::Probe`] tagged with the same side —
-///    *after* the permit is held, so self-inflicted queueing on the
-///    in-flight semaphore is not reported back to the controller as
-///    filesystem latency.
-/// 4. Call `next_entry()` and, on success, classify via `file_type()`.
-/// 5. Complete the probe on success; discard it on error or exhaustion —
-///    error paths must not skew the controller's latency baseline.
-/// 6. Release the permit before returning, so the caller can spawn / await
-///    children without holding it across task boundaries (which would
-///    deadlock at any tree depth greater than cwnd).
+/// 2. Call `next_entry()` and, on success, classify via `file_type()`.
 ///
-/// `side` is almost always [`congestion::Side::Source`] — directory walks
-/// are reads of the source filesystem. The exception is `cmp`'s
-/// destination walk in `expand_missing` mode, which iterates the dst
-/// tree and uses [`congestion::Side::Destination`].
+/// `side` is currently unused at runtime but kept on the signature so
+/// callers stay self-documenting and future per-side gating can be
+/// reintroduced without touching every call site.
 ///
 /// The error is left as `anyhow::Error` so each caller can wrap it in the
 /// site-specific error type (`copy::Error`, `link::Error`, `rm::Error`)
 /// without this helper needing to be generic over the summary payload.
 pub async fn next_entry_probed<F>(
     entries: &mut tokio::fs::ReadDir,
-    side: congestion::Side,
+    _side: congestion::Side,
     context: F,
 ) -> anyhow::Result<Option<(tokio::fs::DirEntry, Option<std::fs::FileType>)>>
 where
     F: FnOnce() -> String,
 {
     throttle::get_ops_token().await;
-    let ops_permit = throttle::ops_in_flight_permit(walk_resource(side)).await;
-    let probe = congestion::Probe::start_walk(side);
     let maybe_entry = entries.next_entry().await.with_context(context)?;
     let Some(entry) = maybe_entry else {
-        probe.discard();
-        drop(ops_permit);
         return Ok(None);
     };
-    let entry_file_type = match entry.file_type().await {
-        Ok(file_type) => {
-            probe.complete_ok(0);
-            Some(file_type)
-        }
-        Err(_) => {
-            probe.discard();
-            None
-        }
-    };
-    drop(ops_permit);
+    let entry_file_type = entry.file_type().await.ok();
     Ok(Some((entry, entry_file_type)))
 }
 

--- a/common/tests/probe_metadata.rs
+++ b/common/tests/probe_metadata.rs
@@ -1,4 +1,4 @@
-//! Integration test verifying that the tree-walk metadata probes wired into
+//! Integration test verifying that the per-syscall metadata probes wired into
 //! `common::rm`, `common::copy`, and `common::link` actually emit samples
 //! when a `SampleSink` is installed.
 //!
@@ -81,11 +81,6 @@ async fn rm_emits_one_metadata_sample_per_tree_entry() {
     congestion::clear_sample_sink();
     assert_eq!(result.directories_removed, 3);
     assert_eq!(result.files_removed, 3);
-    // Source-side walk: one probe per directory entry the walk discovered —
-    // a, b, 1.txt, 2.txt, 3.txt = 5 entries. (rm walks the source tree to
-    // find what to delete; from the controller's standpoint that's a
-    // source-side walk even though the actual delete syscalls hit dst.)
-    assert_eq!(sink.walk_count_for(congestion::Side::Source), 5);
     // Source-side metadata: 1 stat for the top-level path before walking.
     assert!(sink.metadata_count_for(congestion::Side::Source) >= 1);
     // Destination-side metadata: one probe per mutation — 3 remove_file
@@ -93,11 +88,7 @@ async fn rm_emits_one_metadata_sample_per_tree_entry() {
     assert_eq!(sink.metadata_count_for(congestion::Side::Destination), 6);
     // every sample should have a non-zero latency; an all-zero result would
     // mean the probe is bracketing something that isn't a syscall.
-    for s in sink
-        .walk_samples()
-        .iter()
-        .chain(sink.metadata_samples().iter())
-    {
+    for s in sink.metadata_samples().iter() {
         assert!(
             s.latency() > std::time::Duration::ZERO,
             "sample latency must be non-zero: {:?}",
@@ -125,111 +116,50 @@ async fn copy_emits_one_metadata_sample_per_tree_entry() {
     .await
     .expect("copy succeeds");
     congestion::clear_sample_sink();
-    // Source-side walk: one probe per src entry — 5 entries.
-    assert_eq!(sink.walk_count_for(congestion::Side::Source), 5);
-    // Destination-side metadata: at least the 3 create_dir probes for
-    // root + a + b. With preserve_all() each of the 3 dirs and 3 files
-    // also incurs preserve probes (chown + chmod + utimens, plus an
-    // open for files), so we just sanity-check non-zero. Specifically
-    // brittle counts for preserve probes are exercised in the
-    // controller-level tests, not here.
-    assert!(
-        sink.metadata_count_for(congestion::Side::Destination) >= 3,
-        "expected at least 3 dst metadata probes (create_dir × 3), got {}",
-        sink.metadata_count_for(congestion::Side::Destination)
+    // Source-side metadata: one symlink_metadata per copy_internal call —
+    // 6 entries (root + a + b + 3 .txt files) = 6 src probes.
+    assert_eq!(
+        sink.metadata_count_for(congestion::Side::Source),
+        6,
+        "expected 6 src metadata probes (one symlink_metadata per entry)",
     );
-}
-
-/// Regression test for a deadlock that occurs when the ops-in-flight
-/// permit is held across a spawned task's `join_set.join_next()` await.
-///
-/// With cwnd=1 and any tree depth >= 2, the parent task would hold the
-/// only permit while waiting for children; children would block forever
-/// trying to acquire. The fix is to scope the permit tightly around the
-/// actual syscalls in the tree-walk loop so it is released before the
-/// join — which this test pins down.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn rm_on_deep_tree_does_not_deadlock_at_cwnd_one() {
-    let _guard = SINK_GUARD.lock().await;
-    // install the full auto-meta pipeline with cwnd == 1 so any
-    // held-across-join semantics would trigger immediately. The walk
-    // helpers used by `rm` route through SrcWalk, so that's the
-    // resource we cap.
-    let mut builder = congestion::RoutingSinkBuilder::new();
-    let walk_rx = builder.walk_receiver(congestion::Side::Source);
-    congestion::install_sample_sink(std::sync::Arc::new(builder.build()));
-    throttle::set_max_ops_in_flight(throttle::Resource::SrcWalk, 1);
-    let vegas = congestion::VegasController::new(congestion::VegasConfig {
-        initial_cwnd: 1,
-        min_cwnd: 1,
-        max_cwnd: 1,
-        ..congestion::VegasConfig::default()
-    });
-    let (unit, _decision_rx, _snapshot_rx) = congestion::ControlUnit::new(
-        "test-walk-src",
-        vegas,
-        walk_rx,
-        std::time::Duration::from_millis(50),
+    // Destination-side metadata for the 6 entries:
+    //   - 3 dirs:  1 create_dir + 3 preserve (chown + chmod + utimens) = 4 each
+    //   - 3 files: 4 preserve (chown + open + chmod + utimens)         = 4 each
+    // tokio::fs::copy itself is unprobed (data-path), so 6 × 4 = 24 dst.
+    assert_eq!(
+        sink.metadata_count_for(congestion::Side::Destination),
+        24,
+        "expected 24 dst metadata probes (4 per entry × 6 entries)",
     );
-    let ctrl_handle = unit.spawn();
-    let tmp = make_tempdir("deadlock").await;
-    let root = tmp.join("deep");
-    // 5-deep chain: deep/d1/d2/d3/d4/leaf.txt
-    let mut path = root.clone();
-    for _ in 0..5 {
-        path.push("d");
-        tokio::fs::create_dir_all(&path).await.expect("mkdir");
-    }
-    tokio::fs::write(path.join("leaf.txt"), b"x")
-        .await
-        .expect("leaf file");
-    // 5-second watchdog: pre-fix this call hangs forever at cwnd=1.
-    let rm_fut = rm::rm(
-        &PROGRESS,
-        &root,
-        &rm::Settings {
-            fail_early: false,
-            filter: None,
-            dry_run: None,
-            time_filter: None,
-        },
-    );
-    let result = tokio::time::timeout(std::time::Duration::from_secs(5), rm_fut)
-        .await
-        .expect("rm completed within 5s — deadlock detected if timeout fired")
-        .expect("rm succeeded");
-    congestion::clear_sample_sink();
-    throttle::set_max_ops_in_flight(throttle::Resource::SrcWalk, 0);
-    ctrl_handle.abort();
-    assert_eq!(result.directories_removed, 6);
-    assert_eq!(result.files_removed, 1);
 }
 
 /// End-to-end integration test for the auto-meta-throttle pipeline:
 /// Probe -> RoutingSink -> ControlUnit<VegasController> -> Decision watch.
 ///
 /// Doesn't drive throttle::set_max_ops_in_flight (that's validated in the
-/// congestion unit tests). Asserts only that the full pipeline flows:
-/// running a real rm over a tree moves the controller's cwnd away from the
-/// initial UNLIMITED watch value, proving every layer is wired correctly.
+/// congestion unit tests). Asserts that the full pipeline flows: running
+/// a real rm over a tree results in the controller actually consuming
+/// metadata samples (visible via the snapshot's `samples_seen` counter).
 #[tokio::test]
 async fn auto_meta_pipeline_propagates_probes_to_controller() {
     let _guard = SINK_GUARD.lock().await;
-    // Tap the walk-source channel: rm walks the src tree, so its
-    // probes land there. (The pipeline being exercised is the same
-    // regardless of which channel we tap; pick the one with the
-    // most samples to keep this assertion robust.)
+    // Tap the metadata-destination channel: rm's per-file unlinks and
+    // dir removals all hit the destination side, so its probes land
+    // there. (The pipeline being exercised is the same regardless of
+    // which channel we tap; pick the one with the most samples to keep
+    // this assertion robust.)
     let mut builder = congestion::RoutingSinkBuilder::new();
-    let walk_rx = builder.walk_receiver(congestion::Side::Source);
+    let metadata_rx = builder.metadata_receiver(congestion::Side::Destination);
     congestion::install_sample_sink(std::sync::Arc::new(builder.build()));
     let controller = congestion::VegasController::new(congestion::VegasConfig {
         initial_cwnd: 5,
         ..congestion::VegasConfig::default()
     });
-    let (unit, decision_rx, _snapshot_rx) = congestion::ControlUnit::new(
+    let (unit, decision_rx, mut snapshot_rx) = congestion::ControlUnit::new(
         "pipeline-test",
         controller,
-        walk_rx,
+        metadata_rx,
         std::time::Duration::from_millis(20),
     );
     let handle = unit.spawn();
@@ -241,7 +171,11 @@ async fn auto_meta_pipeline_propagates_probes_to_controller() {
         Some(5),
         "ControlUnit must publish the initial cwnd on startup",
     );
-    // walk a tree; probes fire on each entry and flow through the sink
+    // baseline the snapshot sample count; the assertion below only
+    // counts samples observed AFTER this point.
+    let samples_before = snapshot_rx.borrow_and_update().samples_seen;
+    // walk a tree; probes fire on each metadata syscall and flow through the sink.
+    // small_tree under root yields 6 dst probes (3 remove_file + 3 remove_dir).
     let tmp = make_tempdir("pipeline").await;
     let root = tmp.join("tree");
     make_small_tree(&root).await.expect("create tree");
@@ -259,50 +193,26 @@ async fn auto_meta_pipeline_propagates_probes_to_controller() {
     .expect("rm succeeds");
     // give the ControlUnit time to consume samples across a few ticks
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-    // first sample-bearing tick is the bootstrap (baseline establishment);
-    // by 100ms / 20ms = 5 ticks, a well-behaved controller has had ample
-    // opportunity to adjust cwnd in response to real samples.
+    let final_snapshot = *snapshot_rx.borrow();
     let final_decision = *decision_rx.borrow();
     congestion::clear_sample_sink();
     handle.abort();
+    // The controller must have ingested the samples that flowed through
+    // the routing sink. With the small_tree fixture, rm produces 6 dst
+    // probes (3 remove_file + 3 remove_dir); samples_seen is monotonic
+    // and any positive delta proves probes -> sink -> control unit ->
+    // controller all wired correctly.
+    let samples_after = final_snapshot.samples_seen;
+    assert!(
+        samples_after > samples_before,
+        "controller must consume samples — saw {} before rm and {} after",
+        samples_before,
+        samples_after,
+    );
     assert!(
         final_decision.max_in_flight.is_some(),
         "pipeline must keep publishing concrete decisions",
     );
-}
-
-#[tokio::test]
-async fn cmp_emits_one_metadata_sample_per_tree_entry() {
-    // cmp walks both the src AND the dst directories. With src and dst
-    // controllers split, each side gets exactly its own walk's probes —
-    // 5 entries each on identical 5-entry trees.
-    let _guard = SINK_GUARD.lock().await;
-    let sink = install_sink();
-    let tmp = make_tempdir("cmp_samples").await;
-    let src = tmp.join("src");
-    let dst = tmp.join("dst");
-    make_small_tree(&src).await.expect("create src tree");
-    make_small_tree(&dst).await.expect("create dst tree");
-    let log = common::cmp::LogWriter::silent().await.expect("silent log");
-    common::cmp::cmp(
-        &PROGRESS,
-        &src,
-        &dst,
-        &log,
-        &common::cmp::Settings {
-            fail_early: false,
-            exit_early: false,
-            expand_missing: false,
-            compare: Default::default(),
-            filter: None,
-        },
-    )
-    .await
-    .expect("cmp succeeds");
-    congestion::clear_sample_sink();
-    // cmp walks both src and dst, so each side gets 5 walk probes.
-    assert_eq!(sink.walk_count_for(congestion::Side::Source), 5);
-    assert_eq!(sink.walk_count_for(congestion::Side::Destination), 5);
 }
 
 #[tokio::test]
@@ -326,24 +236,23 @@ async fn filegen_emits_metadata_samples_for_created_dirs_and_files() {
         .expect("filegen succeeds");
     congestion::clear_sample_sink();
     // filegen probes only the destination-side mutations (mkdir + open)
-    // — there's no source tree to walk. At least 8: 2 create_dir + 6
-    // file opens. There's no walk-src activity at all.
+    // — there's no source tree. At least 8: 2 create_dir + 6 file opens.
     assert!(
         sink.metadata_count_for(congestion::Side::Destination) >= 8,
         "expected at least 8 dst metadata probes, got {}",
         sink.metadata_count_for(congestion::Side::Destination)
     );
-    assert_eq!(sink.walk_count(), 0);
 }
 
 #[tokio::test]
 async fn link_update_path_emits_probes_for_update_tree() {
-    // Regression: the update walk (for entries present in `update/` but
-    // not in `src/`) was iterating with a raw next_entry() and bypassed
-    // both probing and cwnd gating. This test pins down that it now
-    // probes. With src holding the small-tree (5 probes on src walk)
-    // and update holding 3 unique top-level files, we expect 5 src
-    // probes + 3 update probes = 8 total.
+    // Pins the per-file metadata probes that fire when `link` processes
+    // entries present in `update/` but not in `src/`. These end up on
+    // the spawned `copy::copy` calls inside the update-walk segment of
+    // `link_internal`; if that segment regressed and stopped invoking
+    // copy (or invoked it without probes), the dst count would drop by
+    // the 4 preserve probes per update file (× 3 = 12) and the src
+    // count would drop by the per-file `symlink_metadata` (× 3 = 3).
     let _guard = SINK_GUARD.lock().await;
     let sink = install_sink();
     let tmp = make_tempdir("link_update_samples").await;
@@ -380,17 +289,25 @@ async fn link_update_path_emits_probes_for_update_tree() {
     .await
     .expect("link succeeds");
     congestion::clear_sample_sink();
-    // src walk: 5 entries (small-tree) + 3 update files = 8 walk probes.
-    assert_eq!(sink.walk_count_for(congestion::Side::Source), 8);
-    // dst metadata probes: at least 6 — 3 create_dir (root, a, b) +
-    // 3 hard_link (the small-tree .txt files). With preserve_all()
-    // each of the 6 entries also incurs additional preserve probes
-    // (chown + chmod + utimens, and File::open for files), so we
-    // assert a lower bound rather than an exact count.
-    assert!(
-        sink.metadata_count_for(congestion::Side::Destination) >= 6,
-        "expected at least 6 dst metadata probes, got {}",
-        sink.metadata_count_for(congestion::Side::Destination)
+    // Source-side: 6 link_internal symlink_metadata(src) calls (root + a +
+    // b + 3 .txt) + 1 top-level symlink_metadata(update) (succeeds, dirs
+    // only at top level — recursive update lookups for src/{a,b,*.txt}
+    // are NotFound, so their probes are discarded) + 3 copy_internal
+    // symlink_metadata calls (one per u*.txt under update) = 10.
+    assert_eq!(
+        sink.metadata_count_for(congestion::Side::Source),
+        10,
+        "expected 10 src metadata probes — drops to 7 if the update-walk \
+         path stops spawning copies for u*.txt",
+    );
+    // Destination-side: 15 from the small-tree link (see
+    // link_emits_one_metadata_sample_per_tree_entry) + 12 for the 3
+    // update-only files (4 preserve probes per file via copy_file) = 27.
+    assert_eq!(
+        sink.metadata_count_for(congestion::Side::Destination),
+        27,
+        "expected 27 dst metadata probes — drops to 15 if the update-walk \
+         path stops spawning copies for u*.txt",
     );
 }
 
@@ -421,14 +338,20 @@ async fn link_emits_one_metadata_sample_per_tree_entry() {
     .await
     .expect("link succeeds");
     congestion::clear_sample_sink();
-    // Source-side: 5 walk probes for the small-tree.
-    assert_eq!(sink.walk_count_for(congestion::Side::Source), 5);
-    // Destination-side metadata: at least 6 — 3 hard_link + 3
-    // create_dir. preserve_all() pulls in additional probes per
-    // entry, so we just assert a lower bound here.
-    assert!(
-        sink.metadata_count_for(congestion::Side::Destination) >= 6,
-        "expected at least 6 dst metadata probes, got {}",
-        sink.metadata_count_for(congestion::Side::Destination)
+    // Source-side metadata: one symlink_metadata per link_internal call —
+    // 6 entries (root + a + b + 3 .txt files) = 6 src probes.
+    assert_eq!(
+        sink.metadata_count_for(congestion::Side::Source),
+        6,
+        "expected 6 src metadata probes (one symlink_metadata per entry)",
+    );
+    // Destination-side metadata for the 6 entries:
+    //   - 3 dirs:  1 create_dir + 3 preserve (chown + chmod + utimens) = 4 each
+    //   - 3 files: 1 hard_link (no preserve in hard_link_helper)       = 1 each
+    // Total: 12 + 3 = 15 dst.
+    assert_eq!(
+        sink.metadata_count_for(congestion::Side::Destination),
+        15,
+        "expected 15 dst metadata probes (4 per dir × 3 + 1 per file × 3)",
     );
 }

--- a/common/tests/probe_metadata.rs
+++ b/common/tests/probe_metadata.rs
@@ -245,6 +245,52 @@ async fn filegen_emits_metadata_samples_for_created_dirs_and_files() {
 }
 
 #[tokio::test]
+async fn cmp_emits_metadata_samples_per_tree_entry() {
+    // cmp walks src and dst in parallel and stats every entry on each
+    // side. With identical small_tree fixtures (5 non-root entries)
+    // and the root included, cmp_internal recurses 6 times — each
+    // recursion does one src and one dst symlink_metadata. The walks
+    // themselves are unprobed (Resource::Walk was removed), so the
+    // signal comes purely from those symlink_metadata calls.
+    let _guard = SINK_GUARD.lock().await;
+    let sink = install_sink();
+    let tmp = make_tempdir("cmp_samples").await;
+    let src = tmp.join("src");
+    let dst = tmp.join("dst");
+    make_small_tree(&src).await.expect("create src tree");
+    make_small_tree(&dst).await.expect("create dst tree");
+    let log = common::cmp::LogWriter::silent().await.expect("silent log");
+    common::cmp::cmp(
+        &PROGRESS,
+        &src,
+        &dst,
+        &log,
+        &common::cmp::Settings {
+            fail_early: false,
+            exit_early: false,
+            expand_missing: false,
+            compare: Default::default(),
+            filter: None,
+        },
+    )
+    .await
+    .expect("cmp succeeds");
+    congestion::clear_sample_sink();
+    // 6 entries × 1 src symlink_metadata each = 6 src probes.
+    assert_eq!(
+        sink.metadata_count_for(congestion::Side::Source),
+        6,
+        "expected 6 src metadata probes (one symlink_metadata per entry)",
+    );
+    // 6 entries × 1 dst symlink_metadata each = 6 dst probes.
+    assert_eq!(
+        sink.metadata_count_for(congestion::Side::Destination),
+        6,
+        "expected 6 dst metadata probes (one symlink_metadata per entry)",
+    );
+}
+
+#[tokio::test]
 async fn link_update_path_emits_probes_for_update_tree() {
     // Pins the per-file metadata probes that fire when `link` processes
     // entries present in `update/` but not in `src/`. These end up on

--- a/congestion/src/control_loop.rs
+++ b/congestion/src/control_loop.rs
@@ -84,7 +84,7 @@ impl<C: Controller + 'static> ControlUnit<C> {
     ///
     /// `label` is a short, stable string that identifies this unit in
     /// log events and in the snapshot registry (e.g. `"meta-src"`,
-    /// `"walk-dst"`). Multiple units of the same controller type are
+    /// `"meta-dst"`). Multiple units of the same controller type are
     /// typical, so using only the controller name would make logs
     /// ambiguous.
     pub fn new(
@@ -204,8 +204,6 @@ impl<C: Controller + 'static> ControlUnit<C> {
 /// dropped rather than blocking or allocating; the drop count is exposed
 /// by [`RoutingSink::dropped_samples`].
 pub struct RoutingSink {
-    walk_src: Option<tokio::sync::mpsc::Sender<Sample>>,
-    walk_dst: Option<tokio::sync::mpsc::Sender<Sample>>,
     metadata_src: Option<tokio::sync::mpsc::Sender<Sample>>,
     metadata_dst: Option<tokio::sync::mpsc::Sender<Sample>>,
     read: Option<tokio::sync::mpsc::Sender<Sample>>,
@@ -224,8 +222,6 @@ impl RoutingSink {
 impl SampleSink for RoutingSink {
     fn record(&self, kind: ResourceKind, sample: &Sample) {
         let tx = match kind {
-            ResourceKind::Walk(Side::Source) => self.walk_src.as_ref(),
-            ResourceKind::Walk(Side::Destination) => self.walk_dst.as_ref(),
             ResourceKind::Metadata(Side::Source) => self.metadata_src.as_ref(),
             ResourceKind::Metadata(Side::Destination) => self.metadata_dst.as_ref(),
             ResourceKind::DataRead => self.read.as_ref(),
@@ -250,8 +246,6 @@ impl SampleSink for RoutingSink {
 /// call registers a channel for the corresponding [`ResourceKind`] and
 /// returns the receiver the caller must hand to a [`ControlUnit`].
 pub struct RoutingSinkBuilder {
-    walk_src: Option<tokio::sync::mpsc::Sender<Sample>>,
-    walk_dst: Option<tokio::sync::mpsc::Sender<Sample>>,
     metadata_src: Option<tokio::sync::mpsc::Sender<Sample>>,
     metadata_dst: Option<tokio::sync::mpsc::Sender<Sample>>,
     read: Option<tokio::sync::mpsc::Sender<Sample>>,
@@ -263,8 +257,6 @@ pub struct RoutingSinkBuilder {
 impl Default for RoutingSinkBuilder {
     fn default() -> Self {
         Self {
-            walk_src: None,
-            walk_dst: None,
             metadata_src: None,
             metadata_dst: None,
             read: None,
@@ -283,19 +275,6 @@ impl RoutingSinkBuilder {
     pub fn with_capacity(mut self, capacity: usize) -> Self {
         self.capacity = capacity.max(1);
         self
-    }
-    /// Register a channel for walk-class samples on the given [`Side`]
-    /// and return its receiver. The walk class is for directory
-    /// iteration (`getdents` + cached `file_type`) — kept separate
-    /// from per-file metadata syscalls because the latency regimes
-    /// differ.
-    pub fn walk_receiver(&mut self, side: Side) -> tokio::sync::mpsc::Receiver<Sample> {
-        let (tx, rx) = tokio::sync::mpsc::channel(self.capacity);
-        match side {
-            Side::Source => self.walk_src = Some(tx),
-            Side::Destination => self.walk_dst = Some(tx),
-        }
-        rx
     }
     /// Register a channel for per-file metadata samples on the given
     /// [`Side`] and return its receiver. Covers single metadata
@@ -323,8 +302,6 @@ impl RoutingSinkBuilder {
     }
     pub fn build(self) -> RoutingSink {
         RoutingSink {
-            walk_src: self.walk_src,
-            walk_dst: self.walk_dst,
             metadata_src: self.metadata_src,
             metadata_dst: self.metadata_dst,
             read: self.read,

--- a/congestion/src/controller.rs
+++ b/congestion/src/controller.rs
@@ -101,8 +101,10 @@ pub struct ControllerSnapshot {
     /// Current concurrency window the controller would emit on its
     /// next tick. `0` means "no cap configured."
     pub cwnd: u32,
-    /// Lowest latency observed, the controller's uncongested baseline.
-    /// `Duration::ZERO` if no signal yet.
+    /// Uncongested baseline latency (p10 of the recent sample window).
+    /// Retains the historical `min_latency` field name for backwards
+    /// compatibility with renderers; the value is no longer a strict
+    /// minimum. `Duration::ZERO` if no signal yet.
     pub min_latency: std::time::Duration,
     /// EWMA-smoothed observed latency. `Duration::ZERO` if no
     /// sample-bearing tick has fired yet.

--- a/congestion/src/measurement.rs
+++ b/congestion/src/measurement.rs
@@ -32,24 +32,12 @@ pub enum Side {
 /// Which resource a probe is measuring.
 ///
 /// Separate kinds feed independent controllers in the control loop.
-/// Metadata kinds are split along two axes so each controller's samples
-/// stay within a single latency regime:
-///
-/// - **Walk** vs **Metadata**: directory iteration (`getdents` + cached
-///   `file_type`) is mostly cache-warm and faster than real per-file
-///   metadata syscalls. Mixing them on one controller would let cache
-///   hits pull `min_latency` to a few microseconds, making every real
-///   stat look "slow" and pinning `cwnd` at the floor.
-/// - **Source** vs **Destination** ([`Side`]): different filesystems
-///   typically have different service-time profiles; one cap per side
-///   prevents a saturated source from dragging down the destination's
-///   `cwnd` and vice versa.
+/// Metadata kinds are split by [`Side`]: different filesystems typically
+/// have different service-time profiles, so one cap per side prevents a
+/// saturated source from dragging down the destination's `cwnd` and vice
+/// versa.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ResourceKind {
-    /// Directory iteration: `next_entry` (getdents-batched) plus the
-    /// cached `file_type` lookup that follows it. Mostly served from
-    /// the dirent cache.
-    Walk(Side),
     /// Single per-file metadata syscall: `stat`, `symlink_metadata`,
     /// `mkdir`, `unlink`, `hard_link`, `symlink`, `chmod`,
     /// `open(O_CREAT)`, `read_link`, etc. Real round-trip work each
@@ -131,12 +119,6 @@ impl Probe {
             kind,
             started_at: std::time::Instant::now(),
         }
-    }
-    /// Shorthand for `Probe::start(ResourceKind::Walk(side))`. Use this
-    /// to bracket directory iteration work (`next_entry` + cached
-    /// `file_type`).
-    pub fn start_walk(side: Side) -> Self {
-        Self::start(ResourceKind::Walk(side))
     }
     /// Shorthand for `Probe::start(ResourceKind::Metadata(side))`. Use
     /// this to bracket a single per-file metadata syscall (lookup or

--- a/congestion/src/testing.rs
+++ b/congestion/src/testing.rs
@@ -18,8 +18,6 @@ pub struct CollectingSink {
 
 #[derive(Default)]
 struct CollectingInner {
-    walk_src: Vec<Sample>,
-    walk_dst: Vec<Sample>,
     metadata_src: Vec<Sample>,
     metadata_dst: Vec<Sample>,
     read: Vec<Sample>,
@@ -29,19 +27,6 @@ struct CollectingInner {
 impl CollectingSink {
     pub fn new() -> Self {
         Self::default()
-    }
-    /// Total number of walk samples recorded across both sides.
-    pub fn walk_count(&self) -> usize {
-        let inner = self.inner.lock().expect("collecting sink mutex poisoned");
-        inner.walk_src.len() + inner.walk_dst.len()
-    }
-    /// Number of walk samples recorded for the given [`Side`].
-    pub fn walk_count_for(&self, side: Side) -> usize {
-        let inner = self.inner.lock().expect("collecting sink mutex poisoned");
-        match side {
-            Side::Source => inner.walk_src.len(),
-            Side::Destination => inner.walk_dst.len(),
-        }
     }
     /// Total number of metadata samples recorded across both sides.
     pub fn metadata_count(&self) -> usize {
@@ -71,21 +56,6 @@ impl CollectingSink {
             .expect("collecting sink mutex poisoned")
             .write
             .len()
-    }
-    /// Snapshot of all walk samples recorded so far, both sides combined.
-    pub fn walk_samples(&self) -> Vec<Sample> {
-        let inner = self.inner.lock().expect("collecting sink mutex poisoned");
-        let mut out = inner.walk_src.clone();
-        out.extend(inner.walk_dst.iter().copied());
-        out
-    }
-    /// Snapshot of all walk samples recorded so far for the given [`Side`].
-    pub fn walk_samples_for(&self, side: Side) -> Vec<Sample> {
-        let inner = self.inner.lock().expect("collecting sink mutex poisoned");
-        match side {
-            Side::Source => inner.walk_src.clone(),
-            Side::Destination => inner.walk_dst.clone(),
-        }
     }
     /// Snapshot of all metadata samples recorded so far, both sides combined.
     pub fn metadata_samples(&self) -> Vec<Sample> {
@@ -121,8 +91,6 @@ impl CollectingSink {
     /// Forget everything recorded so far. Useful between test phases.
     pub fn reset(&self) {
         let mut inner = self.inner.lock().expect("collecting sink mutex poisoned");
-        inner.walk_src.clear();
-        inner.walk_dst.clear();
         inner.metadata_src.clear();
         inner.metadata_dst.clear();
         inner.read.clear();
@@ -134,8 +102,6 @@ impl SampleSink for CollectingSink {
     fn record(&self, kind: ResourceKind, sample: &Sample) {
         let mut inner = self.inner.lock().expect("collecting sink mutex poisoned");
         match kind {
-            ResourceKind::Walk(Side::Source) => inner.walk_src.push(*sample),
-            ResourceKind::Walk(Side::Destination) => inner.walk_dst.push(*sample),
             ResourceKind::Metadata(Side::Source) => inner.metadata_src.push(*sample),
             ResourceKind::Metadata(Side::Destination) => inner.metadata_dst.push(*sample),
             ResourceKind::DataRead => inner.read.push(*sample),

--- a/congestion/src/vegas.rs
+++ b/congestion/src/vegas.rs
@@ -1,13 +1,26 @@
 //! Vegas-style latency-based adaptive controller.
 //!
-//! Maintains a running minimum latency (`min_latency`) as the uncongested
-//! baseline and an EWMA-smoothed recent latency (`ewma_latency`) as the
-//! current estimate. On every tick, the ratio `ewma_latency / min_latency` is
-//! compared to the configured thresholds:
+//! Maintains a windowed p10-percentile of recent operation latencies as the
+//! uncongested baseline and an EWMA-smoothed recent latency (`ewma_latency`)
+//! as the current estimate. On every tick, the ratio
+//! `ewma_latency / baseline` is compared to the configured thresholds:
 //!
 //! - `ratio < alpha` → the queue is shallow; grow concurrency.
 //! - `ratio > beta`  → the queue is building; shrink concurrency.
 //! - otherwise       → hold.
+//!
+//! ## Why p10 over a sliding window
+//!
+//! Real metadata syscalls on networked filesystems (Weka, Lustre, NFS) have
+//! natural per-op latency variance much wider than 50% — even with a fixed
+//! `cwnd` and a steady offered load, individual stat/open latencies routinely
+//! span an order of magnitude. A strict running minimum would latch onto a
+//! single fast outlier and treat ordinary variance as queueing, ratcheting
+//! `cwnd` down indefinitely. The p10 of the recent sample window is robust
+//! to a single fast outlier (the floor moves only when ten percent of recent
+//! samples beat it), naturally weighted toward recent samples (older entries
+//! age out of the window), and gracefully accommodates the natural latency
+//! variance of real filesystems.
 //!
 //! This is simpler than classic TCP Vegas (which compares expected vs. actual
 //! rates), but carries the same signal. It is a starting point for adaptive
@@ -15,6 +28,12 @@
 //! be layered on top in their own `impl Controller`s.
 
 use crate::controller::{Controller, ControllerSnapshot, Decision, Sample};
+
+/// Maximum number of samples retained in the sliding window used to
+/// compute the p10 baseline. Older samples are evicted FIFO once this
+/// cap is reached, bounding memory under sustained high sample rates
+/// while still leaving plenty of resolution for the percentile.
+const SAMPLE_WINDOW_CAP: usize = 4096;
 
 /// Tunable parameters for [`VegasController`].
 ///
@@ -29,9 +48,22 @@ pub struct VegasConfig {
     pub min_cwnd: u32,
     /// Ceiling on concurrency. Caps adaptive growth.
     pub max_cwnd: u32,
-    /// If `ewma_latency / min_latency < alpha`, cwnd is increased.
+    /// If `ewma_latency / baseline < alpha`, cwnd is increased.
+    ///
+    /// Defaulted at `1.3` to leave breathing room for the natural latency
+    /// variance of real filesystems: ordinary per-op jitter can briefly
+    /// push the EWMA above the p10 baseline without indicating queueing,
+    /// and a tighter alpha would misread that variance as lack of
+    /// headroom — `ratio < alpha` is rarely satisfied, so `cwnd` stalls
+    /// at the floor even when the filesystem has plenty of capacity.
     pub alpha: f64,
-    /// If `ewma_latency / min_latency > beta`, cwnd is decreased.
+    /// If `ewma_latency / baseline > beta`, cwnd is decreased.
+    ///
+    /// Defaulted at `2.5` for the same natural-variance reason as `alpha`:
+    /// real-world metadata syscalls routinely show ratios in the 1.5–2.0×
+    /// band even at modest concurrency without the filesystem actually
+    /// being congested, and a tighter beta would misread that variance as
+    /// queueing and ratchet `cwnd` toward the floor.
     pub beta: f64,
     /// EWMA smoothing factor in `[0.0, 1.0]`. Higher = more responsive.
     pub ewma_alpha: f64,
@@ -39,10 +71,12 @@ pub struct VegasConfig {
     pub increase_step: u32,
     /// How much to shrink cwnd on each over-shoot tick.
     pub decrease_step: u32,
-    /// Maximum age of the minimum-latency estimate before it is discarded
-    /// and re-established from incoming samples. Prevents a single stale
-    /// low-latency outlier from pinning the baseline and causing Vegas to
-    /// progressively over-throttle.
+    /// Maximum age of samples retained in the baseline window. Each tick,
+    /// samples older than this are evicted; if the eviction empties the
+    /// window, the EWMA is reset alongside it so the next tick re-runs
+    /// the cold-start path. Prevents stale samples from anchoring the
+    /// baseline against a workload that has changed shape since they
+    /// were collected.
     pub min_latency_max_age: std::time::Duration,
 }
 
@@ -52,8 +86,8 @@ impl Default for VegasConfig {
             initial_cwnd: 1,
             min_cwnd: 1,
             max_cwnd: 4096,
-            alpha: 1.1,
-            beta: 1.5,
+            alpha: 1.3,
+            beta: 2.5,
             ewma_alpha: 0.3,
             increase_step: 1,
             decrease_step: 1,
@@ -64,14 +98,25 @@ impl Default for VegasConfig {
 
 /// Adaptive controller driven by latency inflation relative to the
 /// uncongested baseline.
+///
+/// The baseline is the p10-percentile of recent samples held in a
+/// sliding window — robust to a single fast outlier, naturally weighted
+/// toward recent samples (older entries age out of the window), and
+/// gracefully accommodating the natural latency variance of real
+/// filesystems.
 pub struct VegasController {
     config: VegasConfig,
     cwnd: u32,
-    /// The minimum latency observed, plus the `Instant` at which it was
-    /// last lowered. The `Instant` lets us discard stale baselines so a
-    /// single outlier sample cannot pin cwnd at the floor.
-    min_latency: Option<(u64, std::time::Instant)>,
+    /// Sliding window of recent samples, used to compute the p10
+    /// baseline each tick. Capped at [`SAMPLE_WINDOW_CAP`] entries:
+    /// when full, oldest is evicted FIFO on push. Each entry is
+    /// `(latency_ns, observed_at)`; the timestamp drives age-out so a
+    /// stale window can be discarded after `min_latency_max_age`.
+    samples: std::collections::VecDeque<(u64, std::time::Instant)>,
     ewma_latency_ns: Option<f64>,
+    /// p10 baseline (in ns) recomputed each tick from `samples`.
+    /// `None` if the window is empty.
+    baseline_latency_ns: Option<u64>,
     tick_sum_latency_ns: u128,
     tick_sample_count: u64,
     /// Cumulative number of samples consumed across the controller's
@@ -89,8 +134,9 @@ impl VegasController {
         Self {
             config,
             cwnd,
-            min_latency: None,
+            samples: std::collections::VecDeque::with_capacity(SAMPLE_WINDOW_CAP),
             ewma_latency_ns: None,
+            baseline_latency_ns: None,
             tick_sum_latency_ns: 0,
             tick_sample_count: 0,
             total_samples: 0,
@@ -100,11 +146,11 @@ impl VegasController {
     pub fn cwnd(&self) -> u32 {
         self.cwnd
     }
-    /// Running minimum latency, or `None` if no samples have been observed
-    /// or the previously-observed minimum has aged out.
+    /// p10-percentile baseline latency over the recent sample window,
+    /// or `None` if the window is empty.
     pub fn min_latency(&self) -> Option<std::time::Duration> {
-        self.min_latency
-            .map(|(ns, _)| std::time::Duration::from_nanos(ns))
+        self.baseline_latency_ns
+            .map(std::time::Duration::from_nanos)
     }
     /// EWMA latency estimate over recent ticks, or `None` if no
     /// sample-bearing tick has fired yet.
@@ -119,22 +165,20 @@ impl Controller for VegasController {
         // u64 nanos fit any realistic latency; saturate defensively.
         // Clamp to >= 1 so a 0-duration sample (possible when `Instant::now()`
         // resolution coarsely groups back-to-back probes) never lands as
-        // `min_latency = 0` — that would make the ratio below divide by
-        // zero and collapse cwnd to the floor.
+        // `baseline = 0` — that would make the ratio below divide by zero
+        // and collapse cwnd to the floor.
         let latency_ns = u64::try_from(sample.latency().as_nanos())
             .unwrap_or(u64::MAX)
             .max(1);
-        // Refresh `observed_at` whenever a sample is at or below the
-        // recorded minimum so repeated confirmation of a stable
-        // baseline keeps it alive. If latency equals current, the min
-        // value is unchanged but the age timer resets — otherwise a
-        // workload that sits exactly at the true min would see the
-        // baseline expire on `min_latency_max_age` even though it's
-        // continuously confirming the same floor.
-        self.min_latency = Some(match self.min_latency {
-            Some((current, at)) if latency_ns > current => (current, at),
-            _ => (latency_ns, sample.completed_at),
-        });
+        // bound memory under sustained high sample rates. Pop *before*
+        // push when at the cap: `VecDeque::push_back` reallocates if at
+        // capacity, and `VecDeque` never shrinks its underlying buffer,
+        // so a post-push pop would leave the allocation grown past the
+        // cap even though `len` is brought back down immediately.
+        if self.samples.len() >= SAMPLE_WINDOW_CAP {
+            self.samples.pop_front();
+        }
+        self.samples.push_back((latency_ns, sample.completed_at));
         self.tick_sum_latency_ns = self
             .tick_sum_latency_ns
             .saturating_add(u128::from(latency_ns));
@@ -142,27 +186,46 @@ impl Controller for VegasController {
         self.total_samples = self.total_samples.saturating_add(1);
     }
     fn on_tick(&mut self, now: std::time::Instant) -> Decision {
-        // discard a stale min estimate so the next sample can re-establish
-        // the baseline; prevents an outlier from pinning cwnd at the floor.
-        // The EWMA must be reset alongside it: an EWMA frozen during a
+        // discard samples older than the window's max age. The EWMA must
+        // be reset alongside an empty window: an EWMA frozen during a
         // congested period carries forward a "current latency" that is
         // not comparable to the new baseline the next samples will draw,
         // and would otherwise produce a spurious growth burst on the
-        // first tick after expiry under sustained congestion.
-        if let Some((_, observed_at)) = self.min_latency
-            && now.saturating_duration_since(observed_at) > self.config.min_latency_max_age
-        {
-            self.min_latency = None;
+        // first tick after the window emptied under sustained congestion.
+        //
+        // We use `retain` rather than a `pop_front while front is old`
+        // loop because samples arrive in mpsc-receive order, not sorted
+        // by `completed_at`: under concurrent producers a sample with an
+        // older completion time can land in the deque after a newer one,
+        // so the front isn't guaranteed to be the oldest. `retain` is
+        // O(N) per tick, but N <= SAMPLE_WINDOW_CAP, negligible at the
+        // 50ms tick cadence. `checked_sub` because `now - max_age` can
+        // underflow for very early `Instant`s in tests with mocked clocks.
+        if let Some(cutoff) = now.checked_sub(self.config.min_latency_max_age) {
+            self.samples
+                .retain(|&(_, observed_at)| observed_at >= cutoff);
+        }
+        if self.samples.is_empty() {
+            self.baseline_latency_ns = None;
             self.ewma_latency_ns = None;
+        } else {
+            // p10 baseline: collect, sort, pick the 10th-percentile entry.
+            // the window is bounded at SAMPLE_WINDOW_CAP, so this is
+            // O(N log N) on at most a few thousand u64s — negligible at
+            // tick cadence (50ms by default).
+            let mut latencies: Vec<u64> = self.samples.iter().map(|&(ns, _)| ns).collect();
+            latencies.sort_unstable();
+            let idx = ((latencies.len() as f64) * 0.1) as usize;
+            self.baseline_latency_ns = Some(latencies[idx.min(latencies.len() - 1)]);
         }
         if self.tick_sample_count == 0 {
             return Decision::with_concurrency(self.cwnd);
         }
         let mean_ns = (self.tick_sum_latency_ns / u128::from(self.tick_sample_count)) as f64;
         // the very first sample-bearing tick establishes the baseline —
-        // EWMA equals min by construction so ratio is always 1.0. Skipping
-        // the adjustment on that tick prevents an unconditional cwnd bump
-        // from a cold start.
+        // EWMA equals baseline by construction so ratio is always 1.0.
+        // skipping the adjustment on that tick prevents an unconditional
+        // cwnd bump from a cold start.
         let is_first_sample_tick = self.ewma_latency_ns.is_none();
         self.ewma_latency_ns = Some(match self.ewma_latency_ns {
             Some(prev) => self.config.ewma_alpha * mean_ns + (1.0 - self.config.ewma_alpha) * prev,
@@ -171,9 +234,9 @@ impl Controller for VegasController {
         self.tick_sum_latency_ns = 0;
         self.tick_sample_count = 0;
         if !is_first_sample_tick
-            && let (Some(ewma), Some((min, _))) = (self.ewma_latency_ns, self.min_latency)
+            && let (Some(ewma), Some(baseline)) = (self.ewma_latency_ns, self.baseline_latency_ns)
         {
-            let ratio = ewma / (min as f64);
+            let ratio = ewma / (baseline as f64);
             if ratio < self.config.alpha {
                 self.cwnd = self
                     .cwnd
@@ -246,13 +309,46 @@ mod tests {
     }
 
     #[test]
-    fn tracks_minimum_latency_across_samples() {
+    fn tracks_baseline_latency_across_samples() {
+        // p10 over a small window: index = (len * 0.1) as usize. with 3
+        // samples that is index 0, the smallest value after sorting.
         let mut c = VegasController::new(VegasConfig::default());
         let start = std::time::Instant::now();
         c.on_sample(&sample(start, std::time::Duration::from_millis(10)));
         c.on_sample(&sample(start, std::time::Duration::from_millis(2)));
         c.on_sample(&sample(start, std::time::Duration::from_millis(5)));
+        // the baseline is computed inside on_tick; trigger one to populate.
+        c.on_tick(start);
         assert_eq!(c.min_latency(), Some(std::time::Duration::from_millis(2)));
+    }
+
+    #[test]
+    fn baseline_picks_p10_not_strict_min() {
+        // pin down the percentile semantics: 90 fast samples + 10 slow
+        // samples at 100× the fast latency. the strict min would be the
+        // single fastest sample; the p10 admits the lower 10% of the
+        // window, which here is uniformly the fast bucket — so the
+        // baseline lands at 1ms regardless of the slow tail.
+        let mut c = VegasController::new(VegasConfig::default());
+        let t0 = std::time::Instant::now();
+        for i in 0..90 {
+            c.on_sample(&sample(
+                t0 + std::time::Duration::from_micros(i),
+                std::time::Duration::from_millis(1),
+            ));
+        }
+        for i in 0..10 {
+            c.on_sample(&sample(
+                t0 + std::time::Duration::from_micros(90 + i),
+                std::time::Duration::from_millis(100),
+            ));
+        }
+        c.on_tick(t0 + std::time::Duration::from_millis(200));
+        assert_eq!(
+            c.min_latency(),
+            Some(std::time::Duration::from_millis(1)),
+            "p10 of 90×1ms + 10×100ms must be 1ms",
+        );
     }
 
     #[test]
@@ -264,7 +360,7 @@ mod tests {
             ..VegasConfig::default()
         });
         let start = std::time::Instant::now();
-        // consistent minimum latency over many ticks should grow cwnd
+        // consistent baseline latency over many ticks should grow cwnd
         for _ in 0..5 {
             c.on_sample(&sample(start, std::time::Duration::from_millis(2)));
             c.on_tick(start);
@@ -334,10 +430,10 @@ mod tests {
 
     #[test]
     fn first_sample_tick_does_not_adjust_cwnd() {
-        // with min == mean by construction, the naive ratio calculation
-        // returns 1.0 on the first sample-bearing tick and would always
-        // grow cwnd. The controller must skip the adjustment on this tick
-        // to avoid a baseline-inflation bias.
+        // with baseline == mean by construction, the naive ratio
+        // calculation returns 1.0 on the first sample-bearing tick and
+        // would always grow cwnd. The controller must skip the
+        // adjustment on this tick to avoid a baseline-inflation bias.
         let mut c = VegasController::new(VegasConfig {
             initial_cwnd: 5,
             ..VegasConfig::default()
@@ -348,7 +444,7 @@ mod tests {
     }
 
     #[test]
-    fn min_latency_ages_out_and_is_re_established() {
+    fn baseline_window_ages_out_and_is_re_established() {
         let mut c = VegasController::new(VegasConfig {
             initial_cwnd: 10,
             min_latency_max_age: std::time::Duration::from_millis(100),
@@ -356,27 +452,30 @@ mod tests {
         });
         let t0 = std::time::Instant::now();
         c.on_sample(&sample(t0, std::time::Duration::from_micros(500)));
-        // an on_tick before the age expires preserves the min
+        // a tick before the age expires preserves the window contents
         c.on_tick(t0 + std::time::Duration::from_millis(50));
-        assert_eq!(c.min_latency(), Some(std::time::Duration::from_micros(500)),);
-        // after the max age, on_tick discards the stale baseline
+        assert_eq!(c.samples.len(), 1);
+        assert_eq!(c.min_latency(), Some(std::time::Duration::from_micros(500)));
+        // after the max age, on_tick discards the stale window
         c.on_tick(t0 + std::time::Duration::from_millis(200));
+        assert!(c.samples.is_empty(), "stale samples must be evicted");
         assert_eq!(c.min_latency(), None);
         // a fresh, much larger sample becomes the new baseline
-        c.on_sample(&sample(
-            t0 + std::time::Duration::from_millis(201),
-            std::time::Duration::from_millis(3),
-        ));
+        let t_new = t0 + std::time::Duration::from_millis(201);
+        c.on_sample(&sample(t_new, std::time::Duration::from_millis(3)));
+        c.on_tick(t_new);
         assert_eq!(c.min_latency(), Some(std::time::Duration::from_millis(3)));
     }
 
     #[test]
-    fn min_latency_age_out_under_persistent_congestion_does_not_trigger_growth() {
-        // sustained congestion: min_latency at 2ms, ewma inflated at 5ms.
-        // When the min ages out but the congestion is still present, we
-        // must not immediately grow cwnd just because the baseline was
-        // reset. Fix: age-out clears ewma too, so the next tick re-runs
-        // the first-tick skip on the re-established baseline.
+    fn baseline_age_out_under_persistent_congestion_does_not_trigger_growth() {
+        // sustained congestion: window populated with samples whose mean
+        // is well above the baseline. when the window ages out and the
+        // EWMA is reset alongside, the very next sample-bearing tick is
+        // a first-sample-tick — the controller must not interpret the
+        // freshly-reset state as headroom and grow `cwnd`. the original
+        // strict-min controller had the same invariant; the percentile
+        // version preserves it via the empty-deque EWMA reset.
         let mut c = VegasController::new(VegasConfig {
             initial_cwnd: 30,
             min_latency_max_age: std::time::Duration::from_millis(100),
@@ -389,11 +488,11 @@ mod tests {
         // phase 1: establish a low baseline at 2ms
         c.on_sample(&sample(t0, std::time::Duration::from_millis(2)));
         c.on_tick(t0);
-        // phase 2: sustained congestion at 5ms — cwnd shrinks
+        // phase 2: sustained congestion at 8ms — 4× baseline, > beta=2.5
         let cwnd_before_congestion = c.cwnd();
         for i in 1..=5 {
             let now = t0 + std::time::Duration::from_millis(10 * i);
-            c.on_sample(&sample(now, std::time::Duration::from_millis(5)));
+            c.on_sample(&sample(now, std::time::Duration::from_millis(8)));
             c.on_tick(now);
         }
         assert!(
@@ -403,16 +502,30 @@ mod tests {
             cwnd_before_congestion,
         );
         let cwnd_during_congestion = c.cwnd();
-        // phase 3: age out (now > t0 + max_age = 100ms). Congestion persists —
-        // samples still at 5ms. Controller should NOT treat this as new
-        // headroom and grow.
+        // phase 3: a tick after the window's max-age elapses with no
+        // new sample drives the age-out path: every entry in the deque
+        // is older than the cutoff, the deque is emptied, and the EWMA
+        // is reset. cwnd is unchanged at this tick because there are no
+        // new samples to act on.
         let t_expired = t0 + std::time::Duration::from_millis(200);
-        c.on_sample(&sample(t_expired, std::time::Duration::from_millis(5)));
         c.on_tick(t_expired);
+        assert!(c.samples.is_empty(), "stale samples must be evicted");
+        assert_eq!(
+            c.ewma_latency(),
+            None,
+            "EWMA must reset when window empties"
+        );
+        assert_eq!(c.cwnd(), cwnd_during_congestion);
+        // phase 4: a new sample arrives — congestion persists. because
+        // the EWMA was reset, this is a first-sample-tick: ratio is 1.0
+        // by construction and the controller must not adjust cwnd.
+        let t_next = t_expired + std::time::Duration::from_millis(1);
+        c.on_sample(&sample(t_next, std::time::Duration::from_millis(8)));
+        c.on_tick(t_next);
         assert_eq!(
             c.cwnd(),
             cwnd_during_congestion,
-            "cwnd must not grow on the tick immediately after min age-out under persistent congestion",
+            "cwnd must not grow on the first sample-bearing tick after window age-out",
         );
     }
 
@@ -430,7 +543,7 @@ mod tests {
         c.on_sample(&sample(start, std::time::Duration::from_millis(2)));
         c.on_tick(start);
         let baseline_ewma = c.ewma_latency();
-        // several empty ticks
+        // several empty ticks within the age-out window
         for i in 0..5 {
             c.on_tick(start + std::time::Duration::from_millis(i * 10));
         }
@@ -442,7 +555,7 @@ mod tests {
     fn zero_latency_samples_do_not_collapse_cwnd() {
         // Regression: a 0-duration sample (possible when Instant::now()
         // resolution groups back-to-back probes) previously set
-        // min_latency=0, making the ewma/min ratio divide by zero or
+        // baseline=0, making the ewma/baseline ratio divide by zero or
         // turn into NaN — and either way not drive a principled cwnd
         // decision. `on_sample` now clamps latency to >= 1ns, so the
         // ratio stays finite and cwnd follows the normal trajectory.
@@ -475,36 +588,102 @@ mod tests {
     }
 
     #[test]
-    fn equal_min_latency_samples_refresh_observed_at() {
-        // Regression: previously `observed_at` only advanced on a
-        // *strictly* lower sample. A workload that consistently observed
-        // the true minimum would see the baseline expire on
-        // `min_latency_max_age` even though every sample confirmed the
-        // floor. Now, equal-latency samples also refresh the timestamp.
+    fn sample_window_is_capped_to_prevent_unbounded_growth() {
+        // push far more samples than the cap; len must stay at the cap on
+        // every observation, and the underlying allocation must not grow
+        // past its post-construction capacity — `VecDeque::push_back`
+        // reallocates if the buffer is at capacity, and `VecDeque` never
+        // shrinks, so a post-push pop pattern would leak the allocation
+        // even though `len` is brought back down immediately. Pinning to
+        // the initial capacity (rather than a looser `<= 2× cap` bound)
+        // catches that regression: at the cap a post-push push_back would
+        // round up to the next power of two, doubling capacity.
+        let mut c = VegasController::new(VegasConfig::default());
+        let initial_capacity = c.samples.capacity();
+        let start = std::time::Instant::now();
+        let n = SAMPLE_WINDOW_CAP + 10_000;
+        for i in 0..n {
+            c.on_sample(&sample(
+                start + std::time::Duration::from_micros(i as u64),
+                std::time::Duration::from_millis(1),
+            ));
+            assert!(
+                c.samples.len() <= SAMPLE_WINDOW_CAP,
+                "len {} exceeded cap {} at iteration {}",
+                c.samples.len(),
+                SAMPLE_WINDOW_CAP,
+                i,
+            );
+            assert_eq!(
+                c.samples.capacity(),
+                initial_capacity,
+                "underlying deque capacity grew at iteration {i}",
+            );
+        }
+        assert_eq!(c.samples.len(), SAMPLE_WINDOW_CAP);
+    }
+
+    #[test]
+    fn age_out_evicts_old_samples_regardless_of_deque_order() {
+        // Samples arrive in mpsc-receive order, not sorted by
+        // `completed_at`: under concurrent producers a sample with an
+        // older completion time can land in the deque *after* a newer
+        // one. The age-out path must still evict every stale entry —
+        // not just a contiguous prefix at the front — and the empty-
+        // deque-after-age-out path (EWMA reset, first-sample-tick
+        // semantics) must still fire.
         let mut c = VegasController::new(VegasConfig {
+            initial_cwnd: 10,
             min_latency_max_age: std::time::Duration::from_millis(100),
+            ewma_alpha: 1.0,
             ..VegasConfig::default()
         });
         let t0 = std::time::Instant::now();
-        // establish baseline at 2ms
-        c.on_sample(&sample(t0, std::time::Duration::from_millis(2)));
-        assert_eq!(c.min_latency(), Some(std::time::Duration::from_millis(2)));
-        // feed an equal-latency sample 200ms later — past the age-out
-        // window. The baseline must stay alive because the sample
-        // confirmed it.
-        let t_late = t0 + std::time::Duration::from_millis(200);
-        c.on_sample(&Sample {
-            started_at: t_late,
-            completed_at: t_late + std::time::Duration::from_millis(2),
-            bytes: 0,
-            outcome: Outcome::Ok,
-        });
-        c.on_tick(t_late + std::time::Duration::from_millis(1));
+        // Push samples in *interleaved* order: [newer, old, newer, old, ...].
+        // The "newer" entries sit at the front of the deque and the "old"
+        // entries sit immediately behind them. A `pop_front while front
+        // is old` loop would inspect the front (newer, not stale at the
+        // first tick), break, and leave every buried "old" entry behind.
+        // `retain` correctly drops the old ones from arbitrary positions.
+        let old_offset = std::time::Duration::from_millis(10);
+        let newer_offset = std::time::Duration::from_millis(80);
+        for i in 0..10 {
+            let offset = if i % 2 == 0 { newer_offset } else { old_offset };
+            c.on_sample(&sample(t0 + offset, std::time::Duration::from_millis(1)));
+        }
+        assert_eq!(c.samples.len(), 10);
+        // First tick at t0 + 130ms, max_age = 100ms → cutoff = t0 + 30ms.
+        //   - "newer" entries: observed_at ≈ t0 + 81ms (>= cutoff) → retain
+        //   - "old"   entries: observed_at ≈ t0 + 11ms (<  cutoff) → evict
+        // The buggy front-only loop sees a non-stale front and breaks
+        // immediately, leaving all 10. `retain` evicts exactly the 5 old
+        // ones.
+        let t_first = t0 + std::time::Duration::from_millis(130);
+        c.on_tick(t_first);
         assert_eq!(
-            c.min_latency(),
-            Some(std::time::Duration::from_millis(2)),
-            "baseline aged out despite continuous confirmation at the true min",
+            c.samples.len(),
+            5,
+            "out-of-order age-out must evict every stale entry, not just a front prefix",
         );
+        let cutoff = t0 + std::time::Duration::from_millis(30);
+        for &(_, observed_at) in &c.samples {
+            assert!(observed_at >= cutoff);
+        }
+        // EWMA was established by the first tick (5 retained samples
+        // produced a non-empty window). Now tick well past every
+        // observed_at — every remaining entry ages out, the deque
+        // empties, and the EWMA must reset alongside it so the next
+        // sample-bearing tick re-runs first-sample-tick semantics.
+        assert!(c.ewma_latency().is_some());
+        let t_all_expired = t0 + std::time::Duration::from_millis(300);
+        c.on_tick(t_all_expired);
+        assert!(c.samples.is_empty(), "every stale sample must age out");
+        assert_eq!(
+            c.ewma_latency(),
+            None,
+            "EWMA must reset when age-out empties the window",
+        );
+        assert_eq!(c.min_latency(), None);
     }
 
     #[test]

--- a/congestion/tests/scenarios.rs
+++ b/congestion/tests/scenarios.rs
@@ -199,7 +199,11 @@ fn vegas_grows_from_cold_start() {
 #[test]
 fn vegas_converges_near_bdp_without_runaway_latency() {
     // steady-state cwnd should oscillate around BDP — neither pinned at
-    // `min_cwnd` nor growing unboundedly.
+    // `min_cwnd` nor growing to the configured ceiling. With the loosened
+    // alpha=1.3 / beta=2.5 defaults, steady-state ratio sits between
+    // alpha and beta and the deterministic simulator's lack of natural
+    // variance lets cwnd overshoot more than under tighter thresholds —
+    // but it still bounds well below `max_cwnd`.
     let mut controller = VegasController::new(VegasConfig {
         initial_cwnd: 1,
         ..VegasConfig::default()
@@ -210,18 +214,25 @@ fn vegas_converges_near_bdp_without_runaway_latency() {
     let result = run_scenario(&mut controller, &bottleneck, &config);
     let final_cwnd = f64::from(controller.cwnd());
     let bdp = bottleneck.bdp();
-    // allow a generous band: Vegas operates between alpha and beta ratios, so
-    // steady-state cwnd is a small multiple of BDP.
+    let beta = VegasConfig::default().beta;
+    // upper bound: with EWMA lag the controller can overshoot the
+    // beta-implied steady state by a constant factor; 3× beta × BDP
+    // captures the observed band without permitting runaway growth.
+    let upper = bdp * beta * 3.0;
     assert!(
-        final_cwnd >= bdp * 0.5 && final_cwnd <= bdp * 3.0,
-        "expected cwnd near BDP={}, got {}",
+        final_cwnd >= bdp * 0.5 && final_cwnd <= upper,
+        "expected cwnd near BDP={} (within [{}, {}]), got {}",
         bdp,
+        bdp * 0.5,
+        upper,
         final_cwnd,
     );
     let mean = result.mean_latency().expect("samples recorded");
+    // latency bound scales with beta: the controller permits ratios up
+    // to beta in steady state, plus headroom for EWMA-lag overshoot.
     assert!(
-        mean.as_secs_f64() < bottleneck.min_latency.as_secs_f64() * 3.0,
-        "mean latency {:?} should stay within a few × min_latency {:?}",
+        mean.as_secs_f64() < bottleneck.min_latency.as_secs_f64() * beta * 3.0,
+        "mean latency {:?} should stay within beta × small multiple of min_latency {:?}",
         mean,
         bottleneck.min_latency,
     );

--- a/docs/congestion_control.md
+++ b/docs/congestion_control.md
@@ -155,9 +155,10 @@ The algorithm's job is to find a `cwnd` that saturates the bottleneck
 without queueing. It reasons about two derived quantities, both
 collected from the same per-op latency probes:
 
-- **Baseline latency** — the minimum operation latency we've seen
-  recently. By construction this is the floor; no individual sample can
-  be faster.
+- **Baseline latency** — the p10 percentile of recent operation
+  latencies, computed each tick over a sliding window of the last
+  ~4096 samples. This is the *uncongested floor*: most samples in the
+  window are at least this fast.
 - **Smoothed current latency** — an EWMA of recent operation latencies.
   Smoothing absorbs single-sample noise so a brief slow op doesn't kick
   the controller off course.
@@ -168,9 +169,10 @@ Their ratio is the congestion signal:
   ratio  =  smoothed_current / baseline
 ```
 
-By construction `ratio >= 1.0` (the smoothed current can't be smaller
-than the running minimum that defines the baseline). So the regime we
-care about is the strip between 1.0 and "very large":
+In normal operation `ratio >= 1.0` (the smoothed mean of the same
+window is bounded below by the lower decile, modulo sample-ordering
+noise). So the regime we care about is the strip between 1.0 and
+"very large":
 
 ```
        latency ratio
@@ -196,38 +198,52 @@ latency as the new normal and never shrinks?
 
 Three design choices keep the baseline trustworthy:
 
-1. **The baseline is a running minimum, not an average.** `min_latency`
-   records the *smallest* sample observed in the last
-   `min_latency_max_age` window (default 10s). Even when 99% of samples
-   in that window are slow because we're saturating the filesystem, a
-   single fast sample — typically from earlier, before `cwnd` ramped
-   high enough to queue — pins the floor to the true uncongested cost.
-   Slow samples can never drag the floor up; they simply aren't
-   smaller.
+1. **The baseline is the p10 of the recent sample window, not a strict
+   minimum or an average.** Every per-op latency goes into a sliding
+   window capped at ~4096 samples; on each tick the controller takes
+   the value at the 10th percentile of that window as the uncongested
+   floor. The p10 is robust to a single fast outlier (the floor only
+   moves when the lower decile of the window moves with it), naturally
+   weighted toward recent samples (older entries fall out of the
+   window), and tolerant of the natural per-op variance of real
+   filesystems — variance that on a Weka or Lustre mount routinely
+   spans an order of magnitude even on an idle metadata path. A strict
+   running minimum, in contrast, would latch onto the single fastest
+   sample (which may be a kernel cache hit unrepresentative of typical
+   service time) and read ordinary variance as queueing.
 
-2. **The control law shrinks `cwnd` long before the window expires.**
+   What the p10 admits and rejects, concretely: a workload that
+   alternates between fast and slow phases will see the p10 follow
+   the fast phase as long as roughly 10% of recent samples come from
+   it; if the slow phase becomes overwhelmingly dominant, the p10
+   drifts up too — but only after the fast phase has actually fallen
+   out of representation, not on the strength of a single anomaly.
+   Conversely, one freakishly fast outlier at the top of the window
+   doesn't pin the baseline; the p10 absorbs it without moving.
+
+2. **The control law shrinks `cwnd` long before samples age out.**
    When `ratio > beta`, the very next tick (50 ms by default) shrinks
-   `cwnd` by one step. Continued inflation keeps shrinking it.  Once
-   `cwnd` has dropped enough for the queue to drain, a low-latency
-   sample either re-confirms the existing minimum (refreshing the
-   age-out timer) or establishes a new, lower one. So in any healthy
-   operating regime the baseline is continuously re-validated long
-   before it could expire.
+   `cwnd` by one step. Continued inflation keeps shrinking it. Once
+   `cwnd` has dropped enough for the queue to drain, fresh low-latency
+   samples enter the window and the p10 tracks the true uncongested
+   floor. So in any healthy operating regime the baseline is
+   continuously re-validated long before sample age-out matters.
 
-3. **If the baseline does expire under sustained saturation, the
+3. **If the window does empty under sustained saturation, the
    smoothed estimate is reset alongside it.** The case left open is
    *persistent* overload — e.g. `min_cwnd` is configured high and the
-   filesystem is genuinely overloaded for more than 10 seconds. When
-   the baseline ages out, the next sample establishes a new (inflated)
-   floor. To prevent that newly-bad baseline from making the next tick
-   look "uncongested" and grow `cwnd` further, the EWMA is reset at
-   the same instant. The first sample-bearing tick after a reset
-   replays the cold-start path and never adjusts `cwnd`, buying a full
-   smoothing window for the controller to reconverge before any growth
-   decision.
+   filesystem is genuinely overloaded for more than the
+   `min_latency_max_age` window (default 10s). When every sample in
+   the window has aged out, the next sample establishes a new
+   (inflated) floor. To prevent that newly-bad baseline from making
+   the next tick look "uncongested" and grow `cwnd` further, the EWMA
+   is reset at the same instant. The first sample-bearing tick after
+   a reset replays the cold-start path and never adjusts `cwnd`,
+   buying a full smoothing window for the controller to reconverge
+   before any growth decision.
 
-The only state the controller carries across a baseline reset is
-`cwnd` itself — intentionally. The next ratio is computed from a fresh
+The only state the controller carries across a window reset is `cwnd`
+itself — intentionally. The next ratio is computed from a fresh
 baseline and a fresh smoothed current, so "current latency is normal"
 can't be inferred from a window of uniformly inflated samples.
 
@@ -244,8 +260,14 @@ regions and applies a fixed step to `cwnd`:
        ratio  >  beta       cwnd -= decrease_step    (shrink)
 ```
 
-Defaults: `alpha = 1.10`, `beta = 1.50`, `increase_step = decrease_step
-= 1`. Each step is then clamped to `[min_cwnd, max_cwnd]`.
+Defaults: `alpha = 1.30`, `beta = 2.50`, `increase_step =
+decrease_step = 1`. Each step is then clamped to `[min_cwnd,
+max_cwnd]`. The thresholds are deliberately loose: real metadata
+syscalls on a networked filesystem routinely show ewma-to-baseline
+ratios in the 1.5–2.0× band even when the filesystem is *not*
+congested, simply because per-op latency variance on these mounts is
+naturally large. Tighter thresholds would misread that variance as
+queueing and ratchet `cwnd` toward the floor.
 
 A few worked examples make the shape concrete. Assume a 0.5ms baseline,
 default thresholds, and `cwnd = 20` going into the tick:
@@ -253,27 +275,33 @@ default thresholds, and `cwnd = 20` going into the tick:
 | Smoothed current | Ratio | Decision | New `cwnd` |
 |------------------|-------|----------|------------|
 | 0.50 ms          | 1.00  | grow     | 21         |
-| 0.55 ms          | 1.10  | hold     | 20 (1.10 == alpha; not below) |
-| 0.70 ms          | 1.40  | hold     | 20         |
-| 0.75 ms          | 1.50  | hold     | 20 (1.50 == beta; not above) |
-| 1.00 ms          | 2.00  | shrink   | 19         |
+| 0.60 ms          | 1.20  | grow     | 21         |
+| 0.65 ms          | 1.30  | hold     | 20 (1.30 == alpha; not below) |
+| 1.00 ms          | 2.00  | hold     | 20         |
+| 1.25 ms          | 2.50  | hold     | 20 (2.50 == beta; not above) |
+| 1.50 ms          | 3.00  | shrink   | 19         |
 | 2.50 ms          | 5.00  | shrink   | 19         |
-| 0.40 ms          | 0.80  | —        | impossible (see below) |
+| 0.40 ms          | 0.80  | —        | unusual (see below) |
 
 **Two things to notice in this table.** First, the law is a
 *binary trigger*, not a proportional response: a ratio of 5.0 shrinks
-by exactly the same one step as a ratio of 1.51. Sustained inflation
+by exactly the same one step as a ratio of 2.51. Sustained inflation
 drives faster *effective* shrinkage because the ratio stays above
 `beta` over many consecutive ticks — but each individual tick still
 takes one step. This is the classic Vegas shape: simpler control law,
 less prone to oscillation under noisy latency than a gain-tuned PID.
 
-Second, **a ratio below 1.0 cannot occur.** The smoothed current is
-itself an EWMA of samples that have already been folded into the
-running min, so it is bounded below by that min. The baseline-age-out
-path preserves this property: when the min is discarded as stale, the
-smoothed current is reset alongside it so the next tick re-establishes
-both from the same fresh window of samples.
+Second, **a ratio below 1.0 is unusual.** In the typical case the
+smoothed current is the EWMA of samples whose lower decile is the p10
+baseline, so the mean is bounded below by p10 modulo sample-ordering
+noise. A brief excursion under 1.0 is possible if the EWMA's
+exponential weight is dominated by an unusually-fast burst that has
+not yet diluted into the broader window's percentile — this is benign
+and the next tick treats `ratio < alpha` as growth headroom anyway.
+The window-empty path preserves the rest of the invariants: when the
+window is exhausted by age-out, the smoothed current is reset
+alongside it so the next tick re-establishes both from the same fresh
+sample stream.
 
 The "responsiveness" of the controller is shaped by three knobs in
 combination:
@@ -350,7 +378,7 @@ metadata controllers per process — one per [`Side`]:
 | **Metadata** | source single-stat, `read_link`, source-side `File::open` | destination create / unlink / chmod / `hard_link` / `set_permissions` |
 
 Each controller runs the same algorithm with its own independent state
-(its own `min_latency`, EWMA, `cwnd`) and its own enforcement
+(its own p10 baseline window, EWMA, `cwnd`) and its own enforcement
 semaphore. A probe site is annotated with the side
 (`Metadata(Source)`, `Metadata(Destination)`); the control loop and
 enforcement gate are picked accordingly.

--- a/docs/congestion_control.md
+++ b/docs/congestion_control.md
@@ -17,7 +17,7 @@ scope here is conceptual; specific flag names are covered in
 - [The Control Law](#the-control-law)
 - [Enforcement Model](#enforcement-model)
 - [What Counts as a Metadata Op](#what-counts-as-a-metadata-op)
-- [Four Controllers: Walk × Metadata × Source × Destination](#four-controllers-walk--metadata--source--destination)
+- [Two Controllers: One per Filesystem Side](#two-controllers-one-per-filesystem-side)
 - [Interaction with Static Throttles](#interaction-with-static-throttles)
 - [Remote Copy](#remote-copy)
 - [Tuning and Observability](#tuning-and-observability)
@@ -103,11 +103,12 @@ emits absolute limits — concurrency, rate, or both. No I/O, no clocks
 except time values passed in. This purity lets a deterministic simulator
 drive any algorithm through synthetic workloads for regression testing.
 
-**Control loop.** Async glue. Each controlled resource (metadata,
-read-throughput, write-throughput) has its own instance, running as a
-lightweight task. It drains a bounded sample queue, calls the
-algorithm's tick on a configurable cadence, and publishes each emitted
-decision to the enforcement layer.
+**Control loop.** Async glue. Each controlled resource has its own
+instance, running as a lightweight task. It drains a bounded sample
+queue, calls the algorithm's tick on a configurable cadence, and
+publishes each emitted decision to the enforcement layer. We run one
+controller per filesystem side (source vs destination) — see
+[Two Controllers: One per Filesystem Side](#two-controllers-one-per-filesystem-side).
 
 **Enforcement.** The hot-path gates — semaphores and token buckets that
 the filesystem-op callers wait on. These existed before congestion
@@ -298,8 +299,8 @@ algorithm last decided.
 
 ## What Counts as a Metadata Op
 
-We probe **every** metadata-touching syscall the tools issue, on both
-the read side and the write side. The cost of a probe is two
+We probe most per-file metadata syscalls the mutating tools issue, on
+both the read side and the write side. The cost of a probe is two
 `Instant::now()` calls plus a non-blocking channel send (or a no-op when
 no sink is installed), so wide coverage is cheap; in exchange we get a
 control signal that doesn't have visibility holes the controller can be
@@ -307,88 +308,78 @@ fooled by.
 
 What "wide coverage" means concretely:
 
-- **Read-side metadata, walk-class:** the directory-walk pair
-  `next_entry()` + `file_type()`. We bracket the pair as one probe
-  because they're tightly coupled and `file_type` typically serves out
-  of the dirent cache populated by `next_entry`.
-- **Read-side metadata, single-syscall:** every `tokio::fs::metadata`,
-  `symlink_metadata`, `read_link`, `canonicalize`, and `File::open` on
-  the source path.
+- **Read-side metadata:** every `tokio::fs::symlink_metadata`,
+  `metadata`, `read_link`, `canonicalize`, and `File::open` along the
+  source-side paths of `rcp`, `rlink`, and `rrm`. Each is one probe per
+  syscall.
 - **Write-side metadata:** `create_dir`, `hard_link`, `symlink`,
   `remove_file`, `remove_dir`, `set_permissions`, the `chown` and
   `utimens` syscalls inside `preserve::set_*_metadata`, and the
   `File::open` / `OpenOptions::open(create:true, …)` for new files.
   Each is one probe per syscall.
-- **Not probed by design:** data-path reads/writes (the read-loop and
-  write-loop inside the copy pipeline, and `tokio::fs::copy` itself).
-  Bandwidth-bound, not service-time-bound; a Vegas-style controller
-  doesn't fit. See [Pluggability](#pluggability) for the BBR direction.
+- **Not probed today — `rcmp`.** The compare tool reads source and
+  destination metadata via raw `tokio::fs::symlink_metadata` (see
+  `common::cmp`); none of those calls are bracketed by
+  `walk::run_metadata_probed`, so `rcmp` does not currently exercise
+  the metadata controllers. Adding probes there is a follow-up.
+- **Not probed by design — directory iteration.** Walks (`next_entry`
+  + cached `file_type`) are *not* probed. `tokio::fs::ReadDir`
+  amortizes a single `getdents` syscall over many `next_entry` calls,
+  so most "walk probes" don't enter the kernel at all and complete in
+  tens of nanoseconds. The resulting bimodal cache-hit / real-syscall
+  distribution collapses any baseline a controller could derive from
+  it and pins `cwnd` at the floor. The per-file metadata syscalls that
+  *follow* the walk still carry a clean signal, so we let those drive
+  the controllers and skip the walk path entirely.
+- **Not probed by design — data path.** The read-loop and write-loop
+  inside the copy pipeline, and `tokio::fs::copy` itself. Bandwidth-
+  bound, not service-time-bound; a Vegas-style controller doesn't fit.
+  See [Pluggability](#pluggability) for the BBR direction.
 
-The risk of probing every metadata syscall is that *kinds* of metadata
-ops have different latency regimes — a cache-warm `getdents` is much
-faster than a cold `stat`. Mixing the two on one controller would let
-cache hits drag `min_latency` down and make every real syscall look
-"slow." We address this not by probing fewer sites, but by routing
-samples to **separate controllers per (op-class × filesystem-side)**
-— see the next section.
-
-## Four Controllers: Walk × Metadata × Source × Destination
+## Two Controllers: One per Filesystem Side
 
 Filesystems vary enormously. A copy from a saturated NFS mount to a
 local SSD has two completely independent service-time profiles, and
-forcing them onto a single controller pessimizes both. Likewise,
-mixing cache-warm directory iteration with cold per-file metadata on
-the same controller lets `min_latency` collapse to a few microseconds
-and the controller treats every real `stat` as "slow."
+forcing them onto a single controller pessimizes both.
 
-Following the guideline *one controller per filesystem, one controller
-per operation class*, we run four metadata controllers per process,
-partitioning along two axes:
+Following the guideline *one controller per filesystem*, we run two
+metadata controllers per process — one per [`Side`]:
 
-|                | **Source-side**            | **Destination-side**        |
-|----------------|----------------------------|-----------------------------|
-| **Walk**       | source directory iteration | destination dir iteration   |
-| **Metadata**   | source single-stat / open  | destination create / unlink / chmod |
+|              | **Source-side**                   | **Destination-side**                  |
+|--------------|-----------------------------------|---------------------------------------|
+| **Metadata** | source single-stat, `read_link`, source-side `File::open` | destination create / unlink / chmod / `hard_link` / `set_permissions` |
 
 Each controller runs the same algorithm with its own independent state
 (its own `min_latency`, EWMA, `cwnd`) and its own enforcement
-semaphore. A probe site is annotated with both axes (`Walk(Source)`,
-`Metadata(Destination)`, …); the control loop and enforcement gate
-are picked accordingly.
+semaphore. A probe site is annotated with the side
+(`Metadata(Source)`, `Metadata(Destination)`); the control loop and
+enforcement gate are picked accordingly.
 
 How tools map onto this:
 
-| Tool      | walk-src  | meta-src                   | walk-dst | meta-dst                                 |
-|-----------|-----------|----------------------------|----------|------------------------------------------|
-| `rcp`     | source tree walk | top-level / dereferenced stats, `read_link`, file open  | —        | `create_dir`, `symlink`, file create, `set_permissions`, `chown`, `utimens` |
-| `rrm`     | walk of the path being removed | top-level stat | — | `remove_file`, `remove_dir`, pre-unlink `set_permissions` |
-| `rlink`   | src (and update, when set) walks | top-level stats | — | `hard_link`, `create_dir`, `set_permissions` |
-| `rcmp`    | walk of src      | top-level stats           | walk of dst | (compare-only — no writes) |
-| `filegen` | — | — | — | `create_dir`, `open(create:true)`, `set_permissions` |
+| Tool      | meta-src                                       | meta-dst                                       |
+|-----------|------------------------------------------------|------------------------------------------------|
+| `rcp`     | top-level / dereferenced stats, `read_link`, file open | `create_dir`, `symlink`, file create, `set_permissions`, `chown`, `utimens` |
+| `rrm`     | top-level stat                                 | `remove_file`, `remove_dir`, pre-unlink `set_permissions` |
+| `rlink`   | top-level stats                                | `hard_link`, `create_dir`, `set_permissions`   |
+| `rcmp`    | (no probes today — see note above)             | (no probes today — compare-only, no writes)    |
+| `filegen` | —                                              | `create_dir`, `open(create:true)`, `set_permissions` |
 
-Two notes on this layout:
+Single-path tools (rrm, filegen) still get both controllers. rrm
+exercises meta-src + meta-dst; filegen exercises only meta-dst; the
+unused controller stays idle (harmless). Carrying both uniformly
+keeps the wiring identical across tools.
 
-- **Single-path tools (rrm, filegen) still get all four controllers.**
-  rrm exercises walk-src + meta-dst; filegen exercises only meta-dst;
-  the unused controllers stay idle (harmless). Carrying all four
-  uniformly keeps the wiring identical across tools.
-- **rcmp's "destination" probes are reads, not writes.** Compare-only
-  tools read both sides without mutating, so they only exercise
-  walk-src and walk-dst. The principle "one controller per filesystem"
-  still applies — a saturated dst-FS shouldn't push the src-FS
-  controller into shrinking when src-FS is fine.
-
-A note on the rate dimension: the four controllers all gate their own
+A note on the rate dimension: both controllers gate their own
 in-flight concurrency independently, but the global ops-throttle
 (rate-per-second) is shared across the process. Only one controller —
 destination metadata, by convention — drives that single rate gate;
-the other three apply concurrency only.
+the other applies concurrency only.
 
 In remote copy, this layout maps cleanly: `rcpd-source` exercises
-walk-src and meta-src (only ever reads its local source filesystem),
-and `rcpd-destination` exercises meta-dst (only ever mutates its
-local destination filesystem). The unused channels stay idle on each
-side.
+meta-src (only ever reads its local source filesystem), and
+`rcpd-destination` exercises meta-dst (only ever mutates its local
+destination filesystem). The unused channel stays idle on each side.
 
 At the call site, each syscall is bracketed by permit acquisition and a
 *probe* that measures its wall-clock duration:
@@ -488,8 +479,8 @@ tick cadence. Defaults are conservative; aggressive-but-sensible tuning
 comes from field measurements.
 
 The control loop emits structured `tracing` events on a few channels —
-each tagged with a `unit` field so the four controllers can be told
-apart in mixed logs (`walk-src`, `walk-dst`, `meta-src`, `meta-dst`):
+each tagged with a `unit` field so the two controllers can be told
+apart in mixed logs (`meta-src`, `meta-dst`):
 
 - **`tracing::info!`** at startup, describing the effective auto-meta
   configuration.

--- a/docs/congestion_control.md
+++ b/docs/congestion_control.md
@@ -345,20 +345,23 @@ What "wide coverage" means concretely:
   `utimens` syscalls inside `preserve::set_*_metadata`, and the
   `File::open` / `OpenOptions::open(create:true, …)` for new files.
   Each is one probe per syscall.
-- **Not probed today — `rcmp`.** The compare tool reads source and
-  destination metadata via raw `tokio::fs::symlink_metadata` (see
-  `common::cmp`); none of those calls are bracketed by
-  `walk::run_metadata_probed`, so `rcmp` does not currently exercise
-  the metadata controllers. Adding probes there is a follow-up.
 - **Not probed by design — directory iteration.** Walks (`next_entry`
-  + cached `file_type`) are *not* probed. `tokio::fs::ReadDir`
-  amortizes a single `getdents` syscall over many `next_entry` calls,
-  so most "walk probes" don't enter the kernel at all and complete in
-  tens of nanoseconds. The resulting bimodal cache-hit / real-syscall
-  distribution collapses any baseline a controller could derive from
-  it and pins `cwnd` at the floor. The per-file metadata syscalls that
-  *follow* the walk still carry a clean signal, so we let those drive
-  the controllers and skip the walk path entirely.
+  + cached `file_type`) are *not* probed and *not* concurrency-capped.
+  `tokio::fs::ReadDir` amortizes a single `getdents` syscall over many
+  `next_entry` calls, so most "walk probes" don't enter the kernel at
+  all and complete in tens of nanoseconds. The resulting bimodal
+  cache-hit / real-syscall distribution collapses any baseline a
+  controller could derive from it and pins `cwnd` at the floor. The
+  per-file metadata syscalls that *follow* the walk still carry a
+  clean signal, so we let those drive the controllers and skip the
+  walk path entirely. One side-effect worth flagging: a workload that
+  walks a wide tree but filters most entries away (large
+  `--include`/`--exclude` exclusions) will still spawn concurrent
+  directory scans without any auto-meta backpressure, since the
+  filter short-circuit happens before any metadata syscall fires.
+  Walks self-pace through the OS getdents cache and the global
+  `--ops-throttle` rate gate still applies; if you need a hard cap on
+  walk-side load on a fragile NAS, reach for `--ops-throttle`.
 - **Not probed by design — data path.** The read-loop and write-loop
   inside the copy pipeline, and `tokio::fs::copy` itself. Bandwidth-
   bound, not service-time-bound; a Vegas-style controller doesn't fit.
@@ -390,7 +393,7 @@ How tools map onto this:
 | `rcp`     | top-level / dereferenced stats, `read_link`, file open | `create_dir`, `symlink`, file create, `set_permissions`, `chown`, `utimens` |
 | `rrm`     | top-level stat                                 | `remove_file`, `remove_dir`, pre-unlink `set_permissions` |
 | `rlink`   | top-level stats                                | `hard_link`, `create_dir`, `set_permissions`   |
-| `rcmp`    | (no probes today — see note above)             | (no probes today — compare-only, no writes)    |
+| `rcmp`    | per-entry `symlink_metadata` on the src tree   | per-entry `symlink_metadata` on the dst tree (compare-only — no writes) |
 | `filegen` | —                                              | `create_dir`, `open(create:true)`, `set_permissions` |
 
 Single-path tools (rrm, filegen) still get both controllers. rrm

--- a/throttle/src/lib.rs
+++ b/throttle/src/lib.rs
@@ -152,22 +152,15 @@ mod semaphore;
 
 /// Which throttled metadata resource a permit / cap belongs to.
 ///
-/// The four variants partition metadata work along two axes — which
-/// filesystem (source vs destination) and which operation class (cache-warm
-/// directory iteration vs real per-file syscalls). Each variant gets its
-/// own concurrency cap so the per-resource latency regimes don't bleed into
-/// one another. Mirrors the congestion crate's `ResourceKind` for metadata
-/// kinds; this enum is intentionally independent so `throttle` has no
-/// dependency on `congestion`.
+/// One variant per filesystem side (source vs destination); each gets its
+/// own concurrency cap so a saturated source doesn't drag the destination
+/// down or vice versa. Mirrors the congestion crate's `ResourceKind` for
+/// metadata kinds; this enum is intentionally independent so `throttle`
+/// has no dependency on `congestion`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Resource {
-    /// Source-side directory iteration (`getdents` + cached `file_type`).
-    SrcWalk,
     /// Source-side per-file metadata syscall (`stat`, `read_link`, `open`).
     SrcMeta,
-    /// Destination-side directory iteration. Used by tools that walk dst
-    /// (e.g. `rcmp` / `rrm`).
-    DstWalk,
     /// Destination-side per-file metadata syscall — both lookups and
     /// mutations (`create_dir`, `hard_link`, `unlink`, `chmod`, …).
     DstMeta,
@@ -180,23 +173,16 @@ static OPS_THROTTLE: std::sync::LazyLock<semaphore::Semaphore> =
 static IOPS_THROTTLE: std::sync::LazyLock<semaphore::Semaphore> =
     std::sync::LazyLock::new(semaphore::Semaphore::new);
 // Per-op concurrency caps driven by the congestion controller. One
-// semaphore per [`Resource`] so each (side × class) pair is throttled
-// independently. Distinct from OPS_THROTTLE (rate) and OPEN_FILES_LIMIT
-// (FDs).
-static OPS_IN_FLIGHT_LIMIT_SRC_WALK: std::sync::LazyLock<semaphore::Semaphore> =
-    std::sync::LazyLock::new(semaphore::Semaphore::new);
+// semaphore per [`Resource`] so each side is throttled independently.
+// Distinct from OPS_THROTTLE (rate) and OPEN_FILES_LIMIT (FDs).
 static OPS_IN_FLIGHT_LIMIT_SRC_META: std::sync::LazyLock<semaphore::Semaphore> =
-    std::sync::LazyLock::new(semaphore::Semaphore::new);
-static OPS_IN_FLIGHT_LIMIT_DST_WALK: std::sync::LazyLock<semaphore::Semaphore> =
     std::sync::LazyLock::new(semaphore::Semaphore::new);
 static OPS_IN_FLIGHT_LIMIT_DST_META: std::sync::LazyLock<semaphore::Semaphore> =
     std::sync::LazyLock::new(semaphore::Semaphore::new);
 
 fn ops_in_flight_limit(resource: Resource) -> &'static semaphore::Semaphore {
     match resource {
-        Resource::SrcWalk => &OPS_IN_FLIGHT_LIMIT_SRC_WALK,
         Resource::SrcMeta => &OPS_IN_FLIGHT_LIMIT_SRC_META,
-        Resource::DstWalk => &OPS_IN_FLIGHT_LIMIT_DST_WALK,
         Resource::DstMeta => &OPS_IN_FLIGHT_LIMIT_DST_META,
     }
 }


### PR DESCRIPTION
## Summary
- **Drop walk probes.** `tokio::fs::ReadDir::next_entry().await` returns buffered entries from a prior `getdents` batch without entering the kernel — most "walk probes" reported 58ns latencies, collapsing the running-min baseline and pinning cwnd at 1. With walks unprobed, only metadata syscalls (which carry a real signal) drive the controllers, leaving two controllers (`meta-src`, `meta-dst`) instead of four.
- **Use windowed p10 baseline + loosened alpha/beta defaults.** Strict-min latches onto a single fast outlier and treats ordinary per-op variance as queueing; p10 over a sliding window (capped at 4096 samples) is robust to that and is naturally weighted toward recent samples. Defaults bumped from `alpha=1.1, beta=1.5` to `alpha=1.3, beta=2.5` so the hold band tolerates real-world filesystem variance rather than misreading it as congestion.
- **Probe `rcmp`'s metadata syscalls.** All four `tokio::fs::symlink_metadata` sites in `common::cmp` are now bracketed by `run_metadata_probed`, side-tagged correctly. `--auto-meta-throttle` is no longer a silent no-op for `rcmp`.
- **Polish the auto-meta progress panel.** Dashed separator above the panel, hide rows with zero samples (so unused controllers don't clutter the display), and right-align numeric columns to a uniform width so values like `58ns`, `33.5µs`, `1.2k`, `578.4×` line up across rows.

Real-world impact (`rrm --auto-meta-throttle` on Weka): goes from ~150 items/s (cwnd pinned at 1) to comparable with no-throttle (~4600 items/s observed).

## Test plan
- [x] `just lint` clean
- [x] `just test` 791 passed, 50 skipped, 0 failed
- [x] `just doctest` clean
- [ ] Validate against a real Weka workload — verify `rrm`/`rcp` throughput recovers, `meta-src`/`meta-dst` cwnd actually grows, and the new `alpha=1.3 / beta=2.5` defaults don't overshoot in steady state. May need to tune.
- [ ] Spot-check `rcmp --auto-meta-throttle` on a large tree — confirm controllers receive samples and pace mutations.