### PR TITLE
Generalize signal to two-window ratio + rename Vegas → Ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ filesystem latency and adjusts concurrency on the fly.
 
 ### Adaptive metadata throttling (`--auto-meta-throttle`)
 
-Pass `--auto-meta-throttle` to enable a Vegas-style latency controller
+Pass `--auto-meta-throttle` to enable a latency-ratio controller
 that watches per-op latency and grows or shrinks the in-flight
 concurrency cap (`cwnd`) on the fly. The controller stays just below
 the saturation point of whatever metadata path the tool is hitting —
@@ -249,10 +249,10 @@ actually observes.
 
 **Tuning knobs** (all listed under `--help-all` on each binary): the
 initial / minimum / maximum `cwnd`, the grow/shrink ratio thresholds
-(`alpha`, `beta`), the percentile used to summarize each window, the
-long / short window durations, per-tick step sizes, and the
-control-loop tick cadence. Defaults are conservative and a good
-starting point.
+(`alpha`, `beta`), the baseline / current percentiles used to
+summarize the long and short windows, the long / short window
+durations, per-tick step sizes, and the control-loop tick cadence.
+Defaults are conservative and a good starting point.
 
 For the design rationale (why concurrency is the lever, what
 `cwnd` is, the exact control law including worked ratio→action

--- a/common/src/cli.rs
+++ b/common/src/cli.rs
@@ -71,7 +71,7 @@ pub struct CommonArgs {
     )]
     pub max_blocking_threads: usize,
     // Congestion control (experimental, opt-in)
-    /// Enable adaptive metadata-ops throttling (Vegas-style latency controller)
+    /// Enable adaptive metadata-ops throttling (latency-ratio controller)
     #[arg(long, help_heading = "Congestion control")]
     pub auto_meta_throttle: bool,
     /// Initial concurrency window for adaptive metadata throttle
@@ -99,8 +99,12 @@ pub struct CommonArgs {
     )]
     pub auto_meta_max_cwnd: u32,
     /// Latency ratio below which cwnd grows (current / baseline).
-    /// Default 1.1: with matched-percentile signal, ratio sits near 1.0
-    /// at steady state, so a tight alpha is the right scale.
+    /// Default 1.1. `alpha` may be set below 1.0 in passive mode (grow
+    /// only when recent is meaningfully faster than baseline). The
+    /// natural scale depends on the percentile pair: matched percentiles
+    /// produce a steady-state ratio of 1.0; cross percentiles produce a
+    /// ratio above 1.0 set by the inter-quantile spread of the latency
+    /// distribution.
     #[arg(
         long,
         default_value = "1.1",
@@ -116,17 +120,29 @@ pub struct CommonArgs {
         help_heading = "Congestion control (advanced)"
     )]
     pub auto_meta_beta: f64,
-    /// Percentile (in `(0.0, 1.0)`) used to summarize each sample window.
-    /// The same percentile is used for both long-horizon (baseline) and
-    /// short-horizon (current) statistics — see `--auto-meta-long-window`
-    /// and `--auto-meta-short-window`.
+    /// Percentile (in `[0.0, 1.0)`) applied to the long-horizon window
+    /// to derive the baseline statistic. With matched percentiles
+    /// (`baseline == current`) the steady-state ratio sits near 1.0;
+    /// with cross percentiles (`baseline < current`) the ratio
+    /// measures the inter-quantile spread of the latency distribution
+    /// and grows under queueing.
     #[arg(
         long,
         default_value = "0.5",
         value_name = "F",
         help_heading = "Congestion control (advanced)"
     )]
-    pub auto_meta_percentile: f64,
+    pub auto_meta_baseline_percentile: f64,
+    /// Percentile (in `[0.0, 1.0)`) applied to the short-horizon window
+    /// to derive the current statistic. Must be `>= baseline percentile`.
+    /// See `--auto-meta-baseline-percentile`.
+    #[arg(
+        long,
+        default_value = "0.5",
+        value_name = "F",
+        help_heading = "Congestion control (advanced)"
+    )]
+    pub auto_meta_current_percentile: f64,
     /// How much to grow cwnd on each under-shoot tick
     #[arg(
         long,
@@ -211,7 +227,8 @@ impl CommonArgs {
                 beta: self.auto_meta_beta,
                 increase_step: self.auto_meta_increase_step,
                 decrease_step: self.auto_meta_decrease_step,
-                percentile: self.auto_meta_percentile,
+                baseline_percentile: self.auto_meta_baseline_percentile,
+                current_percentile: self.auto_meta_current_percentile,
                 long_window: self.auto_meta_long_window.into(),
                 short_window: self.auto_meta_short_window.into(),
                 tick_interval: self.auto_meta_tick_interval.into(),

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -40,8 +40,12 @@ pub struct AutoMetaThrottleConfig {
     pub beta: f64,
     pub increase_step: u32,
     pub decrease_step: u32,
-    /// Percentile (in `(0.0, 1.0)`) used to summarize each window.
-    pub percentile: f64,
+    /// Percentile (in `[0.0, 1.0)`) applied to the long-horizon window
+    /// to derive the baseline statistic. Must be `<= current_percentile`.
+    pub baseline_percentile: f64,
+    /// Percentile (in `[0.0, 1.0)`) applied to the short-horizon window
+    /// to derive the current statistic. Must be `>= baseline_percentile`.
+    pub current_percentile: f64,
     /// Long-horizon window age. Drives the baseline statistic.
     pub long_window: std::time::Duration,
     /// Short-horizon window age. Drives the current statistic.
@@ -91,20 +95,34 @@ impl ThrottleConfig {
             if auto.min_cwnd > auto.max_cwnd {
                 return Err("auto-meta-min-cwnd must be <= auto-meta-max-cwnd".to_string());
             }
-            if !(0.0..1.0).contains(&auto.percentile) {
-                return Err("auto-meta-percentile must be in [0.0, 1.0)".to_string());
+            if !(0.0..1.0).contains(&auto.baseline_percentile) {
+                return Err("auto-meta-baseline-percentile must be in [0.0, 1.0)".to_string());
             }
-            // alpha and beta are matched-percentile ratios. At steady
-            // state both windows estimate the same population statistic
-            // so the ratio sits near 1.0; alpha < 1.0 would mean "shrink
-            // when current is faster than baseline", which is
-            // nonsensical, and beta < 1.0 would shrink the controller at
-            // its operating point.
-            if auto.alpha <= 1.0 {
-                return Err("auto-meta-alpha must be > 1.0".to_string());
+            if !(0.0..1.0).contains(&auto.current_percentile) {
+                return Err("auto-meta-current-percentile must be in [0.0, 1.0)".to_string());
             }
-            if auto.beta <= 1.0 {
-                return Err("auto-meta-beta must be > 1.0".to_string());
+            if auto.baseline_percentile > auto.current_percentile {
+                return Err(
+                    "auto-meta-baseline-percentile must be <= auto-meta-current-percentile"
+                        .to_string(),
+                );
+            }
+            // alpha and beta gate the ratio = current / baseline:
+            // ratio < alpha → grow, ratio > beta → shrink. The only
+            // hard invariant is `0 < alpha < beta`. The "natural" placement
+            // of alpha and beta relative to 1.0 depends on the percentile
+            // pair: matched percentiles produce a steady-state ratio
+            // near 1.0, while cross percentiles produce a steady-state
+            // ratio above 1.0 set by the inter-quantile spread of the
+            // latency distribution. Either case may want alpha below or
+            // above 1.0 depending on whether the operator wants the
+            // controller to actively probe past the knee or sit passively
+            // until queueing crosses the beta threshold.
+            if !auto.alpha.is_finite() || auto.alpha <= 0.0 {
+                return Err("auto-meta-alpha must be a finite value > 0".to_string());
+            }
+            if !auto.beta.is_finite() || auto.beta <= 0.0 {
+                return Err("auto-meta-beta must be a finite value > 0".to_string());
             }
             if auto.alpha >= auto.beta {
                 return Err("auto-meta-alpha must be < auto-meta-beta".to_string());
@@ -269,7 +287,8 @@ mod auto_meta_validation_tests {
             beta: 1.5,
             increase_step: 1,
             decrease_step: 1,
-            percentile: 0.5,
+            baseline_percentile: 0.5,
+            current_percentile: 0.5,
             long_window: std::time::Duration::from_secs(10),
             short_window: std::time::Duration::from_secs(1),
             tick_interval: std::time::Duration::from_millis(50),
@@ -300,25 +319,94 @@ mod auto_meta_validation_tests {
     }
 
     #[test]
-    fn alpha_at_or_below_one_is_rejected() {
+    fn alpha_at_or_below_zero_is_rejected() {
         let mut auto = valid_auto_meta();
-        auto.alpha = 1.0;
+        auto.alpha = 0.0;
         assert!(config_with(auto).validate().is_err());
         let mut auto = valid_auto_meta();
-        auto.alpha = 0.9;
+        auto.alpha = -0.5;
         assert!(config_with(auto).validate().is_err());
     }
 
     #[test]
-    fn beta_at_or_below_one_is_rejected() {
+    fn alpha_below_one_is_accepted() {
+        // Passive-controller mode: alpha < 1.0 means "grow only when
+        // recent is meaningfully faster than baseline" — the explicit
+        // use case for relaxing the previous alpha > 1.0 constraint.
         let mut auto = valid_auto_meta();
-        // alpha must be > 1.0 so the earlier alpha check passes and we
-        // isolate the beta branch. (alpha < beta is checked after the
-        // individual-bound checks, so 1.05 / 1.0 falls to the beta check.)
-        auto.alpha = 1.05;
-        auto.beta = 1.0;
+        auto.alpha = 0.9;
+        auto.beta = 1.1;
+        assert!(config_with(auto).validate().is_ok());
+    }
+
+    #[test]
+    fn beta_at_or_below_zero_is_rejected() {
+        let mut auto = valid_auto_meta();
+        auto.alpha = 0.5;
+        auto.beta = 0.0;
         let err = config_with(auto).validate().unwrap_err();
         assert!(err.contains("beta"), "got: {err}");
+    }
+
+    #[test]
+    fn cross_percentile_config_validates() {
+        // Cross-percentile mode: baseline at p40, current at p60, with
+        // alpha/beta straddling the steady-state ratio. The validator
+        // accepts both percentiles in (0, 1) with baseline <= current.
+        let mut auto = valid_auto_meta();
+        auto.baseline_percentile = 0.4;
+        auto.current_percentile = 0.6;
+        assert!(config_with(auto).validate().is_ok());
+    }
+
+    #[test]
+    fn baseline_percentile_above_current_is_rejected() {
+        let mut auto = valid_auto_meta();
+        auto.baseline_percentile = 0.6;
+        auto.current_percentile = 0.4;
+        let err = config_with(auto).validate().unwrap_err();
+        assert!(
+            err.contains("baseline-percentile") && err.contains("current-percentile"),
+            "got: {err}",
+        );
+    }
+
+    #[test]
+    fn baseline_percentile_out_of_range_is_rejected() {
+        let mut auto = valid_auto_meta();
+        auto.baseline_percentile = 1.0;
+        let err = config_with(auto).validate().unwrap_err();
+        assert!(err.contains("baseline-percentile"), "got: {err}");
+    }
+
+    #[test]
+    fn non_finite_alpha_or_beta_is_rejected() {
+        // NaN comparisons return false in either direction, so a plain
+        // `auto.alpha <= 0.0` check would silently pass NaN through and
+        // the controller would freeze in the hold band forever. The
+        // `is_finite()` guard catches that.
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let mut auto = valid_auto_meta();
+            auto.alpha = bad;
+            assert!(
+                config_with(auto).validate().is_err(),
+                "alpha={bad} must be rejected",
+            );
+            let mut auto = valid_auto_meta();
+            auto.beta = bad;
+            assert!(
+                config_with(auto).validate().is_err(),
+                "beta={bad} must be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn current_percentile_out_of_range_is_rejected() {
+        let mut auto = valid_auto_meta();
+        auto.current_percentile = 1.0;
+        let err = config_with(auto).validate().unwrap_err();
+        assert!(err.contains("current-percentile"), "got: {err}");
     }
 
     #[test]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1155,14 +1155,14 @@ const fn unit_label(side: congestion::Side, op: congestion::MetadataOp) -> &'sta
 ///    finds a permit available.
 /// 2. Install one `RoutingSink` that fans metadata samples out to per-
 ///    `(side, op)` channels, each consumed by its own
-///    `ControlUnit<VegasController>`. Each syscall on each side gets
+///    `ControlUnit<RatioController>`. Each syscall on each side gets
 ///    an independent latency baseline and an independent cwnd, so a
 ///    saturated `unlink` path doesn't drag down `stat` (or vice versa).
 /// 3. Spawn one combined adapter/monitor task per resource. By
 ///    convention `(Destination, Stat)` is the rate-driver — the global
 ///    `OPS_THROTTLE` is shared, so only one adapter may translate rate
 ///    decisions; all others apply concurrency only. The current
-///    `VegasController` doesn't emit rate decisions, so the choice is
+///    `RatioController` doesn't emit rate decisions, so the choice is
 ///    forward-looking.
 /// 4. Each adapter exits cleanly when its control unit stops
 ///    publishing decisions, so they don't leak as unbounded background
@@ -1207,7 +1207,7 @@ fn spawn_auto_meta_throttle(runtime: &tokio::runtime::Runtime, auto: AutoMetaThr
     congestion::install_sample_sink(sink.clone());
     for (label, side, op, sample_rx, apply_rate) in receivers {
         let resource = walk::meta_resource(side, op);
-        let vegas = congestion::VegasController::new(congestion::VegasConfig {
+        let controller = congestion::RatioController::new(congestion::RatioConfig {
             initial_cwnd: auto.initial_cwnd,
             min_cwnd: auto.min_cwnd,
             max_cwnd: auto.max_cwnd,
@@ -1215,12 +1215,13 @@ fn spawn_auto_meta_throttle(runtime: &tokio::runtime::Runtime, auto: AutoMetaThr
             beta: auto.beta,
             increase_step: auto.increase_step,
             decrease_step: auto.decrease_step,
-            percentile: auto.percentile,
+            baseline_percentile: auto.baseline_percentile,
+            current_percentile: auto.current_percentile,
             long_window: auto.long_window,
             short_window: auto.short_window,
         });
         let (unit, decision_rx, snapshot_rx) =
-            congestion::ControlUnit::new(label, vegas, sample_rx, auto.tick_interval);
+            congestion::ControlUnit::new(label, controller, sample_rx, auto.tick_interval);
         observability::register_unit(label, snapshot_rx);
         runtime.spawn(unit.run());
         runtime.spawn(auto_meta::run_adapter(
@@ -1232,14 +1233,16 @@ fn spawn_auto_meta_throttle(runtime: &tokio::runtime::Runtime, auto: AutoMetaThr
     }
     tracing::info!(
         "auto-meta-throttle enabled (per-(side, op) controllers, {} total): \
-         initial_cwnd={}, max_cwnd={}, alpha={}, beta={}, percentile={}, \
+         initial_cwnd={}, max_cwnd={}, alpha={}, beta={}, \
+         baseline_percentile={}, current_percentile={}, \
          long_window={:?}, short_window={:?}, tick={:?}",
         congestion::N_META_RESOURCES,
         auto.initial_cwnd,
         auto.max_cwnd,
         auto.alpha,
         auto.beta,
-        auto.percentile,
+        auto.baseline_percentile,
+        auto.current_percentile,
         auto.long_window,
         auto.short_window,
         auto.tick_interval,

--- a/common/tests/probe_metadata.rs
+++ b/common/tests/probe_metadata.rs
@@ -135,7 +135,7 @@ async fn copy_emits_one_metadata_sample_per_tree_entry() {
 }
 
 /// End-to-end integration test for the auto-meta-throttle pipeline:
-/// Probe -> RoutingSink -> ControlUnit<VegasController> -> Decision watch.
+/// Probe -> RoutingSink -> ControlUnit<RatioController> -> Decision watch.
 ///
 /// Doesn't drive throttle::set_max_ops_in_flight (that's validated in the
 /// congestion unit tests). Asserts that the full pipeline flows: running
@@ -158,9 +158,9 @@ async fn auto_meta_pipeline_propagates_probes_to_controller() {
         congestion::MetadataOp::Unlink,
     );
     congestion::install_sample_sink(std::sync::Arc::new(builder.build()));
-    let controller = congestion::VegasController::new(congestion::VegasConfig {
+    let controller = congestion::RatioController::new(congestion::RatioConfig {
         initial_cwnd: 5,
-        ..congestion::VegasConfig::default()
+        ..congestion::RatioConfig::default()
     });
     let (unit, decision_rx, mut snapshot_rx) = congestion::ControlUnit::new(
         "pipeline-test",

--- a/congestion/src/controller.rs
+++ b/congestion/src/controller.rs
@@ -85,7 +85,7 @@ impl Decision {
 /// progress bar and other observability surfaces.
 ///
 /// Snapshots are sampled — never authoritative for enforcement. They
-/// expose the same fields a Vegas-style controller reasons about
+/// expose the same fields a ratio-based controller reasons about
 /// (`cwnd`, baseline, current observed latency, sample count) so a
 /// renderer can show *why* the current `cwnd` is what it is. Controllers
 /// without a meaningful internal state (e.g. `Noop`) return
@@ -101,14 +101,15 @@ pub struct ControllerSnapshot {
     /// Current concurrency window the controller would emit on its
     /// next tick. `0` means "no cap configured."
     pub cwnd: u32,
-    /// Long-horizon baseline latency. For matched-percentile controllers
-    /// this is the configured percentile over the long sample window;
-    /// the renderer treats it as the "uncongested floor" reference.
-    /// `Duration::ZERO` if no signal yet.
+    /// Long-horizon baseline latency. For ratio-based controllers
+    /// this is the configured baseline percentile over the long sample
+    /// window; the renderer treats it as the "uncongested floor"
+    /// reference. `Duration::ZERO` if no signal yet.
     pub baseline_latency: std::time::Duration,
-    /// Short-horizon current latency. For matched-percentile controllers
-    /// this is the same percentile computed over the short sample
-    /// window. `Duration::ZERO` if no fresh samples have been observed.
+    /// Short-horizon current latency. For ratio-based controllers
+    /// this is the configured current percentile computed over the
+    /// short sample window. `Duration::ZERO` if no fresh samples have
+    /// been observed.
     pub current_latency: std::time::Duration,
     /// Cumulative number of samples the controller has consumed.
     pub samples_seen: u64,
@@ -134,7 +135,7 @@ pub trait Controller: Send {
     /// layer. The controller must return an absolute limit (not a delta).
     fn on_tick(&mut self, now: std::time::Instant) -> Decision;
     /// Short, stable identifier used in logs and metrics (e.g. "noop",
-    /// "fixed", "vegas").
+    /// "fixed", "ratio").
     fn name(&self) -> &'static str;
     /// Snapshot of the controller's observable state for diagnostics
     /// and progress display. Default returns an empty snapshot, which

--- a/congestion/src/lib.rs
+++ b/congestion/src/lib.rs
@@ -24,9 +24,10 @@
 //! - [`FixedController`] — honors a static concurrency/rate budget. Mirrors
 //!   the existing manual `--ops-throttle` / `--iops-throttle` knobs and is
 //!   the regression baseline for adaptive algorithms.
-//! - [`VegasController`] — adaptive controller that tracks queueing-delay
-//!   inflation (ratio of smoothed current latency to observed minimum)
-//!   and adjusts the concurrency cap to stay at the onset of inflation.
+//! - [`RatioController`] — adaptive controller that tracks queueing-delay
+//!   inflation by comparing two windowed latency percentiles (current vs
+//!   baseline) and adjusts the concurrency cap to stay at the onset of
+//!   inflation. Inspired by TCP Vegas.
 //!
 //! Additional adaptive variants (for example BBR-style) can be layered
 //! on the same trait without changes to the enforcement or control-loop
@@ -43,9 +44,9 @@ mod controller;
 mod fixed;
 mod measurement;
 mod noop;
+mod ratio;
 pub mod sim;
 pub mod testing;
-mod vegas;
 
 pub use control_loop::{ControlUnit, DEFAULT_TICK_INTERVAL, RoutingSink, RoutingSinkBuilder};
 pub use controller::{Controller, ControllerSnapshot, Decision, Outcome, Sample};
@@ -55,4 +56,4 @@ pub use measurement::{
     clear_sample_sink, install_sample_sink,
 };
 pub use noop::NoopController;
-pub use vegas::{VegasConfig, VegasController};
+pub use ratio::{RatioConfig, RatioController};

--- a/congestion/src/measurement.rs
+++ b/congestion/src/measurement.rs
@@ -36,9 +36,11 @@ pub enum Side {
 /// distributions differ — `stat` (pure lookup) and `unlink` (mutation
 /// plus parent-directory write) hit different code paths on the
 /// metadata server and converge on very different baselines. Mixing
-/// them in one controller pollutes the per-op latency signal and makes
-/// the matched-percentile baseline drift with operation-mix changes
-/// that have nothing to do with congestion.
+/// them in one controller pollutes the per-op latency signal: the
+/// resulting ratio drifts with operation-mix changes that have nothing
+/// to do with congestion (the long-window baseline percentile shifts
+/// as the mix changes, and in cross mode the inter-quantile spread
+/// becomes a function of the mix rather than the load).
 ///
 /// The variants are ordered so they index a fixed-size array when paired
 /// with a [`Side`]; see [`N_META_OPS`].

--- a/congestion/src/ratio.rs
+++ b/congestion/src/ratio.rs
@@ -1,40 +1,51 @@
-//! Latency-based adaptive controller using matched-window percentile statistics.
+//! Latency-based adaptive controller using two-window percentile statistics.
 //!
 //! The controller maintains a single sliding window of recent operation
 //! latencies and, on every tick, derives two summary statistics from it:
 //!
-//! - **Baseline** — the configured percentile (default p50) over the full
-//!   long-horizon window (default 10s).
-//! - **Current** — the same percentile computed over a subset of the most
-//!   recent samples (default 1s).
+//! - **Baseline** — the `baseline_percentile` over the full long-horizon
+//!   window (default 10s).
+//! - **Current** — the `current_percentile` computed over a subset of the
+//!   most recent samples (default 1s).
 //!
-//! Their ratio drives the control law:
+//! Their ratio (`current / baseline`) drives the control law,
+//! parameterized by two thresholds `alpha < beta`:
 //!
-//! - `ratio < alpha` → the recent distribution looks at least as fast as
-//!   the long-horizon one; grow concurrency.
-//! - `ratio > beta`  → the recent distribution has shifted to slower
-//!   latencies, indicating queue build-up; shrink concurrency.
+//! - `ratio < alpha` → grow concurrency. The recent distribution sits
+//!   below the alpha threshold relative to baseline; with `alpha > 1.0`
+//!   that includes "recent slightly slower than baseline" (active mode
+//!   probing for headroom), with `alpha < 1.0` it requires the recent
+//!   distribution to be meaningfully *faster* than baseline (passive
+//!   mode).
+//! - `ratio > beta`  → shrink. Recent is meaningfully slower than
+//!   baseline (or, in cross mode, the inter-quantile spread has widened
+//!   past the beta threshold) — queue build-up signal.
 //! - otherwise       → hold.
 //!
-//! ## Why matched percentiles
+//! ## Choosing the two percentiles
 //!
 //! Real metadata syscalls on networked filesystems (Weka, Lustre, NFS) have
 //! per-op latency variance that routinely spans an order of magnitude even
-//! at fixed `cwnd` and steady offered load. Comparing a baseline percentile
-//! (e.g. p10) against the *mean* of recent latencies — the original Vegas
-//! shape — produces a ratio that sits naturally above 1.0 even at idle,
-//! purely because of the heavy-tailed shape of the distribution. The
-//! controller would then need very loose `alpha` / `beta` thresholds to
-//! avoid mistaking that natural inflation for queueing, and the loose
-//! thresholds in turn left a wide hold band where genuine load growth
-//! could not be distinguished from variance.
+//! at fixed `cwnd` and steady offered load.
 //!
-//! Comparing the *same* percentile across two time windows cancels the
-//! distribution-shape contribution: at steady state both windows estimate
-//! the same population statistic, so the ratio approaches 1.0 regardless
-//! of how heavy-tailed the distribution is. A non-1.0 ratio reflects an
-//! actual shift in the latency distribution between the two horizons —
-//! exactly the queue-build-up signal we want to act on.
+//! - **Matched percentiles** (`baseline_percentile == current_percentile`,
+//!   e.g. both at p50): at steady state both windows estimate the same
+//!   population statistic, so the ratio sits near 1.0 regardless of
+//!   how heavy-tailed the distribution is. Distribution shape cancels;
+//!   defaults travel cleanly across filesystems. The trade-off: matched
+//!   percentiles cancel the *level* of queueing once both windows have
+//!   equilibrated to it, so the controller can only see *changes* in load,
+//!   not steady-state queueing.
+//! - **Cross percentiles** (`baseline_percentile < current_percentile`,
+//!   e.g. p40 baseline / p60 current): the ratio measures the inter-quantile
+//!   spread of the recent distribution, which is a direct queueing signal —
+//!   queueing fattens the upper tail asymmetrically, so the spread grows
+//!   with offered load even at steady state. The trade-off: the steady-state
+//!   ratio depends on the per-syscall distribution shape, so `alpha` and
+//!   `beta` may need per-filesystem tuning.
+//!
+//! Defaults ship matched (both percentiles at 0.5); cross-percentile mode
+//! is reachable by setting the two flags differently.
 //!
 //! ## Why a single window holding all samples
 //!
@@ -52,13 +63,13 @@ use crate::controller::{Controller, ControllerSnapshot, Decision, Sample};
 /// for the percentile computation.
 const SAMPLE_WINDOW_CAP: usize = 4096;
 
-/// Tunable parameters for [`VegasController`].
+/// Tunable parameters for [`RatioController`].
 ///
 /// All fields are public to make controller behavior fully observable in
-/// tests; most users should start from [`VegasConfig::default`] and override
+/// tests; most users should start from [`RatioConfig::default`] and override
 /// only the knobs they care about.
 #[derive(Debug, Clone, Copy)]
-pub struct VegasConfig {
+pub struct RatioConfig {
     /// Concurrency the controller starts at, before any samples are seen.
     pub initial_cwnd: u32,
     /// Floor on concurrency. Must be >= 1 to make progress.
@@ -67,31 +78,40 @@ pub struct VegasConfig {
     pub max_cwnd: u32,
     /// If `current / baseline < alpha`, cwnd is increased.
     ///
-    /// With matched-percentile signal, the ratio sits near 1.0 at steady
-    /// state regardless of distribution shape, so `alpha` can be set
-    /// tightly — default 1.1 — which means "grow whenever the recent
-    /// distribution is at most 10% slower than the long-horizon one".
+    /// Interpretation depends on the percentile pair: with matched
+    /// percentiles the steady-state ratio sits near 1.0, so `alpha < 1.0`
+    /// means "grow only when recent is meaningfully faster than baseline"
+    /// (a passive controller that doesn't push past the knee), while
+    /// `alpha > 1.0` means "grow even at steady state" (an active explorer
+    /// that climbs to the saturation point). With cross percentiles the
+    /// steady-state ratio sits above 1.0, set by the inter-quantile
+    /// spread of the latency distribution, and `alpha` is placed around
+    /// that ratio.
     pub alpha: f64,
     /// If `current / baseline > beta`, cwnd is decreased.
     ///
-    /// Default 1.5 — a 50% inflation of the recent percentile relative to
-    /// the long-horizon one is a clear distribution-shift signal that
-    /// queueing is building.
+    /// `beta` should be set wide enough to absorb ordinary variance and
+    /// tight enough to react to genuine queueing. Default 1.5.
     pub beta: f64,
     /// How much to grow cwnd on each under-shoot tick.
     pub increase_step: u32,
     /// How much to shrink cwnd on each over-shoot tick.
     pub decrease_step: u32,
-    /// Percentile (in `(0.0, 1.0)`) used to summarize each window.
+    /// Percentile (in `(0.0, 1.0)`) applied to the long-horizon window
+    /// to derive the baseline statistic.
     ///
-    /// The same percentile is applied to both the long-horizon window
-    /// (baseline) and the short-horizon subset (current) so the natural
-    /// distribution shape cancels in the ratio. Default 0.5 (median).
-    /// Lower values (e.g. 0.1) bias toward the fast end of the
-    /// distribution and produce an earlier congestion signal at the cost
-    /// of more sensitivity to occasional fast outliers; higher values
-    /// (e.g. 0.9) react only when the slow tail itself shifts.
-    pub percentile: f64,
+    /// Matched mode (`baseline_percentile == current_percentile`) cancels
+    /// distribution shape so the steady-state ratio sits near 1.0 across
+    /// any latency distribution. Cross mode
+    /// (`baseline_percentile < current_percentile`) measures the
+    /// inter-quantile spread, which grows under queueing — preserving a
+    /// signal at steady-state heavy load that matched mode loses once
+    /// both windows equilibrate.
+    pub baseline_percentile: f64,
+    /// Percentile (in `(0.0, 1.0)`) applied to the short-horizon window
+    /// to derive the current statistic. Must be `>= baseline_percentile`
+    /// so the steady-state ratio is `>= 1.0`.
+    pub current_percentile: f64,
     /// Long-horizon window age. Samples older than this are evicted on
     /// every tick. Sets the memory of the baseline statistic — too short
     /// and the baseline drifts up under sustained load, losing the anchor;
@@ -104,7 +124,7 @@ pub struct VegasConfig {
     pub short_window: std::time::Duration,
 }
 
-impl Default for VegasConfig {
+impl Default for RatioConfig {
     fn default() -> Self {
         Self {
             initial_cwnd: 1,
@@ -114,22 +134,30 @@ impl Default for VegasConfig {
             beta: 1.5,
             increase_step: 1,
             decrease_step: 1,
-            percentile: 0.5,
+            baseline_percentile: 0.5,
+            current_percentile: 0.5,
             long_window: std::time::Duration::from_secs(10),
             short_window: std::time::Duration::from_secs(1),
         }
     }
 }
 
-/// Adaptive controller driven by matched-percentile latency comparison.
+/// Adaptive controller driven by a two-window latency-percentile ratio.
 ///
-/// The same percentile is computed over a long-horizon sample window
-/// (baseline) and a short-horizon subset (current). The ratio of the two
-/// is the congestion signal: at steady state both estimates converge on
-/// the same population statistic so the ratio approaches 1.0; a recent
-/// distribution shift toward slower latencies pushes the ratio above 1.0.
-pub struct VegasController {
-    config: VegasConfig,
+/// The configured `baseline_percentile` is computed over the long-horizon
+/// sample window and the configured `current_percentile` over a
+/// short-horizon subset. The ratio (`current / baseline`) is the
+/// congestion signal. With matched percentiles
+/// (`baseline_percentile == current_percentile`) both windows estimate
+/// the same population statistic, so the ratio sits near 1.0 at steady
+/// state and a recent distribution shift toward slower latencies pushes
+/// it above 1.0. With cross percentiles
+/// (`baseline_percentile < current_percentile`) the ratio measures the
+/// inter-quantile spread of the recent distribution, which grows with
+/// queueing — a level signal rather than a change signal. See the
+/// module-level docstring for the trade-offs between the two modes.
+pub struct RatioController {
+    config: RatioConfig,
     cwnd: u32,
     /// Sliding window of recent samples, used to derive both baseline and
     /// current percentiles each tick. Capped at [`SAMPLE_WINDOW_CAP`]
@@ -151,14 +179,14 @@ pub struct VegasController {
     /// `total_samples` as of the previous tick. Used to detect ticks
     /// that fire without any new sample arriving since the last
     /// decision — those must hold `cwnd` rather than re-applying the
-    /// same matched-percentile decision over and over. With a
-    /// short-window of 1s and a tick cadence of 50ms, a single sample
-    /// otherwise drives ~20 grow / shrink steps before it ages out.
+    /// same ratio decision over and over. With a short-window of 1s
+    /// and a tick cadence of 50ms, a single sample otherwise drives
+    /// ~20 grow / shrink steps before it ages out.
     last_tick_total_samples: u64,
 }
 
-impl VegasController {
-    pub fn new(config: VegasConfig) -> Self {
+impl RatioController {
+    pub fn new(config: RatioConfig) -> Self {
         let cwnd = config
             .initial_cwnd
             .clamp(config.min_cwnd.max(1), config.max_cwnd.max(1));
@@ -210,7 +238,7 @@ fn percentile_via_select(samples: &mut [u64], percentile: f64) -> u64 {
     *samples.select_nth_unstable(idx).1
 }
 
-impl Controller for VegasController {
+impl Controller for RatioController {
     fn on_sample(&mut self, sample: &Sample) {
         // u64 nanos fit any realistic latency; saturate defensively.
         // Clamp to >= 1 so a 0-duration sample (possible when `Instant::now()`
@@ -250,14 +278,14 @@ impl Controller for VegasController {
             self.current_latency_ns = None;
             return Decision::with_concurrency(self.cwnd);
         }
-        // Baseline: percentile over the full long-horizon window.
+        // Baseline: `baseline_percentile` over the full long-horizon window.
         // Materialize a local copy because the deque must stay
         // time-ordered for age-out, but `select_nth_unstable` reorders
         // the slice in place.
         let mut all_lat: Vec<u64> = self.samples.iter().map(|&(ns, _)| ns).collect();
-        let baseline = percentile_via_select(&mut all_lat, self.config.percentile);
+        let baseline = percentile_via_select(&mut all_lat, self.config.baseline_percentile);
         self.baseline_latency_ns = Some(baseline);
-        // Current: same percentile over the short-horizon subset.
+        // Current: `current_percentile` over the short-horizon subset.
         // `checked_sub` underflows when `short_window` exceeds the
         // duration since the `Instant` epoch (only seen in tests with
         // freshly minted clocks). Fall back to the oldest retained
@@ -286,7 +314,7 @@ impl Controller for VegasController {
             self.current_latency_ns = None;
             return Decision::with_concurrency(self.cwnd);
         }
-        let current = percentile_via_select(&mut short_lat, self.config.percentile);
+        let current = percentile_via_select(&mut short_lat, self.config.current_percentile);
         self.current_latency_ns = Some(current);
         // Adjust `cwnd` only on ticks that consumed at least one fresh
         // sample. Without this guard, a single sample observed late in
@@ -314,7 +342,7 @@ impl Controller for VegasController {
         Decision::with_concurrency(self.cwnd)
     }
     fn name(&self) -> &'static str {
-        "vegas"
+        "ratio"
     }
     fn snapshot(&self) -> ControllerSnapshot {
         ControllerSnapshot {
@@ -342,27 +370,27 @@ mod tests {
 
     #[test]
     fn initial_cwnd_is_clamped_into_bounds() {
-        let c = VegasController::new(VegasConfig {
+        let c = RatioController::new(RatioConfig {
             initial_cwnd: 1000,
             min_cwnd: 1,
             max_cwnd: 64,
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         assert_eq!(c.cwnd(), 64);
-        let c = VegasController::new(VegasConfig {
+        let c = RatioController::new(RatioConfig {
             initial_cwnd: 0,
             min_cwnd: 4,
             max_cwnd: 64,
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         assert_eq!(c.cwnd(), 4);
     }
 
     #[test]
     fn without_samples_tick_holds_cwnd() {
-        let mut c = VegasController::new(VegasConfig {
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 10,
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let now = std::time::Instant::now();
         for _ in 0..5 {
@@ -376,9 +404,10 @@ mod tests {
         // baseline is in the fast bucket; at p50 it's still fast (median
         // of 100 = 50th smallest, which is in the fast 90); at p95 it's
         // the slow bucket because the upper 10% is all slow.
-        let mut c = VegasController::new(VegasConfig {
-            percentile: 0.95,
-            ..VegasConfig::default()
+        let mut c = RatioController::new(RatioConfig {
+            baseline_percentile: 0.95,
+            current_percentile: 0.95,
+            ..RatioConfig::default()
         });
         let t0 = std::time::Instant::now();
         for i in 0..90 {
@@ -407,7 +436,7 @@ mod tests {
         // The reason we picked matched percentiles in the first place:
         // outliers don't pin the baseline. p50 of 90 fast + 10 slow is
         // squarely in the fast bucket.
-        let mut c = VegasController::new(VegasConfig::default());
+        let mut c = RatioController::new(RatioConfig::default());
         let t0 = std::time::Instant::now();
         for i in 0..90 {
             c.on_sample(&sample(
@@ -435,13 +464,13 @@ mod tests {
         // The matched-percentile ratio is ~1.0, which is < alpha (1.1) so
         // cwnd grows. This is exactly the regime the new design wants —
         // no false "queueing" signal from natural variance.
-        let mut c = VegasController::new(VegasConfig {
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 5,
             increase_step: 1,
             max_cwnd: 1000,
             short_window: std::time::Duration::from_millis(500),
             long_window: std::time::Duration::from_secs(5),
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let t0 = std::time::Instant::now();
         // Spread samples across the long window so both short and long
@@ -469,13 +498,13 @@ mod tests {
         // slow (10ms) samples; short window holds only the slow recent
         // samples. The matched percentile in the short window is much
         // higher, ratio > beta, so cwnd shrinks.
-        let mut c = VegasController::new(VegasConfig {
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 50,
             decrease_step: 2,
             beta: 1.5,
             short_window: std::time::Duration::from_millis(500),
             long_window: std::time::Duration::from_secs(10),
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let t0 = std::time::Instant::now();
         // Phase 1: fast historical samples spread over 5 seconds.
@@ -501,13 +530,13 @@ mod tests {
 
     #[test]
     fn holds_cwnd_when_ratio_between_alpha_and_beta() {
-        let mut c = VegasController::new(VegasConfig {
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 10,
             alpha: 1.1,
             beta: 1.5,
             short_window: std::time::Duration::from_millis(500),
             long_window: std::time::Duration::from_secs(5),
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let t0 = std::time::Instant::now();
         // 4500ms of historical samples at 2ms.
@@ -535,14 +564,14 @@ mod tests {
 
     #[test]
     fn cwnd_respects_min_floor() {
-        let mut c = VegasController::new(VegasConfig {
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 3,
             min_cwnd: 2,
             decrease_step: 10,
             beta: 1.1,
             short_window: std::time::Duration::from_millis(200),
             long_window: std::time::Duration::from_millis(2_000),
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let t0 = std::time::Instant::now();
         // Establish a fast baseline.
@@ -564,13 +593,13 @@ mod tests {
 
     #[test]
     fn cwnd_respects_max_ceiling() {
-        let mut c = VegasController::new(VegasConfig {
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 4,
             max_cwnd: 6,
             increase_step: 10,
             short_window: std::time::Duration::from_millis(200),
             long_window: std::time::Duration::from_secs(2),
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let t0 = std::time::Instant::now();
         for i in 0..200 {
@@ -583,11 +612,11 @@ mod tests {
 
     #[test]
     fn baseline_window_ages_out_and_is_re_established() {
-        let mut c = VegasController::new(VegasConfig {
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 10,
             long_window: std::time::Duration::from_millis(100),
             short_window: std::time::Duration::from_millis(50),
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let t0 = std::time::Instant::now();
         c.on_sample(&sample(t0, std::time::Duration::from_micros(500)));
@@ -619,11 +648,11 @@ mod tests {
         // still inside the long window — the baseline is still valid;
         // we just have nothing fresh to compare against. The controller
         // must hold cwnd rather than fabricating a comparison.
-        let mut c = VegasController::new(VegasConfig {
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 10,
             long_window: std::time::Duration::from_secs(10),
             short_window: std::time::Duration::from_millis(500),
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let t0 = std::time::Instant::now();
         c.on_sample(&sample(t0, std::time::Duration::from_millis(2)));
@@ -646,11 +675,11 @@ mod tests {
         // — and either way not drive a principled cwnd decision.
         // `on_sample` clamps latency to >= 1ns, so the ratio stays
         // finite and cwnd follows the normal trajectory.
-        let mut c = VegasController::new(VegasConfig {
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 10,
             min_cwnd: 1,
             max_cwnd: 100,
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let start = std::time::Instant::now();
         for i in 0..10 {
@@ -678,7 +707,7 @@ mod tests {
         // capacity (rather than a looser `<= 2× cap` bound) catches the
         // post-push pop regression: at the cap a post-push push_back
         // would round up to the next power of two, doubling capacity.
-        let mut c = VegasController::new(VegasConfig::default());
+        let mut c = RatioController::new(RatioConfig::default());
         let initial_capacity = c.samples.capacity();
         let start = std::time::Instant::now();
         let n = SAMPLE_WINDOW_CAP + 10_000;
@@ -710,11 +739,11 @@ mod tests {
         // older completion time can land in the deque after a newer one.
         // The age-out path must still evict every stale entry — not just
         // a contiguous prefix at the front.
-        let mut c = VegasController::new(VegasConfig {
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 10,
             long_window: std::time::Duration::from_millis(100),
             short_window: std::time::Duration::from_millis(50),
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let t0 = std::time::Instant::now();
         let old_offset = std::time::Duration::from_millis(10);
@@ -751,16 +780,16 @@ mod tests {
     fn cwnd_does_not_drift_on_ticks_without_fresh_samples() {
         // Regression: with short_window = 1s and tick = 50ms, a single
         // sample is visible to ~20 consecutive ticks. Each tick was
-        // re-applying the same matched-percentile decision and adjusting
-        // cwnd, so one sample in the right phase drove cwnd by ~20
-        // steps even though no new operation completed. Only ticks
-        // that consumed a new sample may adjust cwnd.
-        let mut c = VegasController::new(VegasConfig {
+        // re-applying the same ratio decision and adjusting cwnd, so
+        // one sample in the right phase drove cwnd by ~20 steps even
+        // though no new operation completed. Only ticks that consumed
+        // a new sample may adjust cwnd.
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 10,
             increase_step: 1,
             short_window: std::time::Duration::from_secs(1),
             long_window: std::time::Duration::from_secs(10),
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let t0 = std::time::Instant::now();
         // Single sample. Both baseline and current percentiles agree
@@ -791,11 +820,11 @@ mod tests {
         // include the current percentile too — even if no fresh sample
         // arrived since the last tick (in which case cwnd holds, but
         // the current value is still observable in the snapshot).
-        let mut c = VegasController::new(VegasConfig {
+        let mut c = RatioController::new(RatioConfig {
             initial_cwnd: 5,
             short_window: std::time::Duration::from_secs(1),
             long_window: std::time::Duration::from_secs(10),
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         });
         let t0 = std::time::Instant::now();
         c.on_sample(&sample(t0, std::time::Duration::from_millis(3)));
@@ -812,7 +841,7 @@ mod tests {
 
     #[test]
     fn snapshot_reports_total_samples_seen() {
-        let mut c = VegasController::new(VegasConfig::default());
+        let mut c = RatioController::new(RatioConfig::default());
         assert_eq!(c.snapshot().samples_seen, 0);
         let start = std::time::Instant::now();
         for _ in 0..7 {

--- a/congestion/tests/property.rs
+++ b/congestion/tests/property.rs
@@ -4,23 +4,23 @@
 
 use congestion::sim::{BottleneckModel, ScenarioConfig, run_scenario};
 use congestion::{
-    Controller, Decision, FixedController, NoopController, Outcome, Sample, VegasConfig,
-    VegasController,
+    Controller, Decision, FixedController, NoopController, Outcome, RatioConfig, RatioController,
+    Sample,
 };
 use proptest::prelude::*;
 
-/// Strategy: a `VegasConfig` whose `min_cwnd <= max_cwnd`, with bounds
+/// Strategy: a `RatioConfig` whose `min_cwnd <= max_cwnd`, with bounds
 /// drawn from ranges that make bugs observable (broad enough to explore
 /// clamping, narrow enough to stay fast).
-fn valid_vegas_config() -> impl Strategy<Value = VegasConfig> {
+fn valid_ratio_config() -> impl Strategy<Value = RatioConfig> {
     (1u32..50, 1u32..2000, 1u32..5000).prop_map(|(min_raw, max_raw, initial_raw)| {
         let min = min_raw;
         let max = min.saturating_add(max_raw);
-        VegasConfig {
+        RatioConfig {
             initial_cwnd: initial_raw,
             min_cwnd: min,
             max_cwnd: max,
-            ..VegasConfig::default()
+            ..RatioConfig::default()
         }
     })
 }
@@ -52,7 +52,7 @@ fn sample(start: std::time::Instant, latency_ns: u64, offset_ns: u64) -> Sample 
 }
 
 proptest! {
-    /// Core invariant: a `VegasController`'s emitted cwnd is always within
+    /// Core invariant: a `RatioController`'s emitted cwnd is always within
     /// the configured `[min_cwnd.max(1), max_cwnd]` band, across any
     /// sample/tick sequence — no matter how pathological the latencies.
     ///
@@ -60,11 +60,11 @@ proptest! {
     /// overflow in `saturating_add`/`saturating_sub`, and any code path
     /// that bypasses the clamp on initial_cwnd.
     #[test]
-    fn vegas_cwnd_always_within_configured_bounds(
-        config in valid_vegas_config(),
+    fn ratio_cwnd_always_within_configured_bounds(
+        config in valid_ratio_config(),
         latencies in prop::collection::vec(latency_ns_strategy(), 1..50),
     ) {
-        let mut c = VegasController::new(config);
+        let mut c = RatioController::new(config);
         let start = std::time::Instant::now();
         let expected_min = config.min_cwnd.max(1);
         let expected_max = config.max_cwnd.max(1);
@@ -78,10 +78,10 @@ proptest! {
             // intersperse ticks so the controller has chances to adjust.
             if i % 3 == 2 {
                 let decision = c.on_tick(s.completed_at);
-                // Vegas must always emit concurrency (never rate) and the
-                // value must be within bounds.
+                // The ratio controller must always emit concurrency (never
+                // rate) and the value must be within bounds.
                 prop_assert!(decision.rate_per_sec.is_none());
-                let cwnd = decision.max_in_flight.expect("vegas emits max_in_flight");
+                let cwnd = decision.max_in_flight.expect("ratio emits max_in_flight");
                 prop_assert!(
                     cwnd >= expected_min,
                     "cwnd {cwnd} below min {expected_min} (config={config:?})",
@@ -94,17 +94,17 @@ proptest! {
         }
     }
 
-    /// Vegas must never emit a `rate_per_sec` decision — it's a
-    /// concurrency-based controller, and the Decision contract requires
-    /// the adapter to differentiate rate-only vs concurrency-only
+    /// The ratio controller must never emit a `rate_per_sec` decision —
+    /// it's a concurrency-based controller, and the Decision contract
+    /// requires the adapter to differentiate rate-only vs concurrency-only
     /// controllers by which dimension is `Some`.
     #[test]
-    fn vegas_never_emits_rate_per_sec(
-        config in valid_vegas_config(),
+    fn ratio_never_emits_rate_per_sec(
+        config in valid_ratio_config(),
         latency_ns in latency_ns_strategy(),
         tick_count in 1usize..20,
     ) {
-        let mut c = VegasController::new(config);
+        let mut c = RatioController::new(config);
         let start = std::time::Instant::now();
         for i in 0..tick_count {
             let s = sample(start, latency_ns, i as u64 * 1_000_000);

--- a/congestion/tests/scenarios.rs
+++ b/congestion/tests/scenarios.rs
@@ -2,7 +2,7 @@
 //! through the simulator and assert aggregate throughput/latency behavior.
 
 use congestion::sim::{BottleneckModel, ScenarioConfig, run_scenario};
-use congestion::{FixedController, NoopController, VegasConfig, VegasController};
+use congestion::{FixedController, NoopController, RatioConfig, RatioController};
 
 /// 10k ops/sec capacity, 2ms min latency → BDP = 20 in-flight. These are
 /// the numbers every scenario below reuses unless it overrides them.
@@ -175,12 +175,12 @@ fn scenario_emits_one_decision_per_tick_plus_initial() {
 }
 
 #[test]
-fn vegas_grows_from_cold_start() {
-    // Vegas starts at cwnd=1 and should grow toward BDP when latency stays
+fn ratio_grows_from_cold_start() {
+    // The ratio controller starts at cwnd=1 and should grow toward BDP when latency stays
     // near the baseline.
-    let mut controller = VegasController::new(VegasConfig {
+    let mut controller = RatioController::new(RatioConfig {
         initial_cwnd: 1,
-        ..VegasConfig::default()
+        ..RatioConfig::default()
     });
     let bottleneck = default_bottleneck();
     let duration = std::time::Duration::from_secs(3);
@@ -197,7 +197,7 @@ fn vegas_grows_from_cold_start() {
 }
 
 #[test]
-fn vegas_converges_near_bdp_without_runaway_latency() {
+fn ratio_converges_near_bdp_without_runaway_latency() {
     // Steady-state cwnd should land somewhere above BDP — but not at
     // `max_cwnd`. Use a tighter alpha/beta than defaults: in this
     // deterministic simulator there is no per-op variance, so the
@@ -207,11 +207,11 @@ fn vegas_converges_near_bdp_without_runaway_latency() {
     // estimate carries uncertainty; in the sim a tighter config makes
     // the test assertion meaningful without making the algorithm change
     // behavior in production.
-    let mut controller = VegasController::new(VegasConfig {
+    let mut controller = RatioController::new(RatioConfig {
         initial_cwnd: 1,
         alpha: 1.02,
         beta: 1.10,
-        ..VegasConfig::default()
+        ..RatioConfig::default()
     });
     let bottleneck = default_bottleneck();
     let duration = std::time::Duration::from_secs(5);
@@ -245,18 +245,18 @@ fn vegas_converges_near_bdp_without_runaway_latency() {
 }
 
 #[test]
-fn vegas_achieves_near_capacity_throughput() {
-    // once converged, Vegas should keep the bottleneck well-utilized.
-    let mut controller = VegasController::new(VegasConfig {
+fn ratio_achieves_near_capacity_throughput() {
+    // once converged, the ratio controller should keep the bottleneck well-utilized.
+    let mut controller = RatioController::new(RatioConfig {
         initial_cwnd: 1,
-        ..VegasConfig::default()
+        ..RatioConfig::default()
     });
     let bottleneck = default_bottleneck();
     let duration = std::time::Duration::from_secs(10);
     let config = metadata_config(duration, 2048);
     let result = run_scenario(&mut controller, &bottleneck, &config);
     let throughput = result.throughput_ops_per_sec(duration);
-    // Vegas is conservative compared to Noop; expect at least 70% of capacity
+    // The ratio controller is conservative compared to Noop; expect at least 70% of capacity
     // over a long enough run.
     assert!(
         throughput >= bottleneck.capacity_per_sec * 0.7,
@@ -266,19 +266,19 @@ fn vegas_achieves_near_capacity_throughput() {
 }
 
 #[test]
-fn vegas_keeps_latency_bounded_under_saturation_pressure() {
+fn ratio_keeps_latency_bounded_under_saturation_pressure() {
     // Contrast with noop_controller_inflates_latency_when_saturated:
-    // Vegas's steady-state latency stays within a small multiple of
-    // min_latency even when the workload is eager. As in
-    // `vegas_converges_near_bdp_without_runaway_latency`, use a tighter
+    // the ratio controller's steady-state latency stays within a small
+    // multiple of min_latency even when the workload is eager. As in
+    // `ratio_converges_near_bdp_without_runaway_latency`, use a tighter
     // alpha/beta than defaults so the deterministic sim's lack of
     // per-op variance doesn't let the matched-percentile ratio drift
     // arbitrarily far from 1.0.
-    let mut controller = VegasController::new(VegasConfig {
+    let mut controller = RatioController::new(RatioConfig {
         initial_cwnd: 1,
         alpha: 1.02,
         beta: 1.10,
-        ..VegasConfig::default()
+        ..RatioConfig::default()
     });
     let bottleneck = default_bottleneck();
     let duration = std::time::Duration::from_secs(5);

--- a/docs/congestion_control.md
+++ b/docs/congestion_control.md
@@ -37,8 +37,18 @@ The observation is that the filesystem itself tells us how hard we can
 push: its response latency inflates when we approach saturation. If we
 watch that signal in real time and adjust our concurrency to stay at the
 onset of inflation, we stay near peak throughput without overshooting.
-This is the same idea TCP Vegas uses for network congestion control,
-adapted to filesystem metadata operations.
+The design draws on a lineage of latency-based congestion control
+from networking — TCP Vegas (Brakmo & Peterson, 1995), CoDel (Nichols
+& Jacobson, 2012), and BBR (Cardwell et al, 2017) all watch some
+form of latency-vs-baseline signal and adjust an outbound rate or
+window in response. The controller here adapts that idea to
+filesystem metadata operations, with two notable differences from
+the classical Vegas shape covered in the [The Control Signal][cs]
+section: it summarizes each window with a configurable percentile
+rather than min/mean, and it allows the baseline and current
+percentiles to differ to encode the inter-quantile spread directly.
+
+[cs]: #the-control-signal
 
 ## Goals and Non-Goals
 
@@ -49,8 +59,8 @@ adapted to filesystem metadata operations.
 - Keep the default behavior unchanged — congestion control is opt-in.
 - Expose every tuning knob so the feature can be evaluated and tuned in
   the field without recompiling.
-- Make the control algorithm swappable; do not bake Vegas-specific
-  assumptions into the rest of the stack.
+- Make the control algorithm swappable; do not bake controller-
+  specific assumptions into the rest of the stack.
 
 **Non-goals (for this release):**
 
@@ -143,8 +153,8 @@ So:
   unpredictably. Latency moves continuously and is cheaper to read:
   every op produces one sample.
 
-The single control knob throughout this document — **`cwnd`** (Vegas's
-"congestion window") — is exactly the maximum number of in-flight
+The single control knob throughout this document — **`cwnd`** (the
+TCP "congestion window") — is exactly the maximum number of in-flight
 operations the controller will permit at any instant. We use `cwnd`,
 "concurrency cap", and "max in-flight" interchangeably; they are the
 same number, just expressed in TCP terminology vs. systems terminology.
@@ -153,42 +163,80 @@ same number, just expressed in TCP terminology vs. systems terminology.
 
 The algorithm's job is to find a `cwnd` that saturates the bottleneck
 without queueing. It reasons about two derived quantities computed
-from the same per-op latency probes — at the *same percentile* in two
-different time windows:
+from the same per-op latency probes — a *baseline* percentile over a
+long time window and a *current* percentile over a short subset:
 
-- **Baseline latency** — the configured percentile (default p50) over
-  a long-horizon sample window (default 10s). This is the long-memory
-  reference: the typical fast / median latency over recent history.
-- **Current latency** — the same percentile computed over a short-
-  horizon subset (default 1s) of the same buffer. This is the recent
+- **Baseline latency** — `baseline_percentile` (default p50) over a
+  long-horizon sample window (default 10s). The long-memory reference.
+- **Current latency** — `current_percentile` (default p50) over a
+  short-horizon subset (default 1s) of the same buffer. The recent
   estimate.
 
-Their ratio is the congestion signal:
+The two percentiles are independent knobs. Their ratio is the
+congestion signal:
 
 ```
   ratio  =  current / baseline
 ```
 
-When the offered load is steady the two windows estimate the same
-population statistic, and the ratio sits at ~1.0 *regardless* of how
-heavy-tailed the per-op latency distribution is. A non-1.0 ratio means
-the recent-sample distribution has shifted — exactly the queue
-build-up signal we want to act on. So the regime we care about is the
-strip between 1.0 and "very large":
+There are two natural operating modes, depending on whether the
+percentiles are equal or staggered.
+
+### Matched percentiles (`baseline == current`)
+
+Default. Both windows summarize the same statistic (e.g. p50). When
+the offered load is steady the two windows estimate the same
+population statistic and the ratio stays near 1.0 *regardless* of
+how heavy-tailed the per-op latency distribution is (with finite
+windows the ratio fluctuates around 1.0 within sampling noise; the
+larger the window relative to per-op variance, the tighter the
+fluctuation). Sustained deviations away from 1.0 reflect a shift
+in the recent distribution relative to history — which is what we
+want to act on.
+
+Strength: distribution shape cancels, so default `alpha` / `beta` are
+universal — they don't need to be retuned per filesystem or per
+syscall. Weakness: once both windows have equilibrated to a heavily-
+loaded distribution, the ratio is back at 1.0 and the controller has
+no signal that it's currently overloading the filesystem — it can
+only see *changes* in load, not steady-state queueing.
+
+### Cross percentiles (`baseline < current`)
+
+Set the two percentiles asymmetrically (e.g. baseline at p40, current
+at p60). At steady state both windows still estimate the same
+population, but the ratio now compares two different points on that
+distribution — the inter-quantile spread. Queueing fattens the upper
+tail asymmetrically, so spread grows with offered load even at steady
+state. The ratio rides above 1.0 by an amount that tracks the level
+of congestion, not just changes in it.
+
+Strength: preserves a signal at steady-state heavy load that matched
+mode loses. Weakness: the steady-state ratio depends on the specific
+syscall's latency distribution shape, so `alpha` / `beta` may need
+per-filesystem or per-syscall tuning.
+
+### The hold band
+
+Either way, the control law treats the strip around the steady-state
+ratio as the hold band:
 
 ```
        latency ratio
               │
-   beta ──────┤              ┌── shrink cwnd ──┐
-              │              │                 │
-              │              │                 │
-   alpha ─────┤   ┌── hold ──┤
-              │   │
-     1.0  ────┤───┘
-              │     grow cwnd
+   beta ──────┤                       ┌── shrink cwnd ──┐
+              │                       │                 │
+              │                       │                 │
+   alpha ─────┤    ┌─── hold ─────────┤
+              │    │
+              │    │   grow cwnd
               │
               └───────────────────────────────── time
 ```
+
+For matched percentiles `alpha` typically straddles 1.0; for cross
+percentiles both `alpha` and `beta` typically sit above 1.0, set by
+the natural inter-quantile spread of the distribution.
 
 ## Why Our Own Load Doesn't Skew the Signal
 
@@ -198,18 +246,20 @@ own queueing. Won't the baseline itself drift up to match — leaving us
 with a controller that treats the inflated latency as the new normal
 and never shrinks?
 
-The matched-window design addresses this directly:
+The two-window design addresses this from two complementary angles
+depending on which mode is active:
 
-1. **Baseline and current are the same statistic over different time
-   horizons.** Each tick the controller takes the configured percentile
-   (p50 by default) of the long sample window (10s) as the baseline
-   and the same percentile of the short window (1s) as the current
-   estimate. When the per-op latency distribution is stationary, both
-   estimates converge on the same population value and the ratio sits
-   at exactly 1.0. The natural per-op variance of real filesystems —
-   variance that routinely spans an order of magnitude on a Weka or
-   Lustre mount even on an idle metadata path — cancels out because
-   it's present in both windows in the same proportion.
+1. **In matched mode, the distribution shape cancels.** Each tick the
+   controller takes the configured percentile of the long window
+   (10s) as the baseline and the same percentile of the short window
+   (1s) as the current estimate. When the per-op latency distribution
+   is stationary, both estimates converge on the same population
+   value and the ratio stays near 1.0 (finite-window noise gives
+   small per-tick fluctuations). The natural per-op
+   variance of real filesystems — variance that routinely spans an
+   order of magnitude on a Weka or Lustre mount even on an idle
+   metadata path — cancels out because it's present in both windows
+   in the same proportion.
 
    This is the key contrast with a baseline-vs-mean shape (the prior
    p10 / EWMA design): mean and p10 of a heavy-tailed distribution
@@ -220,7 +270,18 @@ The matched-window design addresses this directly:
    loose thresholds left a wide hold band where genuine load growth
    could not be distinguished from variance.
 
-2. **The control law shrinks `cwnd` as soon as the recent distribution
+2. **In cross mode, the inter-quantile spread tracks queueing
+   directly.** Setting baseline at a lower percentile and current at
+   a higher one (e.g. p40 / p60) makes the ratio a measure of the
+   spread of the recent distribution. Saturation broadens the upper
+   tail more than the lower decile — the lower decile sits near the
+   bare service time even at high `cwnd` because the fastest paths
+   through the metadata server still hit cache, while the upper tail
+   grows with queue depth. So the spread, and therefore the ratio,
+   rises with offered load and stays elevated until `cwnd` is pulled
+   back enough to drain the queue.
+
+3. **The control law shrinks `cwnd` as soon as the recent distribution
    shifts.** When the offered load increases, the short window
    captures the shift before the long window does. Even if both
    eventually equilibrate, the transient `ratio > beta` shrinks `cwnd`
@@ -229,13 +290,13 @@ The matched-window design addresses this directly:
    latency samples enter the short window and the ratio drops back —
    the next tick can grow again.
 
-3. **The window is bounded.** Samples older than `long_window` (default
+4. **The window is bounded.** Samples older than `long_window` (default
    10s) are evicted on every tick, so a one-time spike doesn't pin
    the baseline forever. If the long window empties entirely under
    sustained saturation, both the baseline and the current statistic
    reset to `None` and the controller holds `cwnd` until fresh samples
    arrive — preventing a window of uniformly inflated samples from
-   reading as "uncongested" via the matched-percentile cancellation.
+   reading as "uncongested" via cancellation.
 
 ## The Control Law
 
@@ -251,15 +312,33 @@ regions and applies a fixed step to `cwnd`:
 ```
 
 Defaults: `alpha = 1.10`, `beta = 1.50`, `increase_step =
-decrease_step = 1`. Each step is then clamped to `[min_cwnd,
-max_cwnd]`. The thresholds sit close to 1.0 because the matched-
-percentile signal cancels distribution shape: at steady state the
-ratio rides at ~1.0 regardless of how heavy-tailed the per-op latency
-distribution is, so `alpha = 1.10` cleanly says "grow whenever the
-recent distribution is at most 10% slower than the long-horizon one"
-and `beta = 1.50` says "shrink when the recent distribution is at
-least 50% slower" — both genuine queue-build-up signals rather than
-noise-floor artifacts.
+decrease_step = 1`, with both percentiles at 0.5 (matched p50). Each
+step is clamped to `[min_cwnd, max_cwnd]`.
+
+The only hard invariant on the thresholds is `0 < alpha < beta`. The
+*natural* placement of `alpha` and `beta` relative to 1.0 depends on
+the percentile pair:
+
+- **Matched percentiles** produce a steady-state ratio near 1.0
+  (modulo finite-window noise). With `alpha > 1.0` the controller
+  is in *active* mode — at steady state it sits in the grow region,
+  climbing until queueing pushes the ratio past `beta`. With
+  `alpha < 1.0 < beta` it is in *passive* mode — at steady state
+  it holds, growing only when the recent distribution is
+  meaningfully *faster* than baseline (which happens during
+  transient improvements, e.g. when other clients drop off).
+- **Cross percentiles** produce a steady-state ratio above 1.0 set
+  by the inter-quantile spread of the per-syscall latency
+  distribution. Both `alpha` and `beta` typically sit above 1.0,
+  bracketing the workload's natural spread.
+
+The defaults — `alpha = 1.10`, `beta = 1.50`, both percentiles at
+p50 — put the controller in active matched mode: at steady state
+it climbs until queueing inflates the ratio past 1.5. That makes it
+fast at finding the saturation knee but inherently overshoots; for
+"good neighbor" deployments either lower `alpha` below 1.0 (passive
+matched mode) or stagger the percentiles (cross mode) and re-bracket
+`alpha` / `beta` around the workload's idle spread.
 
 A few worked examples make the shape concrete. Assume a 0.5ms baseline
 percentile, default thresholds, and `cwnd = 20` going into the tick:
@@ -280,21 +359,24 @@ percentile, default thresholds, and `cwnd = 20` going into the tick:
 by exactly the same one step as a ratio of 1.51. Sustained inflation
 drives faster *effective* shrinkage because the ratio stays above
 `beta` over many consecutive ticks — but each individual tick still
-takes one step. This is the classic Vegas shape: simpler control law,
-less prone to oscillation under noisy latency than a gain-tuned PID.
+takes one step. This binary-trigger shape, inherited from TCP Vegas,
+keeps the control law simple and less prone to oscillation under
+noisy latency than a gain-tuned PID.
 
-Second, **`ratio < 1.0` is benign and treated as growth headroom.**
-When the recent samples are *faster* than the long-horizon ones the
-filesystem just got less loaded; the controller pushes `cwnd` up to
-take advantage of it.
+Second, with the active defaults `ratio < 1.0` is treated as growth
+headroom. When `alpha` is set below 1.0 (passive matched mode) the
+table flips at that point: a ratio of 0.80 becomes hold rather than
+grow, because the recent distribution is faster than baseline but
+not by enough to clear the passive growth threshold.
 
 The "responsiveness" of the controller is shaped by these knobs in
 combination:
 
 - `--auto-meta-tick-interval` (how often the binning above is
   evaluated; default 50 ms);
-- `--auto-meta-percentile` (the percentile used in both windows;
-  default 0.5 / median);
+- `--auto-meta-baseline-percentile` /
+  `--auto-meta-current-percentile` (the percentiles used in the
+  long and short windows; defaults 0.5 / 0.5 — matched median);
 - `--auto-meta-long-window` / `--auto-meta-short-window` (how much
   history is used for each estimate; defaults 10s / 1s);
 - `--auto-meta-increase-step` / `--auto-meta-decrease-step` (the per-
@@ -351,8 +433,8 @@ What "wide coverage" means concretely:
   walk-side load on a fragile NAS, reach for `--ops-throttle`.
 - **Not probed by design — data path.** The read-loop and write-loop
   inside the copy pipeline, and `tokio::fs::copy` itself. Bandwidth-
-  bound, not service-time-bound; a Vegas-style controller doesn't fit.
-  See [Pluggability](#pluggability) for the BBR direction.
+  bound, not service-time-bound; a latency-ratio controller doesn't
+  fit. See [Pluggability](#pluggability) for the BBR direction.
 
 ## One Controller per (Side, Syscall)
 
@@ -416,7 +498,7 @@ in-flight concurrency independently, but the global ops-throttle
 (rate-per-second) is shared across the process. Only the
 `(Destination, Stat)` controller drives that single rate gate by
 convention; the others apply concurrency only. The current
-`VegasController` doesn't emit rate decisions, so this choice is
+`RatioController` doesn't emit rate decisions, so this choice is
 forward-looking — if a rate-aware controller (BBR-style, …) is
 swapped in later, exactly one of them must own the global rate gate.
 
@@ -519,8 +601,8 @@ responses on each side.
 ## Tuning and Observability
 
 The controller exposes every tunable as a CLI flag — initial, minimum,
-and maximum cwnd, the grow/shrink thresholds, the percentile applied
-to each window, the long / short window durations, per-tick step sizes,
+and maximum cwnd, the grow/shrink thresholds, the baseline and current
+percentiles, the long / short window durations, per-tick step sizes,
 and the control-loop tick cadence. Defaults are conservative;
 aggressive-but-sensible tuning comes from field measurements.
 
@@ -565,7 +647,15 @@ The algorithm layer is behind a single trait. Shipping today:
 - **Fixed**: emits a constant cap. Regression baseline when comparing
   adaptive algorithms; also useful as an explicit "concurrency ceiling"
   knob.
-- **Vegas-style**: the adaptive controller described above.
+- **Latency-ratio** (`RatioController`): the adaptive controller
+  described above. Inspired by TCP Vegas's
+  current-vs-baseline-RTT signal, with two extensions: each window
+  is summarized by a configurable percentile rather than by min/mean,
+  and the baseline and current percentiles can differ to encode the
+  inter-quantile spread of the latency distribution as the queueing
+  signal. Adjacent precedents in the wider literature: CoDel uses
+  a single-percentile (min) target detector; BBR tracks windowed
+  max bandwidth and min RTT.
 
 New algorithms plug into the same enforcement machinery and the same
 simulator. BBR-style estimators (tracking bottleneck bandwidth and

--- a/remote/src/protocol/mod.rs
+++ b/remote/src/protocol/mod.rs
@@ -380,7 +380,14 @@ impl RcpdConfig {
             args.push(format!("--auto-meta-max-cwnd={}", auto.max_cwnd));
             args.push(format!("--auto-meta-alpha={}", auto.alpha));
             args.push(format!("--auto-meta-beta={}", auto.beta));
-            args.push(format!("--auto-meta-percentile={}", auto.percentile));
+            args.push(format!(
+                "--auto-meta-baseline-percentile={}",
+                auto.baseline_percentile,
+            ));
+            args.push(format!(
+                "--auto-meta-current-percentile={}",
+                auto.current_percentile,
+            ));
             args.push(format!("--auto-meta-increase-step={}", auto.increase_step));
             args.push(format!("--auto-meta-decrease-step={}", auto.decrease_step));
             args.push(format!(
@@ -546,7 +553,8 @@ mod tests {
             beta: 1.6,
             increase_step: 2,
             decrease_step: 3,
-            percentile: 0.4,
+            baseline_percentile: 0.4,
+            current_percentile: 0.6,
             long_window: std::time::Duration::from_secs(20),
             short_window: std::time::Duration::from_secs(2),
             tick_interval: std::time::Duration::from_millis(75),
@@ -560,7 +568,8 @@ mod tests {
         assert!(has("--auto-meta-max-cwnd=128"));
         assert!(has_prefix("--auto-meta-alpha=1.2"));
         assert!(has_prefix("--auto-meta-beta=1.6"));
-        assert!(has_prefix("--auto-meta-percentile=0.4"));
+        assert!(has_prefix("--auto-meta-baseline-percentile=0.4"));
+        assert!(has_prefix("--auto-meta-current-percentile=0.6"));
         assert!(has("--auto-meta-increase-step=2"));
         assert!(has("--auto-meta-decrease-step=3"));
         assert!(has_prefix("--auto-meta-long-window="));


### PR DESCRIPTION
The matched-percentile design from fc23306 cancels distribution shape
at steady state — the ratio sits at exactly 1.0 once both windows
have equilibrated. That cleanly removes shape from the signal but
also cancels the level of queueing: a heavily-loaded system at
steady state and an idle system look identical to the controller.
Combined with default alpha=1.1 (above 1.0), the controller is
guaranteed to grow at steady state until queueing inflates the
ratio past beta — i.e. it always overshoots the saturation knee.

Two changes here:

1. Split `percentile` into `baseline_percentile` / `current_percentile`
   (defaults still 0.5 / 0.5, matched p50 — no behavior change
   out-of-the-box). Setting them differently (e.g. p40 / p60)
   measures the inter-quantile spread of the recent distribution,
   which grows asymmetrically with queueing — preserving a level
   signal at steady-state heavy load that matched mode loses. Drop
   the alpha > 1.0 / beta > 1.0 validation constraints so passive
   matched mode (alpha < 1 < beta, holds at steady state) is also
   reachable. New invariant: 0 < alpha < beta.

2. Rename `VegasController` / `VegasConfig` → `RatioController` /
   `RatioConfig` (file `vegas.rs` → `ratio.rs`). The cross-percentile
   extension diverges enough from classical TCP Vegas that the name
   was more confusing than helpful. Docs keep the lineage —
   Motivation now cites Vegas (1995), CoDel (2012), BBR (2017) as
   ancestors of latency-based congestion control.

Remote rcpd propagation, CLI flags (`--auto-meta-baseline-percentile`,
`--auto-meta-current-percentile`), tracing log, and the
docs/congestion_control.md design doc all updated for the new shape.
