### PR TITLE
Fix --fail-early race in remote copy that swallowed file-open errors

### DIFF
--- a/rcp/src/source.rs
+++ b/rcp/src/source.rs
@@ -536,7 +536,16 @@ async fn send_file_tcp(
                 .send_batch_message(&skip_msg)
                 .await?;
             if settings.fail_early {
-                return Err(e.into());
+                // Defense-in-depth: also push to error_collector so
+                // run_source's take_error() catches this even when the
+                // Err return below loses a race against the destination's
+                // DestinationDone (which causes the shutdown drain in
+                // dispatch_control_messages_tcp to swallow this task's
+                // Err). anyhow::Error isn't Clone, so push a formatted
+                // copy and keep the original chain in the Err return.
+                let err: anyhow::Error = e.into();
+                error_collector.push(anyhow::anyhow!("{err:#}"));
+                return Err(err);
             }
             error_collector.push(e.into());
             return Ok(());
@@ -629,7 +638,16 @@ async fn send_files_in_directory_tcp(
                     .await?;
             }
             if settings.fail_early {
-                return Err(e.into());
+                // Same defense-in-depth as the file-open branch in
+                // send_file_tcp: the FileSkipped messages above let the
+                // destination tally to zero and emit DestinationDone,
+                // which can race with the Err return below and cause the
+                // shutdown drain in dispatch_control_messages_tcp to
+                // swallow this task's error. Push a copy into the
+                // collector so run_source's take_error() catches it.
+                let err: anyhow::Error = e.into();
+                error_collector.push(anyhow::anyhow!("{err:#}"));
+                return Err(err);
             }
             error_collector.push(e.into());
             return Ok(());


### PR DESCRIPTION
When rcp runs with --fail-early and a per-file error fires on the source
side (e.g. EACCES on `File::open`), `send_file_tcp` does:

1. send `FileSkipped` on the control stream so the destination can
   decrement its expected entry count and complete cleanly,
2. return `Err` to abort scheduling further file transfers.

The Err propagates: `send_files_in_directory_tcp`'s `JoinSet` picks it
up, returns `Err`, and that `Err` surfaces in
`dispatch_control_messages_tcp`'s outer `JoinSet`. Meanwhile the
destination receives `FileSkipped`, counts down to zero, and sends
`DestinationDone`. The dispatch loop is a `tokio::select!` between
`join_set.join_next()` and `msg_rx.recv()`. The `biased` keyword
checks branches in source order *only when both are Ready*; if the
join_set's `Err` is still propagating up the inner JoinSets when
`DestinationDone` arrives, the loop takes the `DestinationDone`
branch and `break Ok(())`. After that, `pool_shutdown.cancel()`
runs and the drain loop intentionally swallows task errors during
"shutdown_initiated" — but the file-level fail-early Err is *not*
expected: it's the real error that should fail the run.

Result: rcp returns 0 even though `--fail-early` should have failed
the copy. Reproduced locally as ~4% flake on commit `8388584`
(50-iter stress: 1 fail in 24 runs pre-fix, 0 fails in 50 post-fix);
also seen in CI on dependabot commit `585127d` (2026-04-27).

Fix: push a copy of the error to `error_collector` before returning
`Err` from the fail-early branch. `run_source` always consults the
collector via `take_error()` at the end of the run, so even if the
Err return is lost in the dispatch shutdown drain, the error is
still surfaced and rcpd reports `RcpdResult::Failure` to master.
`anyhow::Error` isn't `Clone`, so the collector copy is a
string-formatted version (chain preserved as text); the Err return
keeps the original structured chain.

50/50 stress passes post-fix; full `just ci` green.
