### PR TITLE
Update Rust toolchain to 1.95.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 let
   rust_overlay = import (builtins.fetchTarball https://github.com/oxalica/rust-overlay/archive/master.tar.gz);
   nixpkgs = import <nixpkgs> { overlays = [ rust_overlay ]; };
-  myrust = nixpkgs.rust-bin.stable."1.91.1".default.override {
+  myrust = nixpkgs.rust-bin.stable."1.95.0".default.override {
     extensions = [ "rust-analysis" "rust-src" ];
     targets = [ "x86_64-unknown-linux-musl" ];
   };

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
           inherit system overlays;
         };
 
-        rustToolchain = pkgs.rust-bin.stable."1.91.1".default.override {
+        rustToolchain = pkgs.rust-bin.stable."1.95.0".default.override {
           extensions = [ "rustfmt" "clippy" "rust-src" ];
           targets = [ "x86_64-unknown-linux-musl" ];
         };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.95.0"
 components = ["rustfmt", "clippy", "rust-src"]
 targets = ["x86_64-unknown-linux-musl"]

--- a/throttle/src/lib.rs
+++ b/throttle/src/lib.rs
@@ -358,8 +358,8 @@ async fn get_iops_tokens(tokens: u32) {
 }
 
 pub async fn get_file_iops_tokens(chunk_size: u64, file_size: u64) {
-    if chunk_size > 0 {
-        let tokens = 1 + (std::cmp::max(1, file_size) - 1) / chunk_size;
+    if let Some(div) = (std::cmp::max(1, file_size) - 1).checked_div(chunk_size) {
+        let tokens = 1 + div;
         if tokens > u64::from(u32::MAX) {
             tracing::error!(
                 "chunk size: {} is too small to limit throughput for files this big, size: {}",


### PR DESCRIPTION
## Summary
- Bumps the pinned Rust toolchain from 1.91.1 to 1.95.0 in `rust-toolchain.toml`, `flake.nix`, and `default.nix`.
- Fixes a new `clippy::manual_checked_ops` lint introduced in 1.95 by replacing the manual `chunk_size > 0` guard around a division with `checked_div`. Behavior is identical (`checked_div` returns `None` exactly when the divisor is 0).

## Test plan
- [x] `scripts/check-rust-version.sh` — version consistency confirmed
- [x] `just ci` — full lint + doc + debug/release tests + Docker tests all pass on 1.95.0