### PR TITLE
Bound pending ops in rrm/rcmp/rlink without deadlock cycles

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -21,6 +21,16 @@ test-group = 'serial'
 filter = 'binary(~docker)'
 test-group = 'serial'
 
+# saturation tests mutate the process-wide throttle semaphores via
+# `throttle::set_max_open_files`. Running them in parallel with each other
+# (or with anything else that depends on the global limit) can race the
+# `Semaphore::setup()` reconfiguration and produce flaky timeouts. Serialize
+# them by name — the convention is to put such tests in a `max_open_files_tests`
+# submodule, which puts the substring in the test path.
+[[profile.default.overrides]]
+filter = 'test(max_open_files)'
+test-group = 'serial'
+
 [profile.docker]
 # docker profile runs Docker integration tests (multi-host and chaos tests)
 # these tests are normally ignored and require Docker containers

--- a/common/src/cmp.rs
+++ b/common/src/cmp.rs
@@ -470,7 +470,23 @@ async fn expand_missing_tree(
         let log = log.clone();
         let settings = settings.clone();
         let existing_root = existing_root.to_owned();
+        // for positively-known leaf entries (file/symlink/special), acquire
+        // the pending-meta permit BEFORE spawning so we don't create
+        // unbounded tasks. We deliberately skip pre-acquire when
+        // `entry_file_type` is None: the entry could actually be a directory,
+        // and chained unknown-typed directories holding permits while
+        // recursing would deadlock the pending-meta pool. Known directories
+        // also skip pre-acquire. We use the pending-meta semaphore (not
+        // open-files) because cmp doesn't hold fds; decoupling avoids
+        // contention with concurrent copy paths that hold open-files permits.
+        let known_leaf = entry_file_type.is_some_and(|ft| !ft.is_dir());
+        let pending_guard = if known_leaf {
+            Some(throttle::pending_meta_permit().await)
+        } else {
+            None
+        };
         join_set.spawn(async move {
+            let _pending_guard = pending_guard;
             expand_missing_tree(
                 prog_track,
                 &entry_path,
@@ -666,7 +682,23 @@ async fn cmp_internal(
         let settings = settings.clone();
         let source_root = source_root.to_owned();
         let dest_root = dest_root.to_owned();
+        // for positively-known leaf entries (file/symlink/special), acquire
+        // the pending-meta permit BEFORE spawning so we don't create
+        // unbounded tasks. We deliberately skip pre-acquire when
+        // `entry_file_type` is None: the entry could actually be a directory,
+        // and chained unknown-typed directories holding permits while
+        // recursing would deadlock the pending-meta pool. Known directories
+        // also skip pre-acquire. We use the pending-meta semaphore (not
+        // open-files) because cmp doesn't hold fds; decoupling avoids
+        // contention with concurrent copy paths that hold open-files permits.
+        let known_leaf = entry_file_type.is_some_and(|ft| !ft.is_dir());
+        let pending_guard = if known_leaf {
+            Some(throttle::pending_meta_permit().await)
+        } else {
+            None
+        };
         let do_cmp = || async move {
+            let _pending_guard = pending_guard;
             cmp_internal(
                 prog_track,
                 &entry_path,
@@ -1722,5 +1754,125 @@ mod cmp_tests {
         let raw = std::path::Path::new(OsStr::from_bytes(b"/tmp/bad\xffname.txt"));
         // these must produce different output
         assert_ne!(path_to_json_string(literal), path_to_json_string(raw));
+    }
+
+    /// Stress tests exercising max-open-files saturation during cmp.
+    mod max_open_files_tests {
+        use super::*;
+        use anyhow::Context;
+
+        /// deep + wide cmp: directory tree deeper than the open-files limit, with files
+        /// at every level. verifies no deadlock occurs (directories don't consume permits).
+        #[tokio::test]
+        #[traced_test]
+        async fn deep_tree_no_deadlock_under_open_files_saturation() -> Result<()> {
+            let tmp_dir = testutils::create_temp_dir().await?;
+            let src = tmp_dir.join("src");
+            let dst = tmp_dir.join("dst");
+            let depth = 20;
+            let files_per_level = 5;
+            let limit = 4;
+            // create matching directory chains in src and dst, deeper than the permit limit
+            let mut src_dir = src.clone();
+            let mut dst_dir = dst.clone();
+            for level in 0..depth {
+                tokio::fs::create_dir_all(&src_dir).await?;
+                tokio::fs::create_dir_all(&dst_dir).await?;
+                for f in 0..files_per_level {
+                    let name = format!("f{}_{}.txt", level, f);
+                    let content = format!("L{}F{}", level, f);
+                    tokio::fs::write(src_dir.join(&name), &content).await?;
+                    tokio::fs::write(dst_dir.join(&name), &content).await?;
+                }
+                src_dir = src_dir.join(format!("d{}", level));
+                dst_dir = dst_dir.join(format!("d{}", level));
+            }
+            throttle::set_max_open_files(limit);
+            let compare_settings = Settings {
+                fail_early: false,
+                exit_early: false,
+                expand_missing: false,
+                compare: enum_map::enum_map! {
+                    ObjType::File => filecmp::MetadataCmpSettings { size: true, ..Default::default() },
+                    ObjType::Dir => filecmp::MetadataCmpSettings::default(),
+                    ObjType::Symlink => filecmp::MetadataCmpSettings::default(),
+                    ObjType::Other => filecmp::MetadataCmpSettings::default(),
+                },
+                filter: None,
+            };
+            let summary = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                cmp(
+                    &PROGRESS,
+                    &src,
+                    &dst,
+                    &LogWriter::silent().await?,
+                    &compare_settings,
+                ),
+            )
+            .await
+            .context("cmp timed out — possible deadlock")?
+            .context("cmp failed")?;
+            assert_eq!(
+                summary.mismatch[ObjType::File][CompareResult::Same],
+                depth * files_per_level
+            );
+            Ok(())
+        }
+
+        /// expand_missing under saturation: dst is empty, src is a deep tree.
+        /// verifies expand_missing_tree's recursion bounds tasks under the permit cap.
+        #[tokio::test]
+        #[traced_test]
+        async fn expand_missing_under_open_files_saturation() -> Result<()> {
+            let tmp_dir = testutils::create_temp_dir().await?;
+            let src = tmp_dir.join("src");
+            let dst = tmp_dir.join("dst");
+            let depth = 10;
+            let files_per_level = 5;
+            let limit = 4;
+            // create a deep tree in src; dst stays empty
+            let mut dir = src.clone();
+            for level in 0..depth {
+                tokio::fs::create_dir_all(&dir).await?;
+                for f in 0..files_per_level {
+                    tokio::fs::write(dir.join(format!("f{}_{}.txt", level, f)), "x").await?;
+                }
+                dir = dir.join(format!("d{}", level));
+            }
+            tokio::fs::create_dir(&dst).await?;
+            throttle::set_max_open_files(limit);
+            let compare_settings = Settings {
+                fail_early: false,
+                exit_early: false,
+                expand_missing: true,
+                compare: enum_map::enum_map! {
+                    ObjType::File => filecmp::MetadataCmpSettings::default(),
+                    ObjType::Dir => filecmp::MetadataCmpSettings::default(),
+                    ObjType::Symlink => filecmp::MetadataCmpSettings::default(),
+                    ObjType::Other => filecmp::MetadataCmpSettings::default(),
+                },
+                filter: None,
+            };
+            let summary = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                cmp(
+                    &PROGRESS,
+                    &src,
+                    &dst,
+                    &LogWriter::silent().await?,
+                    &compare_settings,
+                ),
+            )
+            .await
+            .context("cmp timed out — possible deadlock")?
+            .context("cmp failed")?;
+            // every file under src is missing on dst
+            assert_eq!(
+                summary.mismatch[ObjType::File][CompareResult::DstMissing],
+                depth * files_per_level
+            );
+            Ok(())
+        }
     }
 }

--- a/common/src/copy.rs
+++ b/common/src/copy.rs
@@ -3867,6 +3867,82 @@ mod copy_tests {
             }
             Ok(())
         }
+
+        /// Regression: copy_file → rm cross-pool deadlock.
+        ///
+        /// Scenario: many parallel copies overwrite destinations that are
+        /// directories (so each copy_file path takes the
+        /// "remove existing then copy" branch, and rm recurses). Each copy
+        /// task holds an open-files permit during copy_file; if rm also
+        /// drew permits from the open-files pool, a saturated pool would
+        /// deadlock — every permit held by a copy task waiting for rm to
+        /// release one. Decoupling rm onto pending-meta avoids that.
+        #[tokio::test]
+        #[traced_test]
+        async fn parallel_overwrite_dir_with_file_no_deadlock() -> Result<(), anyhow::Error> {
+            let tmp_dir = testutils::create_temp_dir().await?;
+            let src = tmp_dir.join("src");
+            let dst = tmp_dir.join("dst");
+            tokio::fs::create_dir(&src).await?;
+            tokio::fs::create_dir(&dst).await?;
+            // 8 sources are regular files; the 8 corresponding destinations
+            // are directories with nested files — copy with --overwrite
+            // forces rm of each dst directory tree from inside copy_file.
+            let n = 8;
+            for i in 0..n {
+                tokio::fs::write(src.join(format!("e{}", i)), format!("file-{}", i)).await?;
+                let dst_subdir = dst.join(format!("e{}", i));
+                tokio::fs::create_dir(&dst_subdir).await?;
+                for j in 0..3 {
+                    tokio::fs::write(
+                        dst_subdir.join(format!("inner_{}.txt", j)),
+                        format!("inner-{}-{}", i, j),
+                    )
+                    .await?;
+                }
+            }
+            // Saturate the open-files pool: if rm shared this pool, every
+            // outer copy task would hold its single permit and the inner rm
+            // recursion would block forever.
+            throttle::set_max_open_files(2);
+            let summary = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                copy(
+                    &PROGRESS,
+                    &src,
+                    &dst,
+                    &Settings {
+                        dereference: false,
+                        fail_early: true,
+                        overwrite: true,
+                        overwrite_compare: Default::default(),
+                        overwrite_filter: None,
+                        ignore_existing: false,
+                        chunk_size: 0,
+                        skip_specials: false,
+                        remote_copy_buffer_size: 0,
+                        filter: None,
+                        dry_run: None,
+                    },
+                    &NO_PRESERVE_SETTINGS,
+                    false,
+                ),
+            )
+            .await
+            .context(
+                "copy timed out — deadlock between copy_file's open-files permit and inner rm",
+            )?
+            .context("copy failed")?;
+            assert_eq!(summary.files_copied, n);
+            assert_eq!(summary.rm_summary.files_removed, n * 3);
+            assert_eq!(summary.rm_summary.directories_removed, n);
+            for i in 0..n {
+                let path = dst.join(format!("e{}", i));
+                let content = tokio::fs::read_to_string(&path).await?;
+                assert_eq!(content, format!("file-{}", i));
+            }
+            Ok(())
+        }
     }
 
     mod skip_specials_tests {

--- a/common/src/link.rs
+++ b/common/src/link.rs
@@ -205,9 +205,12 @@ pub async fn link(
             }
         }
     }
-    link_internal(prog_track, cwd, src, dst, src, update, settings, is_fresh).await
+    link_internal(
+        prog_track, cwd, src, dst, src, update, settings, is_fresh, None,
+    )
+    .await
 }
-#[instrument(skip(prog_track, settings))]
+#[instrument(skip(prog_track, settings, open_file_guard))]
 #[async_recursion]
 #[allow(clippy::too_many_arguments)]
 async fn link_internal(
@@ -219,6 +222,7 @@ async fn link_internal(
     update: &Option<std::path::PathBuf>,
     settings: &Settings,
     mut is_fresh: bool,
+    open_file_guard: Option<throttle::OpenFileGuard>,
 ) -> Result<Summary, Error> {
     let _prog_guard = prog_track.ops.guard();
     tracing::debug!("reading source metadata");
@@ -268,6 +272,15 @@ async fn link_internal(
                 update,
                 update_metadata.file_type()
             );
+            // release any caller-supplied open-files permit before delegating
+            // to copy::copy. The permit was acquired for the src entry's file
+            // type at the spawn site, but here `update` has a *different* file
+            // type (we just checked `!is_file_type_same`), so the permit is
+            // mismatched. More importantly, copy::copy → copy_internal will
+            // acquire its own open-files permit for any file it copies; if we
+            // were still holding one here, a saturated pool would deadlock the
+            // inner acquire.
+            drop(open_file_guard);
             let copy_summary = copy::copy(
                 prog_track,
                 update,
@@ -301,7 +314,14 @@ async fn link_internal(
                 src,
                 update
             );
-            let _open_file_guard = throttle::open_file_permit().await;
+            // use the caller's pre-acquired permit (the spawn loop pre-acquires
+            // for regular-file entries so this is the common path); fall back to
+            // acquiring a new one for callers that don't pre-acquire (top-level
+            // `link` and the file-type-changed path above).
+            let _guard = match open_file_guard {
+                Some(g) => g,
+                None => throttle::open_file_permit().await,
+            };
             return Ok(Summary {
                 copy_summary: copy::copy_file(
                     prog_track,
@@ -614,6 +634,7 @@ async fn link_internal(
                         &update_path,
                         &settings,
                         true,
+                        None,
                     )
                     .await
                 };
@@ -629,6 +650,17 @@ async fn link_internal(
         }
         let settings = settings.clone();
         let source_root = source_root.to_owned();
+        // for regular-file entries, acquire the open file permit BEFORE spawning so
+        // we don't create unbounded tasks. mirrors the pattern in copy.rs.
+        // directories must NOT pre-acquire because they recurse and would deadlock
+        // against a saturated semaphore. symlinks aren't pre-acquired because they
+        // can pass through to copy::copy which handles permits internally.
+        let entry_is_regular_file = entry_file_type.as_ref().is_some_and(|ft| ft.is_file());
+        let open_file_guard = if entry_is_regular_file {
+            Some(throttle::open_file_permit().await)
+        } else {
+            None
+        };
         let do_link = || async move {
             link_internal(
                 prog_track,
@@ -639,6 +671,7 @@ async fn link_internal(
                 &update_path,
                 &settings,
                 is_fresh,
+                open_file_guard,
             )
             .await
         };
@@ -655,7 +688,21 @@ async fn link_internal(
             .await
             .with_context(|| format!("cannot open directory {:?} for reading", &update))
             .map_err(|err| Error::new(err, link_summary))?;
-        // iterate through update entries and for each one that's not present in src call "copy"
+        // Iterate through update entries and for each one that's not present in src call "copy".
+        //
+        // We deliberately do NOT pre-acquire any permit here. Two cycles rule out the
+        // straightforward options:
+        //   * `open_file_permit`: copy::copy → copy_internal re-acquires open-files for
+        //     each file; a saturated pool would deadlock the inner acquire if we held one
+        //     across the call.
+        //   * `pending_meta_permit`: with --overwrite, copy::copy → copy_file → rm::rm
+        //     drains pending_meta for child entries (rm.rs spawn loop). N tasks here each
+        //     holding a pending_meta permit would deadlock waiting on each other's inner rm.
+        //
+        // The spawn count at this site is naturally bounded by the number of update-only
+        // entries (user input — typically modest) and per-task tokio overhead is small.
+        // Each spawned task's actual work is throttled by copy::copy's own internal
+        // open-files backpressure inside copy_internal's spawn loop.
         loop {
             let Some((update_entry, _entry_file_type)) = crate::walk::next_entry_probed(
                 &mut update_entries,
@@ -2439,5 +2486,249 @@ mod link_tests {
         assert_eq!(summary.hard_links_created, 0);
         assert!(!dst.exists());
         Ok(())
+    }
+
+    /// Stress tests exercising max-open-files saturation during link.
+    mod max_open_files_tests {
+        use super::*;
+
+        /// deep + wide link: directory tree deeper than the open-files limit, with files
+        /// at every level. verifies no deadlock occurs (directories don't consume permits).
+        #[tokio::test]
+        #[traced_test]
+        async fn deep_tree_no_deadlock_under_open_files_saturation() -> Result<(), anyhow::Error> {
+            let tmp_dir = testutils::create_temp_dir().await?;
+            let src = tmp_dir.join("src");
+            let dst = tmp_dir.join("dst");
+            let depth = 20;
+            let files_per_level = 5;
+            let limit = 4;
+            // create a directory chain deeper than the permit limit, with files at each level
+            let mut dir = src.clone();
+            for level in 0..depth {
+                tokio::fs::create_dir_all(&dir).await?;
+                for f in 0..files_per_level {
+                    tokio::fs::write(
+                        dir.join(format!("f{}_{}.txt", level, f)),
+                        format!("L{}F{}", level, f),
+                    )
+                    .await?;
+                }
+                dir = dir.join(format!("d{}", level));
+            }
+            throttle::set_max_open_files(limit);
+            let summary = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                link(
+                    &PROGRESS,
+                    tmp_dir.as_path(),
+                    &src,
+                    &dst,
+                    &None,
+                    &common_settings(false, false),
+                    false,
+                ),
+            )
+            .await
+            .context("link timed out — possible deadlock")?
+            .context("link failed")?;
+            assert_eq!(summary.hard_links_created, depth * files_per_level);
+            assert_eq!(summary.copy_summary.directories_created, depth);
+            // spot-check that hard links work by reading content at a few levels
+            let mut check_dir = dst.clone();
+            for level in 0..depth {
+                let content =
+                    tokio::fs::read_to_string(check_dir.join(format!("f{}_0.txt", level))).await?;
+                assert_eq!(content, format!("L{}F0", level));
+                check_dir = check_dir.join(format!("d{}", level));
+            }
+            Ok(())
+        }
+
+        /// Regression: link_internal's spawn-time guard must be released before
+        /// delegating to copy::copy on the file-type-changed path.
+        ///
+        /// Scenario: many src entries are regular files (so the spawn loop
+        /// pre-acquires open-files permits for them), but the corresponding
+        /// `update` entries are directories (file types differ). link_internal
+        /// then calls copy::copy on the update directory, which enters
+        /// copy_internal. If the spawn-time permit were still held while
+        /// copy::copy ran, copy_internal's own open-files acquire for any
+        /// inner file would deadlock against a saturated pool.
+        #[tokio::test]
+        #[traced_test]
+        async fn parallel_update_filetype_change_no_deadlock() -> Result<(), anyhow::Error> {
+            let tmp_dir = testutils::create_temp_dir().await?;
+            let src = tmp_dir.join("src");
+            let update = tmp_dir.join("update");
+            let dst = tmp_dir.join("dst");
+            tokio::fs::create_dir(&src).await?;
+            tokio::fs::create_dir(&update).await?;
+            let n = 8;
+            // src/eN: regular files. update/eN: directories with inner files.
+            // file types differ -> link takes the !is_file_type_same branch
+            // -> calls copy::copy(update/eN, dst/eN).
+            for i in 0..n {
+                tokio::fs::write(src.join(format!("e{}", i)), format!("src-{}", i)).await?;
+                let upd_subdir = update.join(format!("e{}", i));
+                tokio::fs::create_dir(&upd_subdir).await?;
+                for j in 0..3 {
+                    tokio::fs::write(
+                        upd_subdir.join(format!("inner_{}.txt", j)),
+                        format!("upd-{}-{}", i, j),
+                    )
+                    .await?;
+                }
+            }
+            // saturate the open-files pool: spawn-time permits held by every
+            // outer link task would block copy::copy's inner permit acquires.
+            throttle::set_max_open_files(2);
+            let summary = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                link(
+                    &PROGRESS,
+                    tmp_dir.as_path(),
+                    &src,
+                    &dst,
+                    &Some(update.clone()),
+                    &common_settings(false, false),
+                    false,
+                ),
+            )
+            .await
+            .context(
+                "link timed out — caller-supplied open-files guard not released before copy::copy",
+            )?
+            .context("link failed")?;
+            // every entry was a type-mismatch -> copied from update.
+            // copy::copy on a directory creates the dir and copies inner files.
+            assert_eq!(summary.copy_summary.directories_created, n + 1); // +1 for dst itself
+            assert_eq!(summary.copy_summary.files_copied, n * 3);
+            // verify content came from update, not src
+            for i in 0..n {
+                for j in 0..3 {
+                    let content =
+                        tokio::fs::read_to_string(dst.join(format!("e{}/inner_{}.txt", i, j)))
+                            .await?;
+                    assert_eq!(content, format!("upd-{}-{}", i, j));
+                }
+            }
+            Ok(())
+        }
+
+        /// Regression: the "update-only entries" spawn loop must not deadlock
+        /// against copy::copy's open-files OR against rm::rm's pending-meta.
+        ///
+        /// Scenario: update has many regular files that don't exist in src.
+        /// The loop at site 3 spawns a copy::copy task per entry under a
+        /// saturated open-files pool. copy::copy's internal acquires must
+        /// proceed normally — site 3 must not be holding open-files.
+        #[tokio::test]
+        #[traced_test]
+        async fn update_only_entries_bounded_no_deadlock() -> Result<(), anyhow::Error> {
+            let tmp_dir = testutils::create_temp_dir().await?;
+            let src = tmp_dir.join("src");
+            let update = tmp_dir.join("update");
+            let dst = tmp_dir.join("dst");
+            tokio::fs::create_dir(&src).await?;
+            tokio::fs::create_dir(&update).await?;
+            // src is empty; update has many regular files. Every update entry
+            // is "missing in src" -> hits the site-3 spawn loop.
+            let n = 50;
+            for i in 0..n {
+                tokio::fs::write(update.join(format!("u{}", i)), format!("upd-{}", i)).await?;
+            }
+            throttle::set_max_open_files(2);
+            let summary = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                link(
+                    &PROGRESS,
+                    tmp_dir.as_path(),
+                    &src,
+                    &dst,
+                    &Some(update.clone()),
+                    &common_settings(false, false),
+                    false,
+                ),
+            )
+            .await
+            .context("link timed out — site-3 spawn loop deadlock")?
+            .context("link failed")?;
+            // dst gets the src directory plus a copy of every update file
+            assert_eq!(summary.copy_summary.directories_created, 1);
+            assert_eq!(summary.copy_summary.files_copied, n);
+            for i in 0..n {
+                let content = tokio::fs::read_to_string(dst.join(format!("u{}", i))).await?;
+                assert_eq!(content, format!("upd-{}", i));
+            }
+            Ok(())
+        }
+
+        /// Regression for the link site-3 ↔ rm pending-meta self-deadlock.
+        ///
+        /// Scenario: update has many entries not in src; dst already has
+        /// directories at those same names; the user passes --overwrite. Each
+        /// site-3 task runs copy::copy → copy_file → rm::rm to remove the
+        /// preexisting dst directory before placing the regular-file copy.
+        /// rm::rm draws from the pending-meta pool. If site 3 also held
+        /// pending-meta across copy::copy, every running task would hold a
+        /// permit while waiting on inner rm to acquire one — classic
+        /// self-deadlock once the pool is saturated.
+        #[tokio::test]
+        #[traced_test]
+        async fn update_only_overwrite_preexisting_dirs_no_deadlock() -> Result<(), anyhow::Error> {
+            let tmp_dir = testutils::create_temp_dir().await?;
+            let src = tmp_dir.join("src");
+            let update = tmp_dir.join("update");
+            let dst = tmp_dir.join("dst");
+            tokio::fs::create_dir(&src).await?;
+            tokio::fs::create_dir(&update).await?;
+            tokio::fs::create_dir(&dst).await?;
+            let n = 12;
+            for i in 0..n {
+                // update/uN is a regular file (site 3 will copy it).
+                tokio::fs::write(update.join(format!("u{}", i)), format!("upd-{}", i)).await?;
+                // dst/uN is a preexisting directory with inner files. With
+                // --overwrite, copy_file calls rm::rm to wipe it, which
+                // recurses into pending-meta.
+                let dst_subdir = dst.join(format!("u{}", i));
+                tokio::fs::create_dir(&dst_subdir).await?;
+                for j in 0..3 {
+                    tokio::fs::write(
+                        dst_subdir.join(format!("inner_{}.txt", j)),
+                        format!("old-{}-{}", i, j),
+                    )
+                    .await?;
+                }
+            }
+            // saturate both pools to force the deadlock if the cycle existed.
+            throttle::set_max_open_files(2);
+            let summary = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                link(
+                    &PROGRESS,
+                    tmp_dir.as_path(),
+                    &src,
+                    &dst,
+                    &Some(update.clone()),
+                    &common_settings(false, true), // overwrite=true
+                    false,
+                ),
+            )
+            .await
+            .context("link timed out — pending-meta self-deadlock between site 3 and inner rm")?
+            .context("link failed")?;
+            // each preexisting dst/uN directory gets removed and replaced
+            // with a regular-file copy from update/uN.
+            assert_eq!(summary.copy_summary.files_copied, n);
+            assert_eq!(summary.copy_summary.rm_summary.files_removed, n * 3);
+            assert_eq!(summary.copy_summary.rm_summary.directories_removed, n);
+            // verify content came from update
+            for i in 0..n {
+                let content = tokio::fs::read_to_string(dst.join(format!("u{}", i))).await?;
+                assert_eq!(content, format!("upd-{}", i));
+            }
+            Ok(())
+        }
     }
 }

--- a/common/src/rm.rs
+++ b/common/src/rm.rs
@@ -312,8 +312,27 @@ async fn rm_internal(
         }
         let settings = settings.clone();
         let source_root = source_root.to_owned();
-        let do_rm =
-            || async move { rm_internal(prog_track, &entry_path, &source_root, &settings).await };
+        // for positively-known leaf entries (files, symlinks, special),
+        // acquire the pending-meta permit BEFORE spawning so we don't create
+        // unbounded tasks. We deliberately skip pre-acquire when
+        // `entry_file_type` is None (file_type() lookup failed): the entry
+        // could actually be a directory, and a chain of such unknown-typed
+        // directories holding permits while recursing would deadlock the
+        // pending-meta pool. Directories also skip pre-acquire for the same
+        // reason. We use the pending-meta semaphore (not open-files) because
+        // rm operations don't hold fds — and rm is reachable from copy_file's
+        // overwrite path, which already holds an open-files permit; using a
+        // distinct semaphore avoids that cross-pool deadlock.
+        let known_leaf = entry_file_type.as_ref().is_some_and(|ft| !ft.is_dir());
+        let pending_guard = if known_leaf {
+            Some(throttle::pending_meta_permit().await)
+        } else {
+            None
+        };
+        let do_rm = || async move {
+            let _pending_guard = pending_guard;
+            rm_internal(prog_track, &entry_path, &source_root, &settings).await
+        };
         join_set.spawn(do_rm());
     }
     // unfortunately ReadDir is opening file-descriptors and there's not a good way to limit this,
@@ -1555,6 +1574,121 @@ mod tests {
                 "root file too new should be skipped"
             );
             assert!(new_file.exists(), "root file should still exist");
+            Ok(())
+        }
+    }
+
+    /// Stress tests exercising max-open-files saturation during rm.
+    mod max_open_files_tests {
+        use super::*;
+
+        /// wide rm: many files with a very low open-files limit.
+        /// verifies all files are removed correctly under permit saturation.
+        #[tokio::test]
+        #[traced_test]
+        async fn wide_rm_under_open_files_saturation() -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let file_count = 200;
+            for i in 0..file_count {
+                tokio::fs::write(
+                    test_path.join(format!("{}.txt", i)),
+                    format!("content-{}", i),
+                )
+                .await?;
+            }
+            // set a very low limit to force permit contention
+            throttle::set_max_open_files(4);
+            let summary = rm(
+                &PROGRESS,
+                &test_path,
+                &Settings {
+                    fail_early: true,
+                    filter: None,
+                    dry_run: None,
+                    time_filter: None,
+                },
+            )
+            .await?;
+            assert_eq!(summary.files_removed, file_count);
+            assert_eq!(summary.directories_removed, 1);
+            assert!(!test_path.exists());
+            Ok(())
+        }
+
+        /// deep + wide rm: directory tree deeper than the open-files limit, with files
+        /// at every level. verifies no deadlock occurs (directories don't consume permits).
+        #[tokio::test]
+        #[traced_test]
+        async fn deep_tree_no_deadlock_under_open_files_saturation() -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let depth = 20;
+            let files_per_level = 5;
+            let limit = 4;
+            // create a directory chain deeper than the permit limit, with files at each level
+            let mut dir = test_path.clone();
+            for level in 0..depth {
+                tokio::fs::create_dir_all(&dir).await?;
+                for f in 0..files_per_level {
+                    tokio::fs::write(
+                        dir.join(format!("f{}_{}.txt", level, f)),
+                        format!("L{}F{}", level, f),
+                    )
+                    .await?;
+                }
+                dir = dir.join(format!("d{}", level));
+            }
+            throttle::set_max_open_files(limit);
+            let summary = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                rm(
+                    &PROGRESS,
+                    &test_path,
+                    &Settings {
+                        fail_early: true,
+                        filter: None,
+                        dry_run: None,
+                        time_filter: None,
+                    },
+                ),
+            )
+            .await
+            .context("rm timed out — possible deadlock")?
+            .context("rm failed")?;
+            assert_eq!(summary.files_removed, depth * files_per_level);
+            assert_eq!(summary.directories_removed, depth);
+            assert!(!test_path.exists());
+            Ok(())
+        }
+
+        /// Locks down the boolean used at the rm spawn site to decide whether
+        /// to pre-acquire a pending-meta permit. A naive `entry_is_dir = false
+        /// ⇒ pre-acquire` policy treats unknown-typed entries (when
+        /// `DirEntry::file_type()` fails) as leaves, so the spawned task
+        /// holds the permit even if the entry is actually a directory and
+        /// recurses. A chain of such entries can deadlock the pool. The
+        /// safer pattern — `pre-acquire iff positively-known-not-directory`
+        /// — keeps the predicate `false` for unknown types.
+        #[test]
+        fn pre_acquire_skips_unknown_filetype() -> Result<(), anyhow::Error> {
+            let tmp = std::env::temp_dir().join(format!(
+                "rcp_pre_acquire_test_{}_{}",
+                std::process::id(),
+                rand::random::<u64>()
+            ));
+            std::fs::create_dir(&tmp)?;
+            let dir_path = tmp.join("d");
+            std::fs::create_dir(&dir_path)?;
+            let file_path = tmp.join("f");
+            std::fs::write(&file_path, "x")?;
+            let dir_ft = std::fs::metadata(&dir_path)?.file_type();
+            let file_ft = std::fs::metadata(&file_path)?.file_type();
+            // The exact predicate used in the rm spawn site:
+            let known_leaf =
+                |ft: Option<std::fs::FileType>| ft.as_ref().is_some_and(|t| !t.is_dir());
+            assert!(!known_leaf(None), "unknown filetype must skip pre-acquire");
+            assert!(!known_leaf(Some(dir_ft)), "directory must skip pre-acquire");
+            assert!(known_leaf(Some(file_ft)), "regular file must pre-acquire");
+            std::fs::remove_dir_all(&tmp).ok();
             Ok(())
         }
     }

--- a/throttle/src/lib.rs
+++ b/throttle/src/lib.rs
@@ -168,6 +168,15 @@ pub enum Resource {
 
 static OPEN_FILES_LIMIT: std::sync::LazyLock<semaphore::Semaphore> =
     std::sync::LazyLock::new(semaphore::Semaphore::new);
+// Spawn-time backpressure for operations that don't actually hold open
+// file descriptors but still benefit from a bound on in-flight tasks
+// (rm, cmp). Kept separate from OPEN_FILES_LIMIT so that an inner rm
+// triggered by a copy/link path that already holds an OPEN_FILES_LIMIT
+// permit cannot deadlock against itself when the outer permit pool is
+// saturated. Both semaphores are sized to the same configured limit by
+// `set_max_open_files`.
+static PENDING_META_LIMIT: std::sync::LazyLock<semaphore::Semaphore> =
+    std::sync::LazyLock::new(semaphore::Semaphore::new);
 static OPS_THROTTLE: std::sync::LazyLock<semaphore::Semaphore> =
     std::sync::LazyLock::new(semaphore::Semaphore::new);
 static IOPS_THROTTLE: std::sync::LazyLock<semaphore::Semaphore> =
@@ -187,8 +196,23 @@ fn ops_in_flight_limit(resource: Resource) -> &'static semaphore::Semaphore {
     }
 }
 
+/// Configure the spawn-time concurrency caps from a single knob.
+///
+/// Despite the name, this sizes **two** independent semaphores:
+///
+/// * [`open_file_permit`] — actual file-descriptor backpressure for
+///   paths that hold open fds (copy/link).
+/// * [`pending_meta_permit`] — task-spawn backpressure for recursive
+///   metadata-only walks (rm/cmp) that don't hold fds. Sized
+///   separately so paths that compose these operations
+///   (e.g. `copy_file → rm` for an overwrite of a directory
+///   destination) cannot deadlock against the open-files pool.
+///
+/// Pass `0` to disable both caps; `setup` is idempotent and intended
+/// for startup or test reset.
 pub fn set_max_open_files(max_open_files: usize) {
     OPEN_FILES_LIMIT.setup(max_open_files);
+    PENDING_META_LIMIT.setup(max_open_files);
 }
 
 pub struct OpenFileGuard {
@@ -198,6 +222,24 @@ pub struct OpenFileGuard {
 pub async fn open_file_permit() -> OpenFileGuard {
     OpenFileGuard {
         _permit: OPEN_FILES_LIMIT.acquire().await,
+    }
+}
+
+/// Backpressure guard for in-flight metadata-only operations (rm, cmp).
+///
+/// Held across a spawned task to bound the live task count under
+/// recursive walk operations that don't hold open file descriptors.
+/// Kept distinct from [`OpenFileGuard`] so that paths which compose
+/// these operations (e.g. `copy_file → rm` for an overwrite of a
+/// directory destination) don't deadlock against a saturated
+/// `OPEN_FILES_LIMIT`.
+pub struct PendingMetaGuard {
+    _permit: Option<semaphore::Permit<'static>>,
+}
+
+pub async fn pending_meta_permit() -> PendingMetaGuard {
+    PendingMetaGuard {
+        _permit: PENDING_META_LIMIT.acquire().await,
     }
 }
 


### PR DESCRIPTION
## Summary

- **rrm and rcmp**: accepted `--max-open-files` but never consumed the limit — recursive walks were effectively unbounded. Now they apply spawn-time backpressure on a new `pending_meta_permit` semaphore.
- **rlink**: previously had no spawn-time backpressure; now applies it on `open_file_permit` for known-regular-file entries (matching `copy.rs`).
- A new `pending_meta_permit` semaphore in `throttle/` decouples rm/cmp's backpressure from `open_file_permit`, breaking the deadlock cycle through `copy_file → rm::rm`.
- All cross-module callsites that compose tools (`link → copy::copy → rm::rm`) were audited: any site that held a permit across the call now either drops it first or doesn't acquire one.
- Spawn-site predicates use `is_some_and(|ft| !ft.is_dir())` — only pre-acquire when positively known to be a leaf, so an unknown-typed entry that turns out to be a directory can't deadlock the pool through its recursion.

## Test plan

- [x] Unit + integration suite (`just test`): 801/801 pass
- [x] Lints + doctests + formatting (`just lint && just doctest`): green
- [x] 12 deadlock/saturation regressions covering:
  - wide and deep tree rm/copy/link under `max_open_files=4`
  - cmp deep tree + expand-missing under saturation
  - `copy_file → rm` cycle (overwrite a preexisting directory with a file in parallel)
  - `link → copy::copy` cycle (file-type-changed update path)
  - link site-3 spawn loop under saturation
  - `link site 3 → copy_file → rm` pending-meta self-deadlock (overwrite preexisting directories at update-entry names)
- [x] Each regression verified to **fail at 30s timeout** when its corresponding fix is reverted, then restored