### PR TITLE
Add per-(side, op) HDR latency histograms with live panel + binary log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `--auto-meta-histogram`, `--auto-meta-histogram-log <PATH>`, and
+  `--auto-meta-histogram-interval <DUR>` for per-(side, op) HDR latency
+  histograms with live distribution panel and binary log file. See
+  `docs/congestion_control.md` for the format reference.
+
 ### Changed
 - Upgrade workspace to Rust 2024 edition; modernize code to use `let` chains and 2024 idioms
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1774,6 +1774,7 @@ dependencies = [
  "filetime",
  "futures",
  "globset",
+ "hdrhistogram",
  "humantime",
  "indicatif",
  "libc",
@@ -1786,6 +1787,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",
@@ -1799,7 +1801,11 @@ dependencies = [
 name = "rcp-tools-congestion"
 version = "0.32.0"
 dependencies = [
+ "hdrhistogram",
  "proptest",
+ "serde",
+ "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
 ]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -35,6 +35,7 @@ console-subscriber = "0.5"
 enum-map = "2.7"
 futures = "0.3"
 globset = "0.4"
+hdrhistogram = { version = "7.5", default-features = false, features = ["serialization"] }
 humantime = "2.3"
 indicatif = "0.18"
 libc = "0.2"
@@ -54,3 +55,4 @@ tracing-test = "0.2"
 [dev-dependencies]
 filetime = "0.2"
 proptest = "1"
+tempfile = "3"

--- a/common/src/cli.rs
+++ b/common/src/cli.rs
@@ -273,9 +273,18 @@ impl CommonArgs {
         }
     }
     /// Returns true if any progress-related flag was set.
+    ///
+    /// `--auto-meta-histogram` implies progress because its sole purpose is
+    /// to render a live distribution panel. `--auto-meta-histogram-log` does
+    /// NOT imply progress — it writes to a file regardless of progress mode,
+    /// and forcing a display would be worse UX for users who only want the
+    /// file.
     #[must_use]
     pub fn progress_requested(&self) -> bool {
-        self.progress || self.progress_type.is_some() || self.progress_delay.is_some()
+        self.progress
+            || self.progress_type.is_some()
+            || self.progress_delay.is_some()
+            || self.auto_meta_histogram
     }
 
     /// Build user-facing [`crate::ProgressSettings`] when any progress flag was
@@ -363,5 +372,25 @@ mod implies_tests {
         );
         // And no log path either.
         assert!(cli.common.auto_meta_histogram_log.is_none());
+    }
+
+    #[test]
+    fn auto_meta_histogram_implies_progress() {
+        let cli = TestCli::parse_from(["test", "--auto-meta-histogram"]);
+        assert!(
+            cli.common.progress_requested(),
+            "--auto-meta-histogram alone must imply progress so the panel actually renders",
+        );
+    }
+
+    #[test]
+    fn auto_meta_histogram_log_does_not_imply_progress() {
+        // the log file writes regardless of progress; user can opt in to
+        // progress separately. don't force it on them.
+        let cli = TestCli::parse_from(["test", "--auto-meta-histogram-log", "/tmp/x.hdr"]);
+        assert!(
+            !cli.common.progress_requested(),
+            "--auto-meta-histogram-log alone should NOT imply progress",
+        );
     }
 }

--- a/common/src/cli.rs
+++ b/common/src/cli.rs
@@ -190,6 +190,28 @@ pub struct CommonArgs {
         help_heading = "Congestion control (advanced)"
     )]
     pub auto_meta_tick_interval: humantime::Duration,
+    /// Enable in-memory HDR latency histograms per (side, op). Implies
+    /// `--auto-meta-throttle`. Adds a distribution panel beneath the
+    /// existing one-line-per-controller summary in the progress display.
+    #[arg(long, help_heading = "Congestion control")]
+    pub auto_meta_histogram: bool,
+    /// Write a binary log of per-(side, op) HDR histograms to the given
+    /// path. The file is truncated if it already exists — rename or move
+    /// logs you want to keep across runs. Format documented in
+    /// `docs/congestion_control.md`. Implies `--auto-meta-histogram` and
+    /// `--auto-meta-throttle`.
+    #[arg(long, value_name = "PATH", help_heading = "Congestion control")]
+    pub auto_meta_histogram_log: Option<std::path::PathBuf>,
+    /// Snapshot cadence for the histogram logger (e.g. "1s"). Drives both
+    /// the panel refresh rate and the log-file record interval. Range
+    /// `[100ms, 60s]`.
+    #[arg(
+        long,
+        default_value = "1s",
+        value_name = "DUR",
+        help_heading = "Congestion control"
+    )]
+    pub auto_meta_histogram_interval: humantime::Duration,
 }
 
 impl CommonArgs {
@@ -222,28 +244,32 @@ impl CommonArgs {
         max_open_files: Option<usize>,
         chunk_size: u64,
     ) -> crate::ThrottleConfig {
-        let auto_meta = self
-            .auto_meta_throttle
-            .then(|| crate::AutoMetaThrottleConfig {
-                initial_cwnd: self.auto_meta_initial_cwnd,
-                min_cwnd: self.auto_meta_min_cwnd,
-                max_cwnd: self.auto_meta_max_cwnd,
-                alpha: self.auto_meta_alpha,
-                beta: self.auto_meta_beta,
-                increase_step: self.auto_meta_increase_step,
-                decrease_step: self.auto_meta_decrease_step,
-                baseline_percentile: self.auto_meta_baseline_percentile,
-                current_percentile: self.auto_meta_current_percentile,
-                long_window: self.auto_meta_long_window.into(),
-                short_window: self.auto_meta_short_window.into(),
-                tick_interval: self.auto_meta_tick_interval.into(),
-            });
+        let auto_meta_implied = self.auto_meta_throttle
+            || self.auto_meta_histogram
+            || self.auto_meta_histogram_log.is_some();
+        let auto_meta = auto_meta_implied.then(|| crate::AutoMetaThrottleConfig {
+            initial_cwnd: self.auto_meta_initial_cwnd,
+            min_cwnd: self.auto_meta_min_cwnd,
+            max_cwnd: self.auto_meta_max_cwnd,
+            alpha: self.auto_meta_alpha,
+            beta: self.auto_meta_beta,
+            increase_step: self.auto_meta_increase_step,
+            decrease_step: self.auto_meta_decrease_step,
+            baseline_percentile: self.auto_meta_baseline_percentile,
+            current_percentile: self.auto_meta_current_percentile,
+            long_window: self.auto_meta_long_window.into(),
+            short_window: self.auto_meta_short_window.into(),
+            tick_interval: self.auto_meta_tick_interval.into(),
+        });
         crate::ThrottleConfig {
             max_open_files,
             ops_throttle: self.ops_throttle,
             iops_throttle: self.iops_throttle,
             chunk_size,
             auto_meta,
+            histogram_enabled: self.auto_meta_histogram || self.auto_meta_histogram_log.is_some(),
+            histogram_log_path: self.auto_meta_histogram_log.clone(),
+            histogram_interval: self.auto_meta_histogram_interval.into(),
         }
     }
     /// Returns true if any progress-related flag was set.
@@ -251,6 +277,7 @@ impl CommonArgs {
     pub fn progress_requested(&self) -> bool {
         self.progress || self.progress_type.is_some() || self.progress_delay.is_some()
     }
+
     /// Build user-facing [`crate::ProgressSettings`] when any progress flag was
     /// set, else `None`. `kind` selects the tool-specific printer. For `rcp`'s
     /// remote-master and `rcpd`'s remote progress modes, build `ProgressSettings`
@@ -270,5 +297,71 @@ impl CommonArgs {
             },
             progress_delay: self.progress_delay.clone(),
         })
+    }
+}
+
+#[cfg(test)]
+mod implies_tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        common: CommonArgs,
+    }
+
+    #[test]
+    fn auto_meta_histogram_implies_throttle_at_cli() {
+        let cli = TestCli::parse_from(["test", "--auto-meta-histogram"]);
+        let throttle = cli.common.throttle_config(None, 0);
+        assert!(
+            throttle.auto_meta.is_some(),
+            "histogram flag must imply auto_meta"
+        );
+        assert!(throttle.histogram_enabled);
+    }
+
+    #[test]
+    fn auto_meta_histogram_log_implies_throttle_at_cli() {
+        let cli = TestCli::parse_from(["test", "--auto-meta-histogram-log", "/tmp/x.hdr"]);
+        let throttle = cli.common.throttle_config(None, 0);
+        assert!(
+            throttle.auto_meta.is_some(),
+            "histogram-log flag must imply auto_meta"
+        );
+        assert!(throttle.histogram_log_path.is_some());
+    }
+
+    #[test]
+    fn no_auto_meta_flags_means_no_throttle() {
+        let cli = TestCli::parse_from(["test"]);
+        let throttle = cli.common.throttle_config(None, 0);
+        assert!(throttle.auto_meta.is_none());
+        assert!(!throttle.histogram_enabled);
+    }
+
+    /// `--auto-meta-histogram` (panel-only) sets `auto_meta_throttle = false`.
+    ///
+    /// The rcp binary uses this distinction when building `RcpdConfig`: it
+    /// gates `RcpdConfig::auto_meta` on `auto_meta_throttle || histogram_log
+    /// .is_some()`, so that the panel-only flag does NOT silently enable the
+    /// throttle pipeline on remote daemons.  This test pins that distinction
+    /// at the `CommonArgs` level so a future refactor cannot accidentally
+    /// collapse the two flags.
+    #[test]
+    fn panel_flag_does_not_set_explicit_throttle_field() {
+        let cli = TestCli::parse_from(["test", "--auto-meta-histogram"]);
+        // `throttle_config()` returns `auto_meta = Some(...)` because the
+        // panel needs the throttle pipeline locally — that's intentional.
+        assert!(cli.common.throttle_config(None, 0).auto_meta.is_some());
+        // But the *explicit* throttle field must stay false so the rcp binary
+        // can distinguish "panel only" from "user explicitly asked for throttle".
+        assert!(
+            !cli.common.auto_meta_throttle,
+            "--auto-meta-histogram must not set auto_meta_throttle"
+        );
+        // And no log path either.
+        assert!(cli.common.auto_meta_histogram_log.is_none());
     }
 }

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -54,7 +54,7 @@ pub struct AutoMetaThrottleConfig {
 }
 
 /// Throttling configuration for resource control
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone)]
 pub struct ThrottleConfig {
     /// Maximum number of open files (None = 80% of system limit)
     pub max_open_files: Option<usize>,
@@ -66,6 +66,32 @@ pub struct ThrottleConfig {
     pub chunk_size: u64,
     /// Adaptive metadata-ops throttle, if enabled via `--auto-meta-throttle`.
     pub auto_meta: Option<AutoMetaThrottleConfig>,
+    /// Enables in-memory HDR histograms for the auto-meta probes (live
+    /// display panel + driver for the optional log file). Implied by
+    /// `histogram_log_path.is_some()`.
+    pub histogram_enabled: bool,
+    /// When set, the auto-meta histogram logger appends a binary record
+    /// stream to this path on each snapshot tick. See
+    /// `docs/congestion_control.md` for the format.
+    pub histogram_log_path: Option<std::path::PathBuf>,
+    /// Snapshot cadence for the histogram logger. Drives both the live
+    /// panel and the log file. Range `[100ms, 60s]`.
+    pub histogram_interval: std::time::Duration,
+}
+
+impl Default for ThrottleConfig {
+    fn default() -> Self {
+        Self {
+            max_open_files: None,
+            ops_throttle: 0,
+            iops_throttle: 0,
+            chunk_size: 0,
+            auto_meta: None,
+            histogram_enabled: false,
+            histogram_log_path: None,
+            histogram_interval: std::time::Duration::from_secs(1),
+        }
+    }
 }
 
 /// Minimum static `--ops-throttle` when `--auto-meta-throttle` is on.
@@ -149,6 +175,72 @@ impl ThrottleConfig {
                      interval.",
                     self.ops_throttle, AUTO_META_MIN_OPS_THROTTLE, AUTO_META_MIN_OPS_THROTTLE,
                 ));
+            }
+        }
+        let histogram_active = self.histogram_enabled || self.histogram_log_path.is_some();
+        if histogram_active && self.auto_meta.is_none() {
+            return Err(
+                "--auto-meta-histogram and --auto-meta-histogram-log require \
+                 --auto-meta-throttle to be enabled"
+                    .into(),
+            );
+        }
+        if histogram_active {
+            let min = std::time::Duration::from_millis(100);
+            let max = std::time::Duration::from_secs(60);
+            if self.histogram_interval < min || self.histogram_interval > max {
+                return Err(format!(
+                    "--auto-meta-histogram-interval must be in [{}ms, {}s]",
+                    min.as_millis(),
+                    max.as_secs(),
+                ));
+            }
+            if let Some(path) = &self.histogram_log_path {
+                // Path::parent() of "foo.hdr" returns Some("") — empty path,
+                // not None. Treat that the same as None (i.e. current dir).
+                let parent = match path.parent() {
+                    Some(p) if p.as_os_str().is_empty() => std::path::Path::new("."),
+                    Some(p) => p,
+                    None => std::path::Path::new("."),
+                };
+                if !parent.exists() {
+                    return Err(format!(
+                        "--auto-meta-histogram-log parent directory does not exist: {parent:?}",
+                    ));
+                }
+                if !parent.is_dir() {
+                    return Err(format!(
+                        "--auto-meta-histogram-log parent is not a directory: {parent:?}",
+                    ));
+                }
+                // Probe writability: try to create a tiny temp file in the parent.
+                // We don't pre-create the actual log file because the spawn step
+                // adds a trace-identifier suffix.
+                //
+                // Use create_new (O_EXCL) and a random suffix so:
+                //   1. a pre-created symlink with the predictable probe name
+                //      can't redirect the create to an attacker-chosen path, and
+                //   2. two concurrent validations never collide on the probe name.
+                let suffix: u64 = rand::random();
+                let probe = parent.join(format!(
+                    ".rcp-auto-meta-probe-{}-{:016x}",
+                    std::process::id(),
+                    suffix,
+                ));
+                match std::fs::OpenOptions::new()
+                    .create_new(true)
+                    .write(true)
+                    .open(&probe)
+                {
+                    Ok(_) => {
+                        let _ = std::fs::remove_file(&probe);
+                    }
+                    Err(err) => {
+                        return Err(format!(
+                            "--auto-meta-histogram-log parent {parent:?} is not writable: {err:#}",
+                        ));
+                    }
+                }
             }
         }
         Ok(())
@@ -302,6 +394,9 @@ mod auto_meta_validation_tests {
             iops_throttle: 0,
             chunk_size: 0,
             auto_meta: Some(auto),
+            histogram_enabled: false,
+            histogram_log_path: None,
+            histogram_interval: std::time::Duration::from_secs(1),
         }
     }
 
@@ -440,6 +535,9 @@ mod auto_meta_validation_tests {
             iops_throttle: 0,
             chunk_size: 0,
             auto_meta: None,
+            histogram_enabled: false,
+            histogram_log_path: None,
+            histogram_interval: std::time::Duration::from_secs(1),
         };
         assert!(config.validate().is_ok());
     }
@@ -451,5 +549,117 @@ mod auto_meta_validation_tests {
         auto.beta = 1.5;
         let err = config_with(auto).validate().unwrap_err();
         assert!(err.contains("alpha") && err.contains("beta"), "got: {err}");
+    }
+
+    #[test]
+    fn histogram_log_without_throttle_is_rejected() {
+        // Recording a log requires the throttle pipeline to be live.
+        let config = ThrottleConfig {
+            max_open_files: None,
+            ops_throttle: 0,
+            iops_throttle: 0,
+            chunk_size: 0,
+            auto_meta: None,
+            histogram_log_path: Some("/tmp/x.hdr".into()),
+            histogram_enabled: false,
+            histogram_interval: std::time::Duration::from_secs(1),
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("histogram") && err.contains("auto-meta-throttle"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn histogram_enabled_without_throttle_is_rejected() {
+        // --auto-meta-histogram alone (no log path) without --auto-meta-throttle
+        // is rejected for the same reason: nothing to histogram.
+        let config = ThrottleConfig {
+            max_open_files: None,
+            ops_throttle: 0,
+            iops_throttle: 0,
+            chunk_size: 0,
+            auto_meta: None,
+            histogram_enabled: true,
+            histogram_log_path: None,
+            histogram_interval: std::time::Duration::from_secs(1),
+        };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("histogram") && err.contains("auto-meta-throttle"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn histogram_interval_below_floor_is_rejected() {
+        let mut config = config_with(valid_auto_meta());
+        config.histogram_enabled = true;
+        config.histogram_interval = std::time::Duration::from_millis(50);
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("histogram-interval"), "got: {err}");
+    }
+
+    #[test]
+    fn histogram_interval_above_ceiling_is_rejected() {
+        let mut config = config_with(valid_auto_meta());
+        config.histogram_enabled = true;
+        config.histogram_interval = std::time::Duration::from_secs(120);
+        let err = config.validate().unwrap_err();
+        assert!(err.contains("histogram-interval"), "got: {err}");
+    }
+
+    #[test]
+    fn histogram_defaults_pass_validation() {
+        let mut config = config_with(valid_auto_meta());
+        config.histogram_enabled = true;
+        config.histogram_interval = std::time::Duration::from_secs(1);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn histogram_log_with_missing_parent_is_rejected() {
+        let mut config = config_with(valid_auto_meta());
+        config.histogram_log_path = Some("/nonexistent-dir-12345/foo.hdr".into());
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.contains("histogram-log") && err.contains("parent"),
+            "got: {err}",
+        );
+    }
+
+    #[test]
+    fn histogram_log_with_writable_parent_is_accepted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = config_with(valid_auto_meta());
+        config.histogram_log_path = Some(dir.path().join("foo.hdr"));
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn histogram_log_with_bare_filename_is_accepted() {
+        // Path::parent() of "foo.hdr" returns Some("") — empty path, not
+        // None. The validator must treat that as the current directory,
+        // not as a missing parent.
+        let mut config = config_with(valid_auto_meta());
+        config.histogram_log_path = Some("bare-filename.hdr".into());
+        assert!(
+            config.validate().is_ok(),
+            "validate err: {:?}",
+            config.validate(),
+        );
+    }
+
+    #[test]
+    fn histogram_log_validation_uses_unique_probe_per_call() {
+        // Two consecutive validations with the same path must succeed —
+        // proving the probe file is removed cleanly and the filename
+        // doesn't collide with itself.
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = config_with(valid_auto_meta());
+        config.histogram_log_path = Some(dir.path().join("log.hdr"));
+        assert!(config.validate().is_ok());
+        assert!(config.validate().is_ok());
     }
 }

--- a/common/src/histogram_logger.rs
+++ b/common/src/histogram_logger.rs
@@ -1,0 +1,399 @@
+//! Process-wide histogram logger task.
+//!
+//! Owns one `Arc<Mutex<HistogramAccumulator>>` per registered (side, op)
+//! pair (each shared with the corresponding `ControlUnit`). On each tick,
+//! takes a snapshot of every accumulator, publishes the snapshot through
+//! a per-unit watch channel for the live display, and (when a log path
+//! was configured) appends a binary record per non-empty snapshot.
+//!
+//! When the task ticks past a snapshot interval, it uses the actual
+//! snapshot end time as the record's `unix_micros` field — readers see
+//! the true coverage even if the host was loaded.
+
+use congestion::format::{LogHeader, write_file_header, write_record};
+use congestion::{HistogramAccumulator, MetadataOp, Side};
+
+/// One slot the logger owns: the accumulator (shared with a ControlUnit)
+/// and the watch sender used to publish snapshots to the display.
+pub struct LoggerUnit {
+    pub label: &'static str,
+    pub side: Side,
+    pub op: MetadataOp,
+    pub accumulator: std::sync::Arc<std::sync::Mutex<HistogramAccumulator>>,
+    pub snapshot_tx: tokio::sync::watch::Sender<hdrhistogram::Histogram<u64>>,
+}
+
+/// Configuration for the logger task.
+pub struct LoggerConfig {
+    pub interval: std::time::Duration,
+    pub log_path: Option<std::path::PathBuf>,
+    pub header: LogHeader,
+}
+
+/// Run the logger task: ticks, snapshots, publishes, optionally writes
+/// to file. Exits when the provided cancellation token signals.
+pub async fn run_logger(
+    config: LoggerConfig,
+    units: Vec<LoggerUnit>,
+    mut cancel: tokio::sync::watch::Receiver<bool>,
+) {
+    let mut writer: Option<std::io::BufWriter<std::fs::File>> = match &config.log_path {
+        Some(path) => {
+            let mut open_options = std::fs::OpenOptions::new();
+            open_options.create(true).write(true).truncate(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                open_options.custom_flags(libc::O_NOFOLLOW);
+            }
+            match open_options.open(path) {
+                Ok(f) => {
+                    let mut w = std::io::BufWriter::new(f);
+                    if let Err(err) = write_file_header(&mut w, &config.header) {
+                        tracing::warn!(
+                            "histogram-logger: failed to write file header: {err:#}; \
+                                        disabling file output"
+                        );
+                        None
+                    } else {
+                        Some(w)
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "histogram-logger: failed to open {path:?}: {err:#}; \
+                                    disabling file output"
+                    );
+                    None
+                }
+            }
+        }
+        None => None,
+    };
+    let mut interval = tokio::time::interval(config.interval);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    interval.tick().await;
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                writer = snapshot_and_publish_units(&units, writer);
+            }
+            _ = cancel.changed() => {
+                if *cancel.borrow() {
+                    // Flush any samples accumulated since the last tick
+                    // so a short copy / partial final interval doesn't lose data.
+                    drop(snapshot_and_publish_units(&units, writer));
+                    break;
+                }
+            }
+        }
+    }
+    tracing::debug!("histogram-logger: exiting");
+}
+
+/// Snapshot every accumulator, publish to its watch, optionally write
+/// to the log file. Returns the (possibly None'd) writer back to the
+/// caller — if a write or flush fails, the returned Option is None
+/// and a warning has been emitted.
+fn snapshot_and_publish_units(
+    units: &[LoggerUnit],
+    mut writer: Option<std::io::BufWriter<std::fs::File>>,
+) -> Option<std::io::BufWriter<std::fs::File>> {
+    use std::io::Write;
+    for unit in units {
+        let snap = unit
+            .accumulator
+            .lock()
+            .expect("histogram accumulator mutex poisoned")
+            .snapshot_and_reset();
+        // Capture the snapshot's end-time AFTER the lock+reset so the
+        // record's unix_micros reflects what samples are actually in
+        // the snapshot. With synchronous histogram capture in the
+        // RoutingSink, samples can land in *later* units' accumulators
+        // while this loop is still walking earlier ones; a single
+        // pre-loop timestamp would backdate those later snapshots.
+        let snapshot_micros = unix_micros_now();
+        let _ = unit.snapshot_tx.send(snap.clone());
+        if snap.is_empty() {
+            continue;
+        }
+        if let Some(w) = writer.as_mut()
+            && let Err(err) = write_record(w, snapshot_micros, unit.side, unit.op, &snap)
+        {
+            tracing::warn!(
+                "histogram-logger: write_record({label}) failed: {err:#}; \
+                 disabling file output",
+                label = unit.label,
+            );
+            writer = None;
+            break;
+        }
+    }
+    if let Some(w) = writer.as_mut()
+        && let Err(err) = w.flush()
+    {
+        tracing::warn!("histogram-logger: flush failed: {err:#}; disabling file output",);
+        writer = None;
+    }
+    writer
+}
+
+fn unix_micros_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_micros()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use congestion::format::{
+        AutoMetaSnapshot, HdrSnapshot, LogHeader, UnitLabel, read_file_header, read_record,
+    };
+
+    fn header() -> LogHeader {
+        LogHeader {
+            format_version: 1,
+            tool: "test".into(),
+            tool_version: "0.0.0".into(),
+            hostname: "h".into(),
+            pid: 0,
+            start_unix_micros: 0,
+            snapshot_interval_micros: 100_000,
+            auto_meta: AutoMetaSnapshot {
+                initial_cwnd: 1,
+                min_cwnd: 1,
+                max_cwnd: 4096,
+                alpha: 1.3,
+                beta: 1.8,
+                increase_step: 1,
+                decrease_step: 1,
+                baseline_percentile: 0.1,
+                current_percentile: 0.5,
+                long_window_micros: 10_000_000,
+                short_window_micros: 1_000_000,
+                tick_interval_micros: 50_000,
+            },
+            hdr: HdrSnapshot {
+                lowest_discernible_micros: 1,
+                highest_trackable_micros: 3_600_000_000,
+                significant_figures: 3,
+                unit: "microseconds".into(),
+            },
+            unit_labels: vec![UnitLabel {
+                side: 0,
+                op: 0,
+                label: "src-stat".into(),
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn writes_records_to_file_for_non_empty_snapshots() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.hdr");
+        let acc = std::sync::Arc::new(std::sync::Mutex::new(HistogramAccumulator::new()));
+        let (snap_tx, _snap_rx) = tokio::sync::watch::channel(
+            hdrhistogram::Histogram::<u64>::new_with_bounds(1, 3_600_000_000, 3).unwrap(),
+        );
+        let units = vec![LoggerUnit {
+            label: "src-stat",
+            side: Side::Source,
+            op: MetadataOp::Stat,
+            accumulator: acc.clone(),
+            snapshot_tx: snap_tx,
+        }];
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        // Pre-load some samples so the first tick records something.
+        acc.lock()
+            .unwrap()
+            .record(std::time::Duration::from_micros(100));
+        acc.lock()
+            .unwrap()
+            .record(std::time::Duration::from_micros(200));
+        let config = LoggerConfig {
+            interval: std::time::Duration::from_millis(50),
+            log_path: Some(path.clone()),
+            header: header(),
+        };
+        let handle = tokio::spawn(run_logger(config, units, cancel_rx));
+        // Wait for at least one tick to fire and write a record.
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        cancel_tx.send(true).unwrap();
+        handle.await.unwrap();
+
+        let file = std::fs::File::open(&path).unwrap();
+        let mut reader = std::io::BufReader::new(file);
+        let _ = read_file_header(&mut reader).unwrap();
+        let rec = read_record(&mut reader)
+            .unwrap()
+            .expect("at least one record written");
+        assert_eq!(rec.samples_count, 2);
+        assert_eq!(rec.side, Side::Source);
+        assert_eq!(rec.op, MetadataOp::Stat);
+    }
+
+    #[tokio::test]
+    async fn empty_snapshots_publish_via_watch_but_skip_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.hdr");
+        let acc = std::sync::Arc::new(std::sync::Mutex::new(HistogramAccumulator::new()));
+        let (snap_tx, snap_rx) = tokio::sync::watch::channel(
+            hdrhistogram::Histogram::<u64>::new_with_bounds(1, 3_600_000_000, 3).unwrap(),
+        );
+        let units = vec![LoggerUnit {
+            label: "src-stat",
+            side: Side::Source,
+            op: MetadataOp::Stat,
+            accumulator: acc.clone(),
+            snapshot_tx: snap_tx,
+        }];
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let config = LoggerConfig {
+            interval: std::time::Duration::from_millis(50),
+            log_path: Some(path.clone()),
+            header: header(),
+        };
+        let handle = tokio::spawn(run_logger(config, units, cancel_rx));
+        // Don't preload any samples; let the logger tick.
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        cancel_tx.send(true).unwrap();
+        handle.await.unwrap();
+
+        let file = std::fs::File::open(&path).unwrap();
+        let mut reader = std::io::BufReader::new(file);
+        let _ = read_file_header(&mut reader).unwrap();
+        // No records were written.
+        assert!(read_record(&mut reader).unwrap().is_none());
+        // But the watch has at least one update (the empty snapshot).
+        assert!(snap_rx.has_changed().unwrap_or(false) || snap_rx.borrow().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancel_before_first_tick_still_writes_pending_samples() {
+        // Regression: a short-lived copy may finish before the first
+        // periodic tick fires. The cancel arm must take one final snapshot
+        // before exiting so the log isn't header-only.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.hdr");
+        let acc = std::sync::Arc::new(std::sync::Mutex::new(HistogramAccumulator::new()));
+        let (snap_tx, _snap_rx) = tokio::sync::watch::channel(
+            hdrhistogram::Histogram::<u64>::new_with_bounds(1, 3_600_000_000, 3).unwrap(),
+        );
+        let units = vec![LoggerUnit {
+            label: "src-stat",
+            side: Side::Source,
+            op: MetadataOp::Stat,
+            accumulator: acc.clone(),
+            snapshot_tx: snap_tx,
+        }];
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        // Pre-load samples, then cancel before any tick fires.
+        acc.lock()
+            .unwrap()
+            .record(std::time::Duration::from_micros(42));
+        let config = LoggerConfig {
+            // Long interval so the periodic tick definitely doesn't fire
+            // before our cancel signal does.
+            interval: std::time::Duration::from_secs(60),
+            log_path: Some(path.clone()),
+            header: header(),
+        };
+        let handle = tokio::spawn(run_logger(config, units, cancel_rx));
+        // Give the task a moment to start and consume the initial tick,
+        // then send cancel before the next 60s tick.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        cancel_tx.send(true).unwrap();
+        handle.await.unwrap();
+
+        let file = std::fs::File::open(&path).unwrap();
+        let mut reader = std::io::BufReader::new(file);
+        let _ = read_file_header(&mut reader).unwrap();
+        let rec = read_record(&mut reader)
+            .unwrap()
+            .expect("cancellation must flush a final record");
+        assert_eq!(rec.samples_count, 1);
+    }
+
+    #[test]
+    fn snapshot_and_publish_uses_per_unit_timestamps() {
+        // Regression: a single pre-loop timestamp would stamp later
+        // units' records with a stale time, backdating samples that
+        // were synchronously recorded into them while the loop was
+        // walking earlier units.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.hdr");
+        let header = header();
+        let mut writer = Some(std::io::BufWriter::new(
+            std::fs::File::create(&path).unwrap(),
+        ));
+        {
+            use std::io::Write;
+            congestion::format::write_file_header(writer.as_mut().unwrap(), &header).unwrap();
+            writer.as_mut().unwrap().flush().unwrap();
+        }
+
+        let acc_a = std::sync::Arc::new(std::sync::Mutex::new(HistogramAccumulator::new()));
+        let acc_b = std::sync::Arc::new(std::sync::Mutex::new(HistogramAccumulator::new()));
+        acc_a
+            .lock()
+            .unwrap()
+            .record(std::time::Duration::from_micros(10));
+        acc_b
+            .lock()
+            .unwrap()
+            .record(std::time::Duration::from_micros(20));
+        let (snap_tx_a, _rx_a) = tokio::sync::watch::channel(
+            hdrhistogram::Histogram::<u64>::new_with_bounds(1, 3_600_000_000, 3).unwrap(),
+        );
+        let (snap_tx_b, _rx_b) = tokio::sync::watch::channel(
+            hdrhistogram::Histogram::<u64>::new_with_bounds(1, 3_600_000_000, 3).unwrap(),
+        );
+        let units = vec![
+            LoggerUnit {
+                label: "src-stat",
+                side: Side::Source,
+                op: MetadataOp::Stat,
+                accumulator: acc_a,
+                snapshot_tx: snap_tx_a,
+            },
+            LoggerUnit {
+                label: "dst-stat",
+                side: Side::Destination,
+                op: MetadataOp::Stat,
+                accumulator: acc_b,
+                snapshot_tx: snap_tx_b,
+            },
+        ];
+
+        let before_micros = unix_micros_now();
+        writer = snapshot_and_publish_units(&units, writer);
+        let after_micros = unix_micros_now();
+        drop(writer);
+
+        let f = std::fs::File::open(&path).unwrap();
+        let mut reader = std::io::BufReader::new(f);
+        let _ = congestion::format::read_file_header(&mut reader).unwrap();
+        let r1 = congestion::format::read_record(&mut reader)
+            .unwrap()
+            .expect("record 1");
+        let r2 = congestion::format::read_record(&mut reader)
+            .unwrap()
+            .expect("record 2");
+        assert!(
+            r1.unix_micros >= before_micros && r1.unix_micros <= after_micros,
+            "record 1 ts {} not in [{}, {}]",
+            r1.unix_micros,
+            before_micros,
+            after_micros,
+        );
+        assert!(
+            r2.unix_micros >= r1.unix_micros && r2.unix_micros <= after_micros,
+            "record 2 ts {} must be >= record 1 ts {} and <= after {}",
+            r2.unix_micros,
+            r1.unix_micros,
+            after_micros,
+        );
+    }
+}

--- a/common/src/histogram_panel.rs
+++ b/common/src/histogram_panel.rs
@@ -1,0 +1,169 @@
+//! Pure rendering of per-(side, op) latency distribution panels.
+//!
+//! The panel sits below the existing [`crate::observability::render_lines`]
+//! summary block and visualizes each active controller's most recent
+//! snapshot as a small ASCII histogram. Truncated to the densest 8 bands
+//! to fit beside the existing one-line-per-controller summary without
+//! overwhelming the terminal.
+
+use hdrhistogram::Histogram;
+
+/// One unit's data for the panel: its label, the snapshot, and the
+/// snapshot's covered duration (so the header line can name the
+/// window).
+pub struct PanelUnit<'a> {
+    pub label: &'a str,
+    pub histogram: &'a Histogram<u64>,
+    pub interval: std::time::Duration,
+}
+
+/// Number of histogram bands rendered per unit. Chosen to fit on screen
+/// alongside the existing one-line summary without overwhelming the
+/// progress display; smaller than the natural HDR bucket count.
+const ROWS_PER_UNIT: usize = 8;
+/// Max characters for the bar of the densest bucket.
+const BAR_WIDTH: usize = 24;
+
+const SEPARATOR: &str = "-----------------------";
+
+/// Render the distribution panel for the given units. Empty units (no
+/// samples) are skipped. Returns an empty string if every unit is
+/// empty.
+#[must_use]
+pub fn render_histogram_panel(units: &[PanelUnit]) -> String {
+    let visible: Vec<_> = units.iter().filter(|u| !u.histogram.is_empty()).collect();
+    if visible.is_empty() {
+        return String::new();
+    }
+    let mut out = String::new();
+    out.push('\n');
+    out.push_str(SEPARATOR);
+    for unit in &visible {
+        out.push('\n');
+        render_unit(&mut out, unit);
+    }
+    out
+}
+
+fn render_unit(out: &mut String, unit: &PanelUnit) {
+    let n = unit.histogram.len();
+    out.push_str(&format!(
+        "{label} distribution (last {secs:.1}s, n={n}):\n",
+        label = unit.label,
+        secs = unit.interval.as_secs_f64(),
+        n = n,
+    ));
+    // HDR's iter_log returns values bucketed at log-scale boundaries.
+    // We iterate, find the densest 8 contiguous bands centered on the
+    // mode, and render those.
+    let bands: Vec<(u64, u64)> = unit
+        .histogram
+        .iter_log(1, 2.0)
+        .map(|v| (v.value_iterated_to(), v.count_since_last_iteration()))
+        .filter(|&(_, c)| c > 0)
+        .collect();
+    if bands.is_empty() {
+        out.push_str("  (no samples)\n");
+        return;
+    }
+    let mode_idx = bands
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, (_, c))| *c)
+        .map(|(i, _)| i)
+        .unwrap_or(0);
+    let half = ROWS_PER_UNIT / 2;
+    let lo = mode_idx.saturating_sub(half);
+    let hi = (lo + ROWS_PER_UNIT).min(bands.len());
+    let lo = hi.saturating_sub(ROWS_PER_UNIT);
+    let visible_bands = &bands[lo..hi];
+    let max_count = visible_bands.iter().map(|&(_, c)| c).max().unwrap_or(1);
+    for &(value, count) in visible_bands {
+        let bar_len = ((count * BAR_WIDTH as u64) / max_count) as usize;
+        let bar = "█".repeat(bar_len);
+        out.push_str(&format!(
+            "  {value:>8} {bar:<bar_width$} {count}\n",
+            value = format_micros(value),
+            bar = bar,
+            bar_width = BAR_WIDTH,
+            count = count,
+        ));
+    }
+}
+
+fn format_micros(v: u64) -> String {
+    if v < 1_000 {
+        format!("{v}µs")
+    } else if v < 1_000_000 {
+        format!("{:.1}ms", v as f64 / 1_000.0)
+    } else {
+        format!("{:.1}s", v as f64 / 1_000_000.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_hist(samples: &[u64]) -> Histogram<u64> {
+        let mut h = Histogram::<u64>::new_with_bounds(1, 3_600_000_000, 3).unwrap();
+        for &v in samples {
+            h.record(v).unwrap();
+        }
+        h
+    }
+
+    #[test]
+    fn empty_units_produce_empty_output() {
+        let h = make_hist(&[]);
+        let units = [PanelUnit {
+            label: "src-stat",
+            histogram: &h,
+            interval: std::time::Duration::from_secs(1),
+        }];
+        assert_eq!(render_histogram_panel(&units), "");
+    }
+
+    #[test]
+    fn renders_per_unit_header_and_bands() {
+        // 100 samples clustered around 100µs / 200µs; render must include
+        // the unit's label, the "last 1.0s, n=100" header, and at least
+        // one bar character.
+        let mut samples = vec![100u64; 70];
+        samples.extend(vec![200u64; 30]);
+        let h = make_hist(&samples);
+        let units = [PanelUnit {
+            label: "src-stat",
+            histogram: &h,
+            interval: std::time::Duration::from_secs(1),
+        }];
+        let out = render_histogram_panel(&units);
+        assert!(out.contains("src-stat distribution"), "got: {out}");
+        assert!(out.contains("n=100"), "got: {out}");
+        assert!(
+            out.contains('█'),
+            "expected at least one bar block, got: {out}"
+        );
+    }
+
+    #[test]
+    fn empty_unit_is_skipped_among_active_units() {
+        let h_empty = make_hist(&[]);
+        let h_full = make_hist(&[100, 200, 300]);
+        let units = [
+            PanelUnit {
+                label: "idle",
+                histogram: &h_empty,
+                interval: std::time::Duration::from_secs(1),
+            },
+            PanelUnit {
+                label: "active",
+                histogram: &h_full,
+                interval: std::time::Duration::from_secs(1),
+            },
+        ];
+        let out = render_histogram_panel(&units);
+        assert!(!out.contains("idle"), "idle unit must be hidden: {out}");
+        assert!(out.contains("active"), "active unit must show: {out}");
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -118,6 +118,8 @@ pub mod error;
 pub mod error_collector;
 pub mod filegen;
 pub mod filter;
+pub mod histogram_logger;
+pub mod histogram_panel;
 pub mod link;
 pub mod observability;
 pub mod preserve;
@@ -207,6 +209,40 @@ static PBAR: std::sync::LazyLock<indicatif::ProgressBar> =
     std::sync::LazyLock::new(indicatif::ProgressBar::new_spinner);
 static REMOTE_RUNTIME_STATS: std::sync::LazyLock<std::sync::Mutex<Option<RemoteRuntimeStats>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
+static HISTOGRAM_LOGGER_CANCEL: std::sync::Mutex<Option<tokio::sync::watch::Sender<bool>>> =
+    std::sync::Mutex::new(None);
+static HISTOGRAM_LOGGER_HANDLE: std::sync::Mutex<Option<tokio::task::JoinHandle<()>>> =
+    std::sync::Mutex::new(None);
+
+fn store_logger_cancel(tx: tokio::sync::watch::Sender<bool>) {
+    *HISTOGRAM_LOGGER_CANCEL
+        .lock()
+        .expect("histogram logger cancel mutex poisoned") = Some(tx);
+}
+
+fn store_logger_handle(handle: tokio::task::JoinHandle<()>) {
+    *HISTOGRAM_LOGGER_HANDLE
+        .lock()
+        .expect("histogram logger handle mutex poisoned") = Some(handle);
+}
+
+fn take_logger_handle() -> Option<tokio::task::JoinHandle<()>> {
+    HISTOGRAM_LOGGER_HANDLE
+        .lock()
+        .expect("histogram logger handle mutex poisoned")
+        .take()
+}
+
+fn signal_logger_cancel() {
+    if let Some(tx) = HISTOGRAM_LOGGER_CANCEL
+        .lock()
+        .expect("histogram logger cancel mutex poisoned")
+        .take()
+        && let Err(err) = tx.send(true)
+    {
+        tracing::debug!("histogram-logger cancel send failed (already gone): {err:#}");
+    }
+}
 
 #[must_use]
 pub fn get_progress() -> &'static progress::Progress {
@@ -301,6 +337,7 @@ fn progress_bar(
         PBAR.set_position(PBAR.position() + 1); // do we need to update?
         let mut msg = prog_printer.print().unwrap();
         msg.push_str(&observability::render_lines());
+        msg.push_str(&render_panel_from_registry());
         PBAR.set_message(msg);
         let result = cvar.wait_timeout(is_done, delay).unwrap();
         is_done = result.0;
@@ -329,10 +366,11 @@ fn text_updates(
     loop {
         eprintln!("=======================");
         eprintln!(
-            "{}\n--{}{}",
+            "{}\n--{}{}{}",
             get_datetime_prefix(),
             prog_printer.print().unwrap(),
             observability::render_lines(),
+            render_panel_from_registry(),
         );
         let result = cvar.wait_timeout(is_done, delay).unwrap();
         is_done = result.0;
@@ -393,11 +431,11 @@ fn remote_master_updates<F>(
             let source_progress = &progress_map[RcpdType::Source];
             let destination_progress = &progress_map[RcpdType::Destination];
             PBAR.set_position(PBAR.position() + 1); // do we need to update?
-            PBAR.set_message(
-                printer
-                    .print(source_progress, destination_progress)
-                    .unwrap(),
-            );
+            let mut msg = printer
+                .print(source_progress, destination_progress)
+                .unwrap();
+            msg.push_str(&render_panel_from_registry());
+            PBAR.set_message(msg);
             let result = cvar.wait_timeout(is_done, delay).unwrap();
             is_done = result.0;
             if *is_done {
@@ -415,11 +453,12 @@ fn remote_master_updates<F>(
             let destination_progress = &progress_map[RcpdType::Destination];
             eprintln!("=======================");
             eprintln!(
-                "{}\n--{}",
+                "{}\n--{}{}",
                 get_datetime_prefix(),
                 printer
                     .print(source_progress, destination_progress)
-                    .unwrap()
+                    .unwrap(),
+                render_panel_from_registry(),
             );
             let result = cvar.wait_timeout(is_done, delay).unwrap();
             is_done = result.0;
@@ -1054,7 +1093,11 @@ fn build_tokio_runtime(
 /// 2. the adapter's 100ms conversion assumption matches the thread's
 ///    real interval, regardless of the user's static `--ops-throttle`
 ///    value.
-fn spawn_throttle_replenishers(runtime: &tokio::runtime::Runtime, throttle: &ThrottleConfig) {
+fn spawn_throttle_replenishers(
+    runtime: &tokio::runtime::Runtime,
+    throttle: &ThrottleConfig,
+    trace_identifier: &str,
+) {
     fn get_replenish_interval(replenish: usize) -> (usize, std::time::Duration) {
         let mut replenish = replenish;
         let mut interval = std::time::Duration::from_secs(1);
@@ -1091,7 +1134,101 @@ fn spawn_throttle_replenishers(runtime: &tokio::runtime::Runtime, throttle: &Thr
         runtime.spawn(throttle::run_iops_replenish_thread(replenish, interval));
     }
     if let Some(auto) = throttle.auto_meta {
-        spawn_auto_meta_throttle(runtime, auto);
+        spawn_auto_meta_throttle(
+            runtime,
+            auto,
+            throttle.histogram_enabled,
+            throttle.histogram_log_path.clone(),
+            throttle.histogram_interval,
+            trace_identifier,
+        );
+    }
+}
+
+/// Compute the per-tool resolved log path by inserting `trace_identifier`
+/// between the user-supplied stem and extension. Mirrors the
+/// chrome_trace_prefix convention so master and rcpds don't collide on
+/// localhost runs.
+///
+/// Handles three edge cases consistently with the validator:
+/// - bare filename (`foo.hdr`): parent → `.`
+/// - no extension (`foo`): extension → `hdr`
+/// - no stem (`.hidden`): stem → `auto-meta`
+///
+/// Non-UTF-8 stem and extension components (valid on Unix) are preserved
+/// unchanged; only genuinely absent components fall back to defaults.
+fn resolve_log_path(path: &std::path::Path, trace_identifier: &str) -> std::path::PathBuf {
+    let parent = match path.parent() {
+        Some(p) if p.as_os_str().is_empty() => std::path::Path::new("."),
+        Some(p) => p,
+        None => std::path::Path::new("."),
+    };
+    let mut name: std::ffi::OsString = path
+        .file_stem()
+        .map(|s| s.to_os_string())
+        .unwrap_or_else(|| std::ffi::OsString::from("auto-meta"));
+    name.push(".");
+    name.push(trace_identifier);
+    name.push(".");
+    match path.extension() {
+        Some(e) => name.push(e),
+        None => name.push("hdr"),
+    }
+    parent.join(name)
+}
+
+/// Verify the resolved histogram log path can actually be opened for
+/// writing. Called from [`run`] before any work begins so a typo or
+/// permission issue surfaces as a configuration error rather than a
+/// silent warning at runtime.
+///
+/// The check creates+truncates the file (matching what the logger
+/// task does later) so it catches "exists as a directory", "exists
+/// as an unwritable file", and most permission issues. The logger's
+/// own open later in startup will reuse the same path; the double-
+/// open is harmless (the logger truncates again).
+fn validate_histogram_log_target(
+    throttle: &ThrottleConfig,
+    trace_identifier: &str,
+) -> Result<(), String> {
+    let Some(path) = &throttle.histogram_log_path else {
+        return Ok(());
+    };
+    if path.is_dir() {
+        return Err(format!(
+            "--auto-meta-histogram-log {path:?} is a directory; expected a file path",
+        ));
+    }
+    if path.file_name().is_none() {
+        return Err(format!(
+            "--auto-meta-histogram-log {path:?} has no filename component",
+        ));
+    }
+    let resolved = resolve_log_path(path, trace_identifier);
+    let mut open_options = std::fs::OpenOptions::new();
+    open_options.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        open_options.custom_flags(libc::O_NOFOLLOW);
+    }
+    match open_options.open(&resolved) {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            // ELOOP from O_NOFOLLOW reads as "too many levels of symbolic links"
+            // — make it explicit that this rejection is intentional security.
+            #[cfg(unix)]
+            let context = if err.raw_os_error() == Some(libc::ELOOP) {
+                " (resolved path is a symlink, which would let a local attacker hijack the write)"
+            } else {
+                ""
+            };
+            #[cfg(not(unix))]
+            let context = "";
+            Err(format!(
+                "--auto-meta-histogram-log cannot create resolved path {resolved:?}: {err:#}{context}",
+            ))
+        }
     }
 }
 
@@ -1147,6 +1284,82 @@ const fn unit_label(side: congestion::Side, op: congestion::MetadataOp) -> &'sta
     }
 }
 
+fn build_histogram_header(
+    auto: &AutoMetaThrottleConfig,
+    tool_name: &str,
+    snapshot_interval: std::time::Duration,
+) -> congestion::format::LogHeader {
+    use congestion::format::{AutoMetaSnapshot, HdrSnapshot, LogHeader, UnitLabel};
+    let hostname = nix::unistd::gethostname()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".into());
+    let mut unit_labels = Vec::with_capacity(congestion::N_META_RESOURCES);
+    for &side in &congestion::Side::ALL {
+        for &op in &congestion::MetadataOp::ALL {
+            unit_labels.push(UnitLabel {
+                side: side as u8,
+                op: op as u8,
+                label: unit_label(side, op).to_string(),
+            });
+        }
+    }
+    LogHeader {
+        format_version: 1,
+        tool: tool_name.to_string(),
+        tool_version: env!("CARGO_PKG_VERSION").to_string(),
+        hostname,
+        pid: std::process::id(),
+        start_unix_micros: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| u64::try_from(d.as_micros()).unwrap_or(u64::MAX))
+            .unwrap_or(0),
+        snapshot_interval_micros: u64::try_from(snapshot_interval.as_micros()).unwrap_or(u64::MAX),
+        auto_meta: AutoMetaSnapshot {
+            initial_cwnd: auto.initial_cwnd,
+            min_cwnd: auto.min_cwnd,
+            max_cwnd: auto.max_cwnd,
+            alpha: auto.alpha,
+            beta: auto.beta,
+            increase_step: auto.increase_step,
+            decrease_step: auto.decrease_step,
+            baseline_percentile: auto.baseline_percentile,
+            current_percentile: auto.current_percentile,
+            long_window_micros: u64::try_from(auto.long_window.as_micros()).unwrap_or(u64::MAX),
+            short_window_micros: u64::try_from(auto.short_window.as_micros()).unwrap_or(u64::MAX),
+            tick_interval_micros: u64::try_from(auto.tick_interval.as_micros()).unwrap_or(u64::MAX),
+        },
+        hdr: HdrSnapshot {
+            lowest_discernible_micros: congestion::HDR_LOWEST_DISCERNIBLE_MICROS,
+            highest_trackable_micros: congestion::HDR_HIGHEST_TRACKABLE_MICROS,
+            significant_figures: congestion::HDR_SIGNIFICANT_FIGURES,
+            unit: "microseconds".into(),
+        },
+        unit_labels,
+    }
+}
+
+fn render_panel_from_registry() -> String {
+    let entries = observability::registered_histograms();
+    if entries.is_empty() {
+        return String::new();
+    }
+    let snapshots: Vec<hdrhistogram::Histogram<u64>> = entries
+        .iter()
+        .map(|e| (*e.snapshot_rx.borrow()).clone())
+        .collect();
+    let units: Vec<histogram_panel::PanelUnit> = entries
+        .iter()
+        .zip(snapshots.iter())
+        .map(|(e, snap)| histogram_panel::PanelUnit {
+            label: e.label,
+            histogram: snap,
+            interval: e.interval,
+        })
+        .collect();
+    histogram_panel::render_histogram_panel(&units)
+}
+
 /// Wire up the adaptive metadata-ops control loops — one per
 /// `(Side, MetadataOp)` pair (18 in total):
 ///
@@ -1170,43 +1383,72 @@ const fn unit_label(side: congestion::Side, op: congestion::MetadataOp) -> &'sta
 ///
 /// Only one auto-meta config is supported per process. If a sample sink
 /// was already installed, it is silently replaced.
-fn spawn_auto_meta_throttle(runtime: &tokio::runtime::Runtime, auto: AutoMetaThrottleConfig) {
+fn spawn_auto_meta_throttle(
+    runtime: &tokio::runtime::Runtime,
+    auto: AutoMetaThrottleConfig,
+    histogram_enabled: bool,
+    histogram_log_path: Option<std::path::PathBuf>,
+    histogram_interval: std::time::Duration,
+    trace_identifier: &str,
+) {
     let initial_cwnd = auto
         .initial_cwnd
         .clamp(auto.min_cwnd.max(1), auto.max_cwnd.max(1));
+    let histogram_active = histogram_enabled || histogram_log_path.is_some();
+    // Per-tool log path: each rcpd / master writes to its own file by
+    // suffixing trace_identifier on the user-supplied path, mirroring
+    // chrome_trace_prefix's convention.
+    let resolved_log_path = histogram_log_path
+        .as_ref()
+        .map(|p| resolve_log_path(p, trace_identifier));
+
+    // Build receivers + accumulators in parallel arrays so we can pass
+    // each accumulator both to a ControlUnit and to a LoggerUnit.
     let mut builder = congestion::RoutingSinkBuilder::new();
-    // Materialize one receiver per (side, op) so every resource has a
-    // dedicated sample channel. Order matches the canonical iteration
-    // below; collected into a Vec rather than the inferred 18-element
-    // array literal for legibility.
-    let mut receivers: Vec<(
-        &'static str,
-        congestion::Side,
-        congestion::MetadataOp,
-        tokio::sync::mpsc::Receiver<congestion::Sample>,
-        bool,
-    )> = Vec::with_capacity(congestion::N_META_RESOURCES);
+    struct Slot {
+        label: &'static str,
+        side: congestion::Side,
+        op: congestion::MetadataOp,
+        sample_rx: tokio::sync::mpsc::Receiver<congestion::Sample>,
+        apply_rate: bool,
+        accumulator: Option<std::sync::Arc<std::sync::Mutex<congestion::HistogramAccumulator>>>,
+    }
+    let mut slots: Vec<Slot> = Vec::with_capacity(congestion::N_META_RESOURCES);
     for &side in &congestion::Side::ALL {
         for &op in &congestion::MetadataOp::ALL {
-            // Seed the throttle resource so the first probe finds a
-            // permit available; controllers grow / shrink from here.
             let resource = walk::meta_resource(side, op);
             throttle::set_max_ops_in_flight(resource, initial_cwnd as usize);
             let rx = builder.metadata_receiver(side, op);
-            // (Destination, Stat) is the rate-driver convention — see
-            // the function-level doc comment for why exactly one
-            // controller may own the global OPS_THROTTLE.
             let apply_rate = matches!(
                 (side, op),
                 (congestion::Side::Destination, congestion::MetadataOp::Stat),
             );
-            receivers.push((unit_label(side, op), side, op, rx, apply_rate));
+            let accumulator = if histogram_active {
+                let acc = std::sync::Arc::new(std::sync::Mutex::new(
+                    congestion::HistogramAccumulator::new(),
+                ));
+                builder.metadata_histogram(side, op, acc.clone());
+                Some(acc)
+            } else {
+                None
+            };
+            slots.push(Slot {
+                label: unit_label(side, op),
+                side,
+                op,
+                sample_rx: rx,
+                apply_rate,
+                accumulator,
+            });
         }
     }
     let sink = std::sync::Arc::new(builder.build());
     congestion::install_sample_sink(sink.clone());
-    for (label, side, op, sample_rx, apply_rate) in receivers {
-        let resource = walk::meta_resource(side, op);
+
+    // Per-unit watch senders for the live histogram panel; collected into
+    // a parallel vec so we can also build the logger's `LoggerUnit` list.
+    let mut logger_units: Vec<histogram_logger::LoggerUnit> = Vec::new();
+    for slot in slots {
         let controller = congestion::RatioController::new(congestion::RatioConfig {
             initial_cwnd: auto.initial_cwnd,
             min_cwnd: auto.min_cwnd,
@@ -1220,22 +1462,62 @@ fn spawn_auto_meta_throttle(runtime: &tokio::runtime::Runtime, auto: AutoMetaThr
             long_window: auto.long_window,
             short_window: auto.short_window,
         });
-        let (unit, decision_rx, snapshot_rx) =
-            congestion::ControlUnit::new(label, controller, sample_rx, auto.tick_interval);
-        observability::register_unit(label, snapshot_rx);
+        let (unit, decision_rx, snapshot_rx) = congestion::ControlUnit::new(
+            slot.label,
+            controller,
+            slot.sample_rx,
+            auto.tick_interval,
+        );
+        observability::register_unit(slot.label, snapshot_rx);
+        if let Some(acc) = slot.accumulator.as_ref() {
+            let (snap_tx, snap_rx) = tokio::sync::watch::channel(
+                hdrhistogram::Histogram::<u64>::new_with_bounds(
+                    congestion::HDR_LOWEST_DISCERNIBLE_MICROS,
+                    congestion::HDR_HIGHEST_TRACKABLE_MICROS,
+                    congestion::HDR_SIGNIFICANT_FIGURES,
+                )
+                .expect("histogram bounds valid"),
+            );
+            observability::register_histogram(slot.label, snap_rx, histogram_interval);
+            logger_units.push(histogram_logger::LoggerUnit {
+                label: slot.label,
+                side: slot.side,
+                op: slot.op,
+                accumulator: acc.clone(),
+                snapshot_tx: snap_tx,
+            });
+        }
         runtime.spawn(unit.run());
         runtime.spawn(auto_meta::run_adapter(
-            resource,
-            apply_rate,
+            walk::meta_resource(slot.side, slot.op),
+            slot.apply_rate,
             decision_rx,
             sink.clone(),
         ));
     }
+
+    if histogram_active {
+        let header = build_histogram_header(&auto, trace_identifier, histogram_interval);
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        store_logger_cancel(cancel_tx);
+        let handle = runtime.spawn(histogram_logger::run_logger(
+            histogram_logger::LoggerConfig {
+                interval: histogram_interval,
+                log_path: resolved_log_path,
+                header,
+            },
+            logger_units,
+            cancel_rx,
+        ));
+        store_logger_handle(handle);
+    }
+
     tracing::info!(
         "auto-meta-throttle enabled (per-(side, op) controllers, {} total): \
          initial_cwnd={}, max_cwnd={}, alpha={}, beta={}, \
          baseline_percentile={}, current_percentile={}, \
-         long_window={:?}, short_window={:?}, tick={:?}",
+         long_window={:?}, short_window={:?}, tick={:?}, \
+         histograms={}",
         congestion::N_META_RESOURCES,
         auto.initial_cwnd,
         auto.max_cwnd,
@@ -1246,6 +1528,7 @@ fn spawn_auto_meta_throttle(runtime: &tokio::runtime::Runtime, auto: AutoMetaThr
         auto.long_window,
         auto.short_window,
         auto.tick_interval,
+        histogram_active,
     );
 }
 
@@ -1279,10 +1562,16 @@ where
         suppress_runtime_stats,
     } = output;
     // tracing guards must outlive the runtime so chrome/flame traces flush
+    // extract trace_identifier before install_tracing_subscriber consumes tracing_config
+    let trace_identifier = tracing_config.trace_identifier.clone();
+    if let Err(e) = validate_histogram_log_target(&throttle_config, &trace_identifier) {
+        eprintln!("Configuration error: {e}");
+        return None;
+    }
     let _tracing_guards = install_tracing_subscriber(quiet, verbose, tracing_config);
     let res = {
         let runtime = build_tokio_runtime(&runtime_config, &throttle_config);
-        spawn_throttle_replenishers(&runtime, &throttle_config);
+        spawn_throttle_replenishers(&runtime, &throttle_config, &trace_identifier);
         let res = {
             let _progress_tracker = progress.map(|settings| {
                 tracing::debug!("Requesting progress updates {settings:?}");
@@ -1311,6 +1600,17 @@ where
             && let Err(err) = print_runtime_stats()
         {
             println!("Failed to print runtime stats: {err:?}");
+        }
+        // Signal the histogram logger to exit cleanly so its final
+        // snapshot is written before the runtime drops and aborts it.
+        // No-op when histograms are disabled.
+        signal_logger_cancel();
+        if let Some(handle) = take_logger_handle() {
+            // Bound the wait so a stuck logger can't hang shutdown — 1s is
+            // generous: the logger only does a snapshot+flush on cancel.
+            let _ = runtime.block_on(async {
+                tokio::time::timeout(std::time::Duration::from_secs(1), handle).await
+            });
         }
         res
         // runtime drops here, cancelling all spawned tasks (control
@@ -1608,5 +1908,152 @@ mod validate_update_compare_vs_preserve_tests {
         let result = validate_update_compare_vs_preserve(&compare, &preserve);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("mode"));
+    }
+}
+
+#[cfg(test)]
+mod resolve_log_path_tests {
+    use super::*;
+
+    #[test]
+    fn full_path_with_extension() {
+        let p = std::path::Path::new("/tmp/foo.hdr");
+        assert_eq!(
+            resolve_log_path(p, "rcp"),
+            std::path::PathBuf::from("/tmp/foo.rcp.hdr"),
+        );
+    }
+
+    #[test]
+    fn bare_filename_resolves_to_current_dir() {
+        let p = std::path::Path::new("foo.hdr");
+        assert_eq!(
+            resolve_log_path(p, "rcp"),
+            std::path::PathBuf::from("./foo.rcp.hdr"),
+        );
+    }
+
+    #[test]
+    fn no_extension_defaults_to_hdr() {
+        let p = std::path::Path::new("/tmp/foo");
+        assert_eq!(
+            resolve_log_path(p, "rcp"),
+            std::path::PathBuf::from("/tmp/foo.rcp.hdr"),
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn preserves_non_utf8_stem() {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+        // Build a path with an invalid-UTF-8 stem: /tmp/<0xFF><0xFE>.hdr
+        let mut raw_name = vec![b'/', b't', b'm', b'p', b'/'];
+        raw_name.extend_from_slice(&[0xFF, 0xFE]);
+        raw_name.extend_from_slice(b".hdr");
+        let p = std::path::PathBuf::from(std::ffi::OsString::from_vec(raw_name));
+        let resolved = resolve_log_path(&p, "rcp");
+        // The non-UTF-8 stem must be preserved; the suffix and extension
+        // append cleanly.
+        let bytes = resolved.as_os_str().as_bytes();
+        assert!(
+            bytes.windows(2).any(|w| w == [0xFF, 0xFE]),
+            "non-UTF-8 bytes must survive resolution; got bytes: {bytes:?}",
+        );
+        assert!(
+            bytes.ends_with(b".rcp.hdr"),
+            "expected .rcp.hdr suffix; got bytes: {bytes:?}",
+        );
+    }
+}
+
+#[cfg(test)]
+mod validate_histogram_log_target_tests {
+    use super::*;
+
+    fn throttle_with_log_path(path: Option<std::path::PathBuf>) -> ThrottleConfig {
+        ThrottleConfig {
+            histogram_enabled: path.is_some(),
+            histogram_log_path: path,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn no_log_path_is_ok() {
+        let throttle = throttle_with_log_path(None);
+        assert!(validate_histogram_log_target(&throttle, "rcp").is_ok());
+    }
+
+    #[test]
+    fn writable_resolved_path_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let throttle = throttle_with_log_path(Some(dir.path().join("foo.hdr")));
+        assert!(validate_histogram_log_target(&throttle, "rcp").is_ok());
+    }
+
+    #[test]
+    fn resolved_path_existing_as_directory_is_rejected() {
+        // Create a directory at the exact resolved path; OpenOptions::open
+        // with create+truncate fails when target is a directory.
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("foo.rcp.hdr");
+        std::fs::create_dir(&blocker).unwrap();
+        let throttle = throttle_with_log_path(Some(dir.path().join("foo.hdr")));
+        let err = validate_histogram_log_target(&throttle, "rcp").unwrap_err();
+        assert!(
+            err.contains("histogram-log") && err.contains("foo.rcp.hdr"),
+            "got: {err}",
+        );
+    }
+
+    #[test]
+    fn resolved_path_in_missing_parent_is_rejected() {
+        let throttle = throttle_with_log_path(Some("/nonexistent-dir-67890/foo.hdr".into()));
+        let err = validate_histogram_log_target(&throttle, "rcp").unwrap_err();
+        assert!(err.contains("histogram-log"), "got: {err}");
+    }
+
+    #[test]
+    fn log_path_pointing_at_existing_directory_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let throttle = throttle_with_log_path(Some(dir.path().to_path_buf()));
+        let err = validate_histogram_log_target(&throttle, "rcp").unwrap_err();
+        assert!(err.contains("directory"), "got: {err}");
+    }
+
+    #[test]
+    fn log_path_with_no_filename_is_rejected() {
+        // PathBuf::from("/") has parent() == None and file_name() == None.
+        let throttle = throttle_with_log_path(Some(std::path::PathBuf::from("/")));
+        let err = validate_histogram_log_target(&throttle, "rcp").unwrap_err();
+        assert!(
+            err.contains("filename") || err.contains("directory"),
+            "got: {err}",
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn resolved_path_existing_as_symlink_is_rejected() {
+        // Defense against symlink-based hijacking: a local attacker who
+        // can pre-create the predictable suffixed path as a symlink must
+        // not be able to redirect the truncating open to a victim file.
+        let dir = tempfile::tempdir().unwrap();
+        // The resolved path will be `<dir>/foo.rcp.hdr`. Pre-create it as
+        // a symlink pointing somewhere else (in this test, just to a
+        // sibling file we don't care about).
+        let target = dir.path().join("victim.txt");
+        std::fs::write(&target, b"do not clobber").unwrap();
+        let resolved_path = dir.path().join("foo.rcp.hdr");
+        std::os::unix::fs::symlink(&target, &resolved_path).unwrap();
+        let throttle = throttle_with_log_path(Some(dir.path().join("foo.hdr")));
+        let err = validate_histogram_log_target(&throttle, "rcp").unwrap_err();
+        assert!(
+            err.contains("symlink") || err.contains("ELOOP") || err.contains("Too many levels"),
+            "got: {err}",
+        );
+        // Victim file content is preserved (the truncating open never reached it).
+        let preserved = std::fs::read(&target).unwrap();
+        assert_eq!(preserved, b"do not clobber");
     }
 }

--- a/common/src/observability.rs
+++ b/common/src/observability.rs
@@ -58,6 +58,50 @@ pub fn clear() {
         .write()
         .expect("observability registry poisoned")
         .clear();
+    HIST_REGISTRY
+        .write()
+        .expect("histogram registry poisoned")
+        .clear();
+}
+
+/// One entry in the histogram registry.
+#[derive(Clone)]
+pub struct RegisteredHistogram {
+    pub label: &'static str,
+    pub snapshot_rx: tokio::sync::watch::Receiver<hdrhistogram::Histogram<u64>>,
+    /// The configured snapshot interval — used by the panel renderer to
+    /// label its "(last X.Xs)" header so the label matches the actual
+    /// cadence even when the user overrode the default.
+    pub interval: std::time::Duration,
+}
+
+static HIST_REGISTRY: std::sync::LazyLock<std::sync::RwLock<Vec<RegisteredHistogram>>> =
+    std::sync::LazyLock::new(|| std::sync::RwLock::new(Vec::new()));
+
+/// Register a per-(side, op) histogram snapshot stream. Called once per
+/// active unit by the auto-meta setup when histograms are enabled.
+pub fn register_histogram(
+    label: &'static str,
+    snapshot_rx: tokio::sync::watch::Receiver<hdrhistogram::Histogram<u64>>,
+    interval: std::time::Duration,
+) {
+    HIST_REGISTRY
+        .write()
+        .expect("histogram registry poisoned")
+        .push(RegisteredHistogram {
+            label,
+            snapshot_rx,
+            interval,
+        });
+}
+
+/// Cheap clone of the current histogram registry.
+#[must_use]
+pub fn registered_histograms() -> Vec<RegisteredHistogram> {
+    HIST_REGISTRY
+        .read()
+        .expect("histogram registry poisoned")
+        .clone()
 }
 
 /// Width (in display chars) of every right-aligned numeric column in
@@ -409,5 +453,40 @@ mod tests {
             assert!(col_a.is_some(), "{key} missing from row: {row_lines:?}");
         }
         clear();
+    }
+
+    #[test]
+    fn histogram_registry_starts_empty() {
+        let _g = GUARD.lock().unwrap();
+        clear();
+        assert!(registered_histograms().is_empty());
+    }
+
+    #[test]
+    fn registered_histograms_preserve_order() {
+        let _g = GUARD.lock().unwrap();
+        clear();
+        let h_empty = hdrhistogram::Histogram::<u64>::new_with_bounds(1, 1_000_000, 3).unwrap();
+        let (_tx_a, rx_a) = tokio::sync::watch::channel(h_empty.clone());
+        let (_tx_b, rx_b) = tokio::sync::watch::channel(h_empty);
+        register_histogram("first", rx_a, std::time::Duration::from_secs(1));
+        register_histogram("second", rx_b, std::time::Duration::from_secs(1));
+        let units = registered_histograms();
+        assert_eq!(units.len(), 2);
+        assert_eq!(units[0].label, "first");
+        assert_eq!(units[1].label, "second");
+        clear();
+    }
+
+    #[test]
+    fn clear_removes_histogram_registrations_too() {
+        let _g = GUARD.lock().unwrap();
+        clear();
+        let h_empty = hdrhistogram::Histogram::<u64>::new_with_bounds(1, 1_000_000, 3).unwrap();
+        let (_tx, rx) = tokio::sync::watch::channel(h_empty);
+        register_histogram("only", rx, std::time::Duration::from_secs(1));
+        assert_eq!(registered_histograms().len(), 1);
+        clear();
+        assert!(registered_histograms().is_empty());
     }
 }

--- a/common/tests/histogram_log_e2e.rs
+++ b/common/tests/histogram_log_e2e.rs
@@ -1,0 +1,85 @@
+//! End-to-end: spawn auto-meta with histogram logging, generate a few
+//! probes, terminate, parse the resulting log, assert structure.
+
+use congestion::format::{read_file_header, read_record};
+use std::io::BufReader;
+
+#[test]
+fn auto_meta_histogram_log_records_real_probes() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.hdr");
+
+    let auto = common::AutoMetaThrottleConfig {
+        initial_cwnd: 1,
+        min_cwnd: 1,
+        max_cwnd: 4096,
+        alpha: 1.3,
+        beta: 1.8,
+        increase_step: 1,
+        decrease_step: 1,
+        baseline_percentile: 0.1,
+        current_percentile: 0.5,
+        long_window: std::time::Duration::from_secs(10),
+        short_window: std::time::Duration::from_secs(1),
+        tick_interval: std::time::Duration::from_millis(50),
+    };
+    let throttle = common::ThrottleConfig {
+        max_open_files: None,
+        ops_throttle: 0,
+        iops_throttle: 0,
+        chunk_size: 0,
+        auto_meta: Some(auto),
+        histogram_enabled: true,
+        histogram_log_path: Some(path.clone()),
+        histogram_interval: std::time::Duration::from_millis(150),
+    };
+    let workdir = tempfile::tempdir().unwrap();
+    let workdir_path = workdir.path().to_path_buf();
+    let summary = common::run::<_, String, anyhow::Error>(
+        None,
+        common::OutputConfig::default(),
+        common::RuntimeConfig::default(),
+        throttle,
+        common::TracingConfig {
+            trace_identifier: "rcp".to_string(),
+            ..Default::default()
+        },
+        || async move {
+            // Fire stat probes by creating + statting files via the
+            // probed walk API so the auto-meta sample sink receives samples.
+            for i in 0..50 {
+                let p = workdir_path.join(format!("f{i}"));
+                tokio::fs::write(&p, b"x").await?;
+                let _ = common::walk::run_metadata_probed(
+                    common::Side::Source,
+                    common::MetadataOp::Stat,
+                    tokio::fs::metadata(&p),
+                )
+                .await?;
+            }
+            // Wait long enough for at least one snapshot tick (interval = 150ms).
+            tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+            Ok::<_, anyhow::Error>("done".to_string())
+        },
+    );
+    assert!(summary.is_some());
+
+    // Parse the log file (suffixed with the trace identifier).
+    let actual_path = path.with_file_name("test.rcp.hdr");
+    let f = std::fs::File::open(&actual_path)
+        .unwrap_or_else(|e| panic!("expected log at {actual_path:?}: {e}"));
+    let mut reader = BufReader::new(f);
+    let header = read_file_header(&mut reader).expect("header parses");
+    assert_eq!(header.format_version, 1);
+    assert_eq!(header.tool, "rcp");
+    assert_eq!(header.snapshot_interval_micros, 150_000);
+
+    let mut total_samples = 0u64;
+    while let Some(rec) = read_record(&mut reader).expect("reads cleanly") {
+        total_samples += rec.samples_count;
+    }
+    assert!(
+        total_samples > 0,
+        "expected at least one sample recorded; got 0"
+    );
+}

--- a/congestion/Cargo.toml
+++ b/congestion/Cargo.toml
@@ -21,6 +21,10 @@ rustdoc-args = ["--cfg", "tokio_unstable"]
 name = "congestion"
 
 [dependencies]
+hdrhistogram = { version = "7.5", default-features = false, features = ["serialization"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
+thiserror = "2.0"
 tokio = { version = "1.52", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1"
 

--- a/congestion/src/control_loop.rs
+++ b/congestion/src/control_loop.rs
@@ -219,6 +219,13 @@ pub struct RoutingSink {
     /// [`metadata_index`]. `None` slots are silently dropped — that's
     /// how a tool that doesn't exercise a particular op opts out.
     metadata: [Option<tokio::sync::mpsc::Sender<Sample>>; N_META_RESOURCES],
+    /// Parallel to `metadata`: optional histogram accumulator per
+    /// `(Side, MetadataOp)` pair. Recorded synchronously inside
+    /// [`SampleSink::record`] so every probe completion lands in the
+    /// accumulator before the function returns — eliminating the drain
+    /// race on shutdown.
+    histograms: [Option<std::sync::Arc<std::sync::Mutex<crate::histogram::HistogramAccumulator>>>;
+        N_META_RESOURCES],
     read: Option<tokio::sync::mpsc::Sender<Sample>>,
     write: Option<tokio::sync::mpsc::Sender<Sample>>,
     dropped: std::sync::Arc<std::sync::atomic::AtomicU64>,
@@ -233,7 +240,37 @@ impl RoutingSink {
 }
 
 impl SampleSink for RoutingSink {
+    /// Records a sample into the histogram accumulator and forwards it to
+    /// the controller's mpsc channel.
+    ///
+    /// The histogram update happens SYNCHRONOUSLY before the `try_send` to
+    /// the controller. This is intentional: the histogram is the source of
+    /// truth for "what probes completed", which must include every probe
+    /// regardless of whether the controller's queue drained. The
+    /// controller's own `samples_seen` counter (visible in
+    /// [`ControllerSnapshot`]) reflects what the controller actually acted
+    /// on, which may be less when the per-resource mpsc is saturated; the
+    /// difference is the count surfaced via [`RoutingSink::dropped_samples`]
+    /// and the periodic warning log. By design, n (histogram) >=
+    /// samples_seen (controller); their difference is the queue-saturation
+    /// signal. Recording only on `try_send` success would cause histogram
+    /// data loss precisely when the user most needs it: under heavy load,
+    /// the controller's queue can saturate, and that's exactly when the
+    /// distribution is most informative.
     fn record(&self, kind: ResourceKind, sample: &Sample) {
+        // Synchronously update the histogram accumulator (if any) before
+        // the async hop to the control unit. This way every probe that
+        // completes is reflected in the accumulator immediately, so the
+        // logger's final snapshot at shutdown captures every sample —
+        // even ones that haven't yet been drained from the per-resource
+        // mpsc by the control-unit task.
+        if let ResourceKind::Metadata(side, op) = kind
+            && let Some(acc) = &self.histograms[metadata_index(side, op)]
+        {
+            acc.lock()
+                .expect("histogram accumulator mutex poisoned")
+                .record(sample.latency());
+        }
         let tx = match kind {
             ResourceKind::Metadata(side, op) => self.metadata[metadata_index(side, op)].as_ref(),
             ResourceKind::DataRead => self.read.as_ref(),
@@ -247,7 +284,7 @@ impl SampleSink for RoutingSink {
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                    // the ControlUnit exited; nothing to do.
+                    // ControlUnit exited; nothing to do.
                 }
             }
         }
@@ -259,6 +296,8 @@ impl SampleSink for RoutingSink {
 /// returns the receiver the caller must hand to a [`ControlUnit`].
 pub struct RoutingSinkBuilder {
     metadata: [Option<tokio::sync::mpsc::Sender<Sample>>; N_META_RESOURCES],
+    histograms: [Option<std::sync::Arc<std::sync::Mutex<crate::histogram::HistogramAccumulator>>>;
+        N_META_RESOURCES],
     read: Option<tokio::sync::mpsc::Sender<Sample>>,
     write: Option<tokio::sync::mpsc::Sender<Sample>>,
     capacity: usize,
@@ -269,6 +308,7 @@ impl Default for RoutingSinkBuilder {
     fn default() -> Self {
         Self {
             metadata: [const { None }; N_META_RESOURCES],
+            histograms: [const { None }; N_META_RESOURCES],
             read: None,
             write: None,
             capacity: DEFAULT_CHANNEL_CAPACITY,
@@ -299,6 +339,20 @@ impl RoutingSinkBuilder {
         self.metadata[metadata_index(side, op)] = Some(tx);
         rx
     }
+
+    /// Register a histogram accumulator for the given `(Side, MetadataOp)`
+    /// pair. Synchronous: every probe completion will record into this
+    /// accumulator before `record` returns — eliminating the drain race on
+    /// shutdown that arises when the accumulator lives in the `ControlUnit`
+    /// task instead.
+    pub fn metadata_histogram(
+        &mut self,
+        side: Side,
+        op: MetadataOp,
+        accumulator: std::sync::Arc<std::sync::Mutex<crate::histogram::HistogramAccumulator>>,
+    ) {
+        self.histograms[metadata_index(side, op)] = Some(accumulator);
+    }
     /// Register a channel for read-throughput samples and return its receiver.
     pub fn read_receiver(&mut self) -> tokio::sync::mpsc::Receiver<Sample> {
         let (tx, rx) = tokio::sync::mpsc::channel(self.capacity);
@@ -314,6 +368,7 @@ impl RoutingSinkBuilder {
     pub fn build(self) -> RoutingSink {
         RoutingSink {
             metadata: self.metadata,
+            histograms: self.histograms,
             read: self.read,
             write: self.write,
             dropped: self.dropped,
@@ -491,5 +546,30 @@ mod tests {
             .await
             .expect("control loop exits within timeout")
             .expect("control loop joins without panic");
+    }
+
+    #[tokio::test]
+    async fn routing_sink_records_to_histogram_synchronously() {
+        // Synchronous histogram capture: a sample sent to the sink must
+        // land in the accumulator before record() returns, regardless of
+        // whether the corresponding ControlUnit's mpsc has been drained.
+        use crate::histogram::HistogramAccumulator;
+        let mut builder = RoutingSinkBuilder::new();
+        let _meta_rx = builder.metadata_receiver(Side::Source, MetadataOp::Stat);
+        let acc = std::sync::Arc::new(std::sync::Mutex::new(HistogramAccumulator::new()));
+        builder.metadata_histogram(Side::Source, MetadataOp::Stat, acc.clone());
+        let sink = builder.build();
+        sink.record(
+            ResourceKind::Metadata(Side::Source, MetadataOp::Stat),
+            &make_sample(5),
+        );
+        sink.record(
+            ResourceKind::Metadata(Side::Source, MetadataOp::Stat),
+            &make_sample(7),
+        );
+        // Synchronous capture: the accumulator already has both samples,
+        // even though the control-unit task (if any) has not been polled.
+        let snap = acc.lock().unwrap().snapshot_and_reset();
+        assert_eq!(snap.len(), 2);
     }
 }

--- a/congestion/src/format.rs
+++ b/congestion/src/format.rs
@@ -1,0 +1,460 @@
+//! Binary log file format for auto-meta histogram recordings.
+//!
+//! See `docs/congestion_control.md` for the canonical format reference.
+//! The short version:
+//!
+//! ```text
+//!   "RCP-AUTOMETA-HIST-V1\n"  // 21 ASCII bytes (magic, includes \n)
+//!   <hdr_len: u32 LE>
+//!   <hdr_bytes: JSON, hdr_len bytes>
+//!   loop {
+//!       <rec_len: u32 LE>
+//!       <unix_micros: u64 LE>
+//!       <side: u8>            // 0 = Source, 1 = Destination
+//!       <op: u8>              // MetadataOp discriminant
+//!       <samples_count: u64 LE>
+//!       <hdr_v2_blob: rec_len - 18 bytes>
+//!   }
+//! ```
+//!
+//! Multi-byte integers are little-endian. Records are length-prefixed so
+//! readers can detect partial writes (process killed mid-record) and stop
+//! cleanly at the last full record.
+
+use crate::measurement::{MetadataOp, Side};
+
+/// Magic bytes at the start of every log file. Includes a trailing
+/// newline so `head -1 file.hdr` shows the version on a clean line.
+pub const MAGIC: &[u8; 21] = b"RCP-AUTOMETA-HIST-V1\n";
+
+/// The fixed (non-blob) bytes per record: u64 timestamp + u8 side + u8 op + u64 count.
+pub const RECORD_FIXED_BYTES: usize = 8 + 1 + 1 + 8;
+
+/// Maximum accepted size of the JSON header in bytes. Real headers
+/// are a few hundred bytes; this cap is generous enough that any
+/// realistic configuration fits, but tight enough to refuse a
+/// malicious or corrupt file that claims a multi-GiB header.
+pub const MAX_HEADER_BYTES: u32 = 1 << 20; // 1 MiB
+
+/// Maximum accepted size of a single record in bytes. HDR v2 blobs
+/// at the configured range and precision are ~few KiB; this cap
+/// catches obvious corruption while leaving generous headroom.
+pub const MAX_RECORD_BYTES: u32 = 1 << 20; // 1 MiB
+
+/// Top-level header captured at file start. Mirrors the fields a reader
+/// needs to interpret records; `auto_meta` carries a snapshot of the
+/// `AutoMetaThrottleConfig` that drove the run.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct LogHeader {
+    pub format_version: u32,
+    pub tool: String,
+    pub tool_version: String,
+    pub hostname: String,
+    pub pid: u32,
+    pub start_unix_micros: u64,
+    pub snapshot_interval_micros: u64,
+    pub auto_meta: AutoMetaSnapshot,
+    pub hdr: HdrSnapshot,
+    pub unit_labels: Vec<UnitLabel>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct AutoMetaSnapshot {
+    pub initial_cwnd: u32,
+    pub min_cwnd: u32,
+    pub max_cwnd: u32,
+    pub alpha: f64,
+    pub beta: f64,
+    pub increase_step: u32,
+    pub decrease_step: u32,
+    pub baseline_percentile: f64,
+    pub current_percentile: f64,
+    pub long_window_micros: u64,
+    pub short_window_micros: u64,
+    pub tick_interval_micros: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct HdrSnapshot {
+    pub lowest_discernible_micros: u64,
+    pub highest_trackable_micros: u64,
+    pub significant_figures: u8,
+    pub unit: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct UnitLabel {
+    pub side: u8,
+    pub op: u8,
+    pub label: String,
+}
+
+/// One record's worth of decoded data after parsing the binary frame.
+///
+/// `histogram` is the deserialized HDR; `samples_count` is what the
+/// writer recorded in the fixed prefix (it equals `histogram.len()`
+/// for valid records and is exposed redundantly for tools that want to
+/// scan a log without parsing each blob).
+#[derive(Debug)]
+pub struct Record {
+    pub unix_micros: u64,
+    pub side: Side,
+    pub op: MetadataOp,
+    pub samples_count: u64,
+    pub histogram: hdrhistogram::Histogram<u64>,
+}
+
+/// Errors returned by the binary format reader.
+#[derive(Debug, thiserror::Error)]
+pub enum ReadError {
+    #[error("io: {0:#}")]
+    Io(#[from] std::io::Error),
+    #[error("bad magic: expected {MAGIC:?}, found {0:?}")]
+    BadMagic([u8; 21]),
+    #[error("unsupported format version {0}")]
+    UnsupportedVersion(u32),
+    #[error("invalid Side discriminant {0}")]
+    BadSide(u8),
+    #[error("invalid MetadataOp discriminant {0}")]
+    BadOp(u8),
+    #[error("hdr deserialization failed: {0}")]
+    Hdr(String),
+    #[error("json: {0:#}")]
+    Json(#[from] serde_json::Error),
+    #[error("header length {0} exceeds max {MAX_HEADER_BYTES}")]
+    HeaderTooLarge(u32),
+    #[error("record length {0} exceeds max {MAX_RECORD_BYTES}")]
+    RecordTooLarge(u32),
+}
+
+/// Errors returned by the binary format writer.
+#[derive(Debug, thiserror::Error)]
+pub enum WriteError {
+    #[error("io: {0:#}")]
+    Io(#[from] std::io::Error),
+    #[error("hdr serialization failed: {0}")]
+    Hdr(String),
+    #[error("json: {0:#}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// Write the file header (magic + length + JSON header) to `out`.
+pub fn write_file_header<W: std::io::Write>(
+    out: &mut W,
+    header: &LogHeader,
+) -> Result<(), WriteError> {
+    out.write_all(MAGIC)?;
+    let json = serde_json::to_vec_pretty(header)?;
+    let len = u32::try_from(json.len()).expect("header < 4GB");
+    out.write_all(&len.to_le_bytes())?;
+    out.write_all(&json)?;
+    Ok(())
+}
+
+/// Read and validate the file header, returning the deserialized struct.
+pub fn read_file_header<R: std::io::Read>(input: &mut R) -> Result<LogHeader, ReadError> {
+    let mut magic = [0u8; 21];
+    input.read_exact(&mut magic)?;
+    if &magic != MAGIC {
+        return Err(ReadError::BadMagic(magic));
+    }
+    let mut len_bytes = [0u8; 4];
+    input.read_exact(&mut len_bytes)?;
+    let len = u32::from_le_bytes(len_bytes);
+    if len > MAX_HEADER_BYTES {
+        return Err(ReadError::HeaderTooLarge(len));
+    }
+    let len = len as usize;
+    let mut json = vec![0u8; len];
+    input.read_exact(&mut json)?;
+    let header: LogHeader = serde_json::from_slice(&json)?;
+    if header.format_version != 1 {
+        return Err(ReadError::UnsupportedVersion(header.format_version));
+    }
+    Ok(header)
+}
+
+/// Append one record to `out`, encoding `histogram` as HDR v2 binary.
+///
+/// The record body's fixed prefix (unix_micros + side + op + samples_count)
+/// occupies [`RECORD_FIXED_BYTES`] bytes; the rest is the HDR blob.
+pub fn write_record<W: std::io::Write>(
+    out: &mut W,
+    unix_micros: u64,
+    side: Side,
+    op: MetadataOp,
+    histogram: &hdrhistogram::Histogram<u64>,
+) -> Result<(), WriteError> {
+    use hdrhistogram::serialization::{Serializer, V2Serializer};
+    let mut blob: Vec<u8> = Vec::new();
+    let mut serializer = V2Serializer::new();
+    serializer
+        .serialize(histogram, &mut blob)
+        .map_err(|e| WriteError::Hdr(format!("{e:?}")))?;
+    let rec_len = u32::try_from(RECORD_FIXED_BYTES + blob.len()).expect("record < 4GB");
+    out.write_all(&rec_len.to_le_bytes())?;
+    out.write_all(&unix_micros.to_le_bytes())?;
+    out.write_all(&[side as u8])?;
+    out.write_all(&[op as u8])?;
+    out.write_all(&histogram.len().to_le_bytes())?;
+    out.write_all(&blob)?;
+    Ok(())
+}
+
+/// Read one record. Returns `Ok(None)` at EOF *or* on truncation
+/// (partial-record tail): the caller treats this as "stop cleanly,
+/// every prior record is valid".
+pub fn read_record<R: std::io::Read>(input: &mut R) -> Result<Option<Record>, ReadError> {
+    let mut len_bytes = [0u8; 4];
+    match input.read_exact(&mut len_bytes) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(ReadError::Io(e)),
+    }
+    let rec_len = u32::from_le_bytes(len_bytes);
+    if rec_len > MAX_RECORD_BYTES {
+        return Err(ReadError::RecordTooLarge(rec_len));
+    }
+    let rec_len = rec_len as usize;
+    if rec_len < RECORD_FIXED_BYTES {
+        // Length too small to even fit the fixed prefix → corrupt or
+        // truncated; bail rather than erroring so callers preserve any
+        // earlier good records.
+        return Ok(None);
+    }
+    let mut body = vec![0u8; rec_len];
+    if let Err(e) = input.read_exact(&mut body) {
+        if e.kind() == std::io::ErrorKind::UnexpectedEof {
+            return Ok(None);
+        }
+        return Err(ReadError::Io(e));
+    }
+    let unix_micros = u64::from_le_bytes(body[0..8].try_into().unwrap());
+    let side = match body[8] {
+        0 => Side::Source,
+        1 => Side::Destination,
+        x => return Err(ReadError::BadSide(x)),
+    };
+    let op = match body[9] {
+        0 => MetadataOp::Stat,
+        1 => MetadataOp::ReadLink,
+        2 => MetadataOp::MkDir,
+        3 => MetadataOp::RmDir,
+        4 => MetadataOp::Unlink,
+        5 => MetadataOp::HardLink,
+        6 => MetadataOp::Symlink,
+        7 => MetadataOp::Chmod,
+        8 => MetadataOp::OpenCreate,
+        x => return Err(ReadError::BadOp(x)),
+    };
+    let samples_count = u64::from_le_bytes(body[10..18].try_into().unwrap());
+    let blob = &body[18..];
+    let mut deserializer = hdrhistogram::serialization::Deserializer::new();
+    let mut blob_cursor = std::io::Cursor::new(blob);
+    let histogram: hdrhistogram::Histogram<u64> = deserializer
+        .deserialize(&mut blob_cursor)
+        .map_err(|e| ReadError::Hdr(format!("{e:?}")))?;
+    Ok(Some(Record {
+        unix_micros,
+        side,
+        op,
+        samples_count,
+        histogram,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_header() -> LogHeader {
+        LogHeader {
+            format_version: 1,
+            tool: "rcp".to_string(),
+            tool_version: "0.32.0".to_string(),
+            hostname: "test-host".to_string(),
+            pid: 12345,
+            start_unix_micros: 1_700_000_000_000_000,
+            snapshot_interval_micros: 1_000_000,
+            auto_meta: AutoMetaSnapshot {
+                initial_cwnd: 1,
+                min_cwnd: 1,
+                max_cwnd: 4096,
+                alpha: 1.3,
+                beta: 1.8,
+                increase_step: 1,
+                decrease_step: 1,
+                baseline_percentile: 0.1,
+                current_percentile: 0.5,
+                long_window_micros: 10_000_000,
+                short_window_micros: 1_000_000,
+                tick_interval_micros: 50_000,
+            },
+            hdr: HdrSnapshot {
+                lowest_discernible_micros: 1,
+                highest_trackable_micros: 3_600_000_000,
+                significant_figures: 3,
+                unit: "microseconds".to_string(),
+            },
+            unit_labels: vec![
+                UnitLabel {
+                    side: 0,
+                    op: 0,
+                    label: "src-stat".into(),
+                },
+                UnitLabel {
+                    side: 1,
+                    op: 0,
+                    label: "dst-stat".into(),
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn header_serde_roundtrip() {
+        let h = sample_header();
+        let bytes = serde_json::to_vec(&h).unwrap();
+        let h2: LogHeader = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(h, h2);
+    }
+
+    #[test]
+    fn header_tolerates_unknown_top_level_keys() {
+        // Forward-compat: a future writer adding `extra: { ... }` must not
+        // break older readers. serde's default is to error on unknown
+        // fields; we explicitly need the lenient behavior.
+        let json = r#"{
+            "format_version": 1,
+            "tool": "rcp",
+            "tool_version": "0.32.0",
+            "hostname": "h",
+            "pid": 1,
+            "start_unix_micros": 0,
+            "snapshot_interval_micros": 1000000,
+            "auto_meta": {
+                "initial_cwnd": 1, "min_cwnd": 1, "max_cwnd": 4096,
+                "alpha": 1.3, "beta": 1.8,
+                "increase_step": 1, "decrease_step": 1,
+                "baseline_percentile": 0.1, "current_percentile": 0.5,
+                "long_window_micros": 10000000, "short_window_micros": 1000000,
+                "tick_interval_micros": 50000
+            },
+            "hdr": {
+                "lowest_discernible_micros": 1,
+                "highest_trackable_micros": 3600000000,
+                "significant_figures": 3, "unit": "microseconds"
+            },
+            "unit_labels": [],
+            "extra": { "future_key": 42 }
+        }"#;
+        let parsed: LogHeader = serde_json::from_str(json).expect("must tolerate unknown keys");
+        assert_eq!(parsed.format_version, 1);
+    }
+
+    #[test]
+    fn write_and_read_file_with_two_records_roundtrips() {
+        // Build a small file: header + two records + truncate. Read it back;
+        // both records present, both decode cleanly.
+        let mut buf: Vec<u8> = Vec::new();
+        let header = sample_header();
+        write_file_header(&mut buf, &header).unwrap();
+        let mut h1 = hdrhistogram::Histogram::<u64>::new_with_bounds(1, 1_000_000, 3).unwrap();
+        h1.record(100).unwrap();
+        h1.record(200).unwrap();
+        write_record(
+            &mut buf,
+            1_700_000_000_500_000,
+            Side::Source,
+            MetadataOp::Stat,
+            &h1,
+        )
+        .unwrap();
+        let mut h2 = hdrhistogram::Histogram::<u64>::new_with_bounds(1, 1_000_000, 3).unwrap();
+        h2.record(300).unwrap();
+        write_record(
+            &mut buf,
+            1_700_000_001_500_000,
+            Side::Destination,
+            MetadataOp::MkDir,
+            &h2,
+        )
+        .unwrap();
+
+        let mut cursor = std::io::Cursor::new(&buf);
+        let parsed_header = read_file_header(&mut cursor).unwrap();
+        assert_eq!(parsed_header, header);
+        let r1 = read_record(&mut cursor).unwrap().expect("first record");
+        assert_eq!(r1.unix_micros, 1_700_000_000_500_000);
+        assert_eq!(r1.side, Side::Source);
+        assert_eq!(r1.op, MetadataOp::Stat);
+        assert_eq!(r1.samples_count, 2);
+        let r2 = read_record(&mut cursor).unwrap().expect("second record");
+        assert_eq!(r2.side, Side::Destination);
+        assert_eq!(r2.op, MetadataOp::MkDir);
+        assert_eq!(r2.samples_count, 1);
+        // EOF after last record returns Ok(None).
+        assert!(read_record(&mut cursor).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_record_returns_none_on_truncated_tail() {
+        // Process killed mid-write: file ends inside a record. The reader
+        // must detect the truncation via the length prefix and return
+        // Ok(None) so callers can recover all complete records.
+        let mut buf: Vec<u8> = Vec::new();
+        let header = sample_header();
+        write_file_header(&mut buf, &header).unwrap();
+        let mut h = hdrhistogram::Histogram::<u64>::new_with_bounds(1, 1_000_000, 3).unwrap();
+        h.record(100).unwrap();
+        write_record(&mut buf, 0, Side::Source, MetadataOp::Stat, &h).unwrap();
+        // Truncate: drop the last 5 bytes.
+        buf.truncate(buf.len() - 5);
+        let mut cursor = std::io::Cursor::new(&buf);
+        let _ = read_file_header(&mut cursor).unwrap();
+        // Truncation manifests on read_record: it must return Ok(None),
+        // not an error.
+        assert!(read_record(&mut cursor).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_file_header_rejects_bad_magic() {
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(b"NOT-THE-RIGHT-MAGIC!!"); // 21 bytes
+        let mut cursor = std::io::Cursor::new(&buf);
+        assert!(read_file_header(&mut cursor).is_err());
+    }
+
+    #[test]
+    fn read_file_header_rejects_excessive_length() {
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(MAGIC);
+        // pretend the header is 100 MiB
+        buf.extend_from_slice(&(100u32 * 1024 * 1024).to_le_bytes());
+        // append a few bytes of "header" so the read doesn't simply EOF
+        buf.extend_from_slice(b"{ \"format_version\": 1 }");
+        let mut cursor = std::io::Cursor::new(&buf);
+        let err = read_file_header(&mut cursor).unwrap_err();
+        assert!(
+            matches!(err, ReadError::HeaderTooLarge(_)),
+            "expected HeaderTooLarge, got: {err:?}",
+        );
+    }
+
+    #[test]
+    fn read_record_rejects_excessive_length() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_file_header(&mut buf, &sample_header()).unwrap();
+        // append a record with claimed length 100 MiB
+        buf.extend_from_slice(&(100u32 * 1024 * 1024).to_le_bytes());
+        // some bytes; the read will hit the cap before allocating
+        buf.extend_from_slice(&[0u8; 32]);
+        let mut cursor = std::io::Cursor::new(&buf);
+        let _ = read_file_header(&mut cursor).unwrap();
+        let err = read_record(&mut cursor).unwrap_err();
+        assert!(
+            matches!(err, ReadError::RecordTooLarge(_)),
+            "expected RecordTooLarge, got: {err:?}",
+        );
+    }
+}

--- a/congestion/src/histogram.rs
+++ b/congestion/src/histogram.rs
@@ -1,0 +1,157 @@
+//! Per-controller HDR latency histograms.
+//!
+//! A `HistogramAccumulator` wraps a single `hdrhistogram::Histogram<u64>`
+//! configured for filesystem-metadata-syscall latencies (1µs to 1h, 3 sig
+//! figures). It records `Duration` values in microseconds and supports a
+//! "snapshot and reset" operation so a logger task can periodically harvest
+//! distributions for offline reconstruction without disturbing the live
+//! sample path.
+//!
+//! HDR is mergeable: distinct snapshots over disjoint time windows can be
+//! folded together to reconstruct any window's distribution. That's the
+//! property the offline log reader relies on to materialize "current"
+//! (1s) and "baseline" (10s) windows from a single per-bucket stream.
+
+/// Minimum value representable in the histogram, in microseconds.
+pub const HDR_LOWEST_DISCERNIBLE_MICROS: u64 = 1;
+/// Maximum value representable in the histogram, in microseconds (1 hour).
+pub const HDR_HIGHEST_TRACKABLE_MICROS: u64 = 3_600_000_000;
+/// Significant figures of precision tracked by the histogram.
+pub const HDR_SIGNIFICANT_FIGURES: u8 = 3;
+
+/// Per-controller HDR latency accumulator.
+///
+/// Records sample latencies into an HDR histogram with fixed bounds and
+/// precision (see the `HDR_*` constants). `record` is the hot-path
+/// accessor; `snapshot_and_reset` is called by the logger task at its
+/// configured interval and returns a clone of the histogram while
+/// resetting the local one to empty.
+pub struct HistogramAccumulator {
+    histogram: hdrhistogram::Histogram<u64>,
+}
+
+impl HistogramAccumulator {
+    /// Construct a fresh empty accumulator using the workspace HDR settings.
+    #[must_use]
+    pub fn new() -> Self {
+        // Histogram::new_with_bounds returns Result; the configured bounds
+        // are constants we control, so panicking on failure is correct — a
+        // failure here is a build-time bug, not a runtime concern.
+        let histogram = hdrhistogram::Histogram::<u64>::new_with_bounds(
+            HDR_LOWEST_DISCERNIBLE_MICROS,
+            HDR_HIGHEST_TRACKABLE_MICROS,
+            HDR_SIGNIFICANT_FIGURES,
+        )
+        .expect("HDR bounds are valid by construction");
+        Self { histogram }
+    }
+
+    /// Record one sample latency.
+    ///
+    /// Sub-microsecond durations round up to 1 µs (the lowest discernible
+    /// value); samples longer than 1 hour saturate at the upper bound
+    /// rather than being dropped. Both clamps preserve sample count, so
+    /// the histogram's `len()` always matches the number of `record`
+    /// calls.
+    pub fn record(&mut self, latency: std::time::Duration) {
+        let micros = u64::try_from(latency.as_micros())
+            .unwrap_or(HDR_HIGHEST_TRACKABLE_MICROS)
+            .clamp(HDR_LOWEST_DISCERNIBLE_MICROS, HDR_HIGHEST_TRACKABLE_MICROS);
+        self.histogram.saturating_record(micros);
+    }
+
+    /// Take a snapshot of the current histogram and reset the accumulator
+    /// to empty. The returned histogram owns its data and can be
+    /// serialized or merged independently.
+    #[must_use]
+    pub fn snapshot_and_reset(&mut self) -> hdrhistogram::Histogram<u64> {
+        let snapshot = self.histogram.clone();
+        self.histogram.reset();
+        snapshot
+    }
+}
+
+impl Default for HistogramAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_and_snapshot_returns_count() {
+        let mut acc = HistogramAccumulator::new();
+        acc.record(std::time::Duration::from_micros(100));
+        acc.record(std::time::Duration::from_micros(200));
+        acc.record(std::time::Duration::from_micros(300));
+        let snap = acc.snapshot_and_reset();
+        assert_eq!(snap.len(), 3);
+    }
+
+    #[test]
+    fn snapshot_and_reset_clears_underlying_histogram() {
+        // After snapshot_and_reset, the accumulator is empty — a follow-up
+        // record only contributes one sample to the next snapshot.
+        let mut acc = HistogramAccumulator::new();
+        acc.record(std::time::Duration::from_micros(50));
+        let _ = acc.snapshot_and_reset();
+        acc.record(std::time::Duration::from_micros(75));
+        let snap = acc.snapshot_and_reset();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(snap.value_at_percentile(50.0), 75);
+    }
+
+    #[test]
+    fn record_clamps_zero_duration_to_one_micro() {
+        // A zero-duration sample (possible when Instant::now() resolution
+        // groups back-to-back probes) lands at the lowest discernible
+        // value rather than silently being dropped or panicking on the
+        // HDR's strict-positive precondition.
+        let mut acc = HistogramAccumulator::new();
+        acc.record(std::time::Duration::ZERO);
+        let snap = acc.snapshot_and_reset();
+        assert_eq!(snap.len(), 1);
+        assert_eq!(
+            snap.value_at_percentile(50.0),
+            HDR_LOWEST_DISCERNIBLE_MICROS
+        );
+    }
+
+    #[test]
+    fn record_saturates_at_upper_bound() {
+        // A sample longer than the configured upper bound (1h) saturates
+        // rather than panicking. HDR's `record` would otherwise return Err
+        // on out-of-range values.
+        let mut acc = HistogramAccumulator::new();
+        acc.record(std::time::Duration::from_secs(7200)); // 2 hours
+        let snap = acc.snapshot_and_reset();
+        assert_eq!(snap.len(), 1);
+        let p50 = snap.value_at_percentile(50.0);
+        // HDR bucket boundaries can round slightly above the nominal trackable
+        // max (3-sig-fig buckets at 3.6B are ~0.8M wide). The important
+        // invariant is that we didn't panic and that the value is close to the
+        // configured ceiling, not that it's strictly below it.
+        let tolerance = HDR_HIGHEST_TRACKABLE_MICROS / 1000; // 0.1% tolerance
+        assert!(
+            p50 >= HDR_HIGHEST_TRACKABLE_MICROS - 1_000_000, // allow up to 1s of HDR quantization below the nominal max
+            "p50={p50} too far below max"
+        );
+        assert!(
+            p50 <= HDR_HIGHEST_TRACKABLE_MICROS + tolerance,
+            "p50={p50} too far above max"
+        );
+    }
+
+    #[test]
+    fn record_converts_nanoseconds_to_microseconds() {
+        // Sub-microsecond samples truncate to the micro floor (1 µs) rather
+        // than being binned at zero.
+        let mut acc = HistogramAccumulator::new();
+        acc.record(std::time::Duration::from_nanos(500)); // 0.5 µs → 1 µs
+        let snap = acc.snapshot_and_reset();
+        assert_eq!(snap.value_at_percentile(50.0), 1);
+    }
+}

--- a/congestion/src/lib.rs
+++ b/congestion/src/lib.rs
@@ -42,6 +42,8 @@
 mod control_loop;
 mod controller;
 mod fixed;
+pub mod format;
+mod histogram;
 mod measurement;
 mod noop;
 mod ratio;
@@ -51,6 +53,10 @@ pub mod testing;
 pub use control_loop::{ControlUnit, DEFAULT_TICK_INTERVAL, RoutingSink, RoutingSinkBuilder};
 pub use controller::{Controller, ControllerSnapshot, Decision, Outcome, Sample};
 pub use fixed::FixedController;
+pub use histogram::{
+    HDR_HIGHEST_TRACKABLE_MICROS, HDR_LOWEST_DISCERNIBLE_MICROS, HDR_SIGNIFICANT_FIGURES,
+    HistogramAccumulator,
+};
 pub use measurement::{
     MetadataOp, N_META_OPS, N_META_RESOURCES, N_SIDES, Probe, ResourceKind, SampleSink, Side,
     clear_sample_sink, install_sample_sink,

--- a/congestion/tests/format_roundtrip.rs
+++ b/congestion/tests/format_roundtrip.rs
@@ -1,0 +1,127 @@
+//! Proptest coverage for the histogram log file format:
+//! 1. Random sequences of records roundtrip exactly through write+read.
+//! 2. Splitting a sample sequence into N snapshots and merging the per-snapshot
+//!    histograms equals recording all samples into a single histogram (modulo
+//!    HDR sig-fig rounding, which is exact for repeated values and bounded
+//!    for distinct ones).
+//!
+//! Property (1) is the durability contract: a process that survives long
+//! enough to flush at least one full record can have its log read back
+//! losslessly. Property (2) is the offline-reconstruction contract: the
+//! reader can recover any time window's distribution by merging the
+//! records that fall inside it.
+
+use congestion::format::{
+    AutoMetaSnapshot, HdrSnapshot, LogHeader, UnitLabel, read_file_header, read_record,
+    write_file_header, write_record,
+};
+use congestion::{HistogramAccumulator, MetadataOp, Side};
+use proptest::prelude::*;
+
+fn arb_latency_micros() -> impl Strategy<Value = u64> {
+    1u64..1_000_000
+}
+
+fn fixed_header() -> LogHeader {
+    LogHeader {
+        format_version: 1,
+        tool: "test".into(),
+        tool_version: "0.0.0".into(),
+        hostname: "host".into(),
+        pid: 0,
+        start_unix_micros: 0,
+        snapshot_interval_micros: 1_000_000,
+        auto_meta: AutoMetaSnapshot {
+            initial_cwnd: 1,
+            min_cwnd: 1,
+            max_cwnd: 4096,
+            alpha: 1.3,
+            beta: 1.8,
+            increase_step: 1,
+            decrease_step: 1,
+            baseline_percentile: 0.1,
+            current_percentile: 0.5,
+            long_window_micros: 10_000_000,
+            short_window_micros: 1_000_000,
+            tick_interval_micros: 50_000,
+        },
+        hdr: HdrSnapshot {
+            lowest_discernible_micros: 1,
+            highest_trackable_micros: 3_600_000_000,
+            significant_figures: 3,
+            unit: "microseconds".into(),
+        },
+        unit_labels: vec![UnitLabel {
+            side: 0,
+            op: 0,
+            label: "src-stat".into(),
+        }],
+    }
+}
+
+proptest! {
+    #[test]
+    fn write_then_read_yields_same_records(
+        sample_groups in proptest::collection::vec(
+            proptest::collection::vec(arb_latency_micros(), 1..32),
+            1..8,
+        ),
+    ) {
+        let mut buf: Vec<u8> = Vec::new();
+        write_file_header(&mut buf, &fixed_header()).unwrap();
+        let mut expected_counts: Vec<u64> = Vec::new();
+        for (i, samples) in sample_groups.iter().enumerate() {
+            let mut acc = HistogramAccumulator::new();
+            for &micros in samples {
+                acc.record(std::time::Duration::from_micros(micros));
+            }
+            let snap = acc.snapshot_and_reset();
+            expected_counts.push(snap.len());
+            write_record(&mut buf, i as u64, Side::Source, MetadataOp::Stat, &snap).unwrap();
+        }
+        let mut cursor = std::io::Cursor::new(&buf);
+        let _h = read_file_header(&mut cursor).unwrap();
+        let mut got_counts: Vec<u64> = Vec::new();
+        while let Some(rec) = read_record(&mut cursor).unwrap() {
+            got_counts.push(rec.samples_count);
+        }
+        prop_assert_eq!(got_counts, expected_counts);
+    }
+
+    #[test]
+    fn split_and_merge_is_equivalent_to_single_recording(
+        samples in proptest::collection::vec(arb_latency_micros(), 1..256),
+        split_at in 1usize..256,
+    ) {
+        let split_at = split_at.min(samples.len().saturating_sub(1)).max(1);
+        // Reference: one accumulator, all samples.
+        let mut single = HistogramAccumulator::new();
+        for &m in &samples {
+            single.record(std::time::Duration::from_micros(m));
+        }
+        let single_snap = single.snapshot_and_reset();
+        // Split: two accumulators, halves merged.
+        let mut a = HistogramAccumulator::new();
+        let mut b = HistogramAccumulator::new();
+        for &m in &samples[..split_at] {
+            a.record(std::time::Duration::from_micros(m));
+        }
+        for &m in &samples[split_at..] {
+            b.record(std::time::Duration::from_micros(m));
+        }
+        let snap_a = a.snapshot_and_reset();
+        let snap_b = b.snapshot_and_reset();
+        let mut merged = snap_a.clone();
+        merged.add(&snap_b).unwrap();
+        prop_assert_eq!(single_snap.len(), merged.len());
+        // Compare a few percentiles — exact-equality of HDR histograms is
+        // brittle under reorderings; percentile equivalence is the
+        // property the offline reconstruction actually relies on.
+        for pct in [10.0, 50.0, 90.0, 99.0] {
+            prop_assert_eq!(
+                single_snap.value_at_percentile(pct),
+                merged.value_at_percentile(pct),
+            );
+        }
+    }
+}

--- a/docs/congestion_control.md
+++ b/docs/congestion_control.md
@@ -774,22 +774,40 @@ the rcp binary gates `auto_meta` propagation on the *explicit* flags:
   purely observational; propagating it would silently change remote
   concurrency while giving the user no histogram surface at all.
 
-The master's own `auto_meta` (from `throttle_config()`) is unaffected by
-this gating: the throttle pipeline runs locally on the master in all
-cases where any histogram flag is set, which is correct for local copies
-and harmless for remote copies (master has no metadata probes to throttle
-in remote mode).
+**The master's `ThrottleConfig` is stripped of both histogram fields in
+remote mode.** Specifically, after building the master's `ThrottleConfig`
+via `throttle_config()`, the rcp binary sets `histogram_log_path = None`
+and `histogram_enabled = false` whenever the copy is remote. This has
+three effects:
+
+1. **No local path validation.** `--auto-meta-histogram-log <PATH>` is
+   intended for the rcpd hosts; the directory at `<PATH>` may not exist
+   on the master's filesystem at all. Stripping the field prevents the
+   master from probing it.
+2. **No junk empty log on the master.** Without the strip the master would
+   open `<PATH>.rcp-master.<ext>` on its local filesystem, write a
+   header, and produce an empty record stream — a misleading artifact
+   when the user's intent is per-rcpd logs on remote hosts.
+3. **No spurious accumulator or logger task spawn.** The master in remote
+   mode runs no metadata controllers (all probes fire inside rcpd), so
+   accumulators that never receive a sample are wasteful. Stripping
+   `histogram_enabled` prevents them from being constructed.
+
+The `RcpdConfig` sent to each rcpd still carries the original path. Each
+rcpd validates the path locally against its own filesystem and writes its
+own log there. The split is exact: the master validates and writes nothing;
+each rcpd validates and writes independently.
 
 For distributed-run diagnostics, use `--auto-meta-histogram-log`
 instead: it captures per-rcpd distributions on each host and is the
 reliable surface for remote-copy histogram analysis.
 
 `--auto-meta-histogram-log` is forwarded to rcpd because it produces a
-concrete artifact. The master's path `/path/to/foo.hdr` becomes
-`foo.rcp-master.hdr` on the master, `foo.rcpd-source.hdr` on the
-source rcpd, and `foo.rcpd-destination.hdr` on the destination rcpd,
-mirroring the chrome-trace prefixing convention. Users on shared
-filesystems can collect all three from a single mountpoint; users on
+concrete artifact. The log path `foo.rcpd-source.hdr` is written on the
+source rcpd's host and `foo.rcpd-destination.hdr` on the destination
+rcpd's host, mirroring the chrome-trace prefixing convention. No
+corresponding `foo.rcp-master.hdr` is produced. Users on shared
+filesystems can collect both rcpd logs from a single mountpoint; users on
 per-host paths collect them after the run.
 
 ## Pluggability

--- a/docs/congestion_control.md
+++ b/docs/congestion_control.md
@@ -652,6 +652,146 @@ operator run a candidate controller through a configured scenario
 entirely deterministically, without touching a real filesystem. This is
 how new algorithms should be evaluated before shipping.
 
+### Per-(side, op) latency histograms
+
+Beyond the per-tick controller summary above, the auto-meta pipeline can
+emit full per-(side, op) latency *distributions* — both as a live
+in-terminal panel and as a binary log file. Both surfaces are
+independently toggleable:
+
+- **`--auto-meta-histogram`** turns on per-controller HDR accumulators
+  and renders an ASCII distribution panel beneath the existing
+  one-line-per-controller summary in the progress display. The panel
+  refreshes at the snapshot interval (default 1s) so bars stay
+  monotonic within an interval rather than shrinking mid-fill.
+- **`--auto-meta-histogram-log <PATH>`** writes a binary record
+  stream to `<PATH>` containing the same snapshots the panel reads.
+  Each record is a length-prefixed envelope around a standard
+  `hdrhistogram` v2 binary blob, so existing HDR tooling can read
+  the body after the 18-byte fixed prefix. If `<PATH>` already
+  exists it is truncated at the start of the run — rename or move
+  prior logs you want to keep.
+- **`--auto-meta-histogram-interval <DUR>`** controls both the panel
+  refresh and the per-record snapshot cadence. Range `[100ms, 60s]`,
+  default `1s`.
+
+The log file is self-describing — its header captures every tunable
+in effect plus host/PID/timestamp, so a record stream is meaningful
+in isolation.
+
+When neither flag is set, the histogram code is bypassed entirely:
+no accumulator construction, no extra task, no extra hot-path lock.
+
+#### Log file layout
+
+One log file per run, written in a fixed framing:
+
+```
+"RCP-AUTOMETA-HIST-V1\n"      21 ASCII bytes (magic, includes \n)
+<hdr_len: u32 LE>             byte length of the JSON header
+<hdr_bytes: hdr_len bytes>    JSON document, UTF-8
+
+loop {                        zero or more records, time-ordered
+  <rec_len: u32 LE>           byte length of the rest of the record
+  <unix_micros: u64 LE>       Unix epoch microseconds at snapshot end
+  <side: u8>                  0 = Source, 1 = Destination
+  <op: u8>                    MetadataOp discriminant
+  <samples_count: u64 LE>     count of samples in this snapshot
+  <hdr_blob: rec_len - 18>    HDR v2 serialized histogram
+}
+```
+
+All multi-byte integers are little-endian. The 4-byte length prefix
+plus 18-byte fixed-field section let a reader scan records without
+parsing the HDR blob. Empty snapshots (`samples_count == 0`) are
+omitted — most (side, op) slots are inactive on any real workload,
+and absence of records in a time range means "no samples", never
+"data lost".
+
+The writer flushes after every record; if the process is killed
+mid-record the tail can be partial, and readers detect that via the
+length prefix and stop cleanly. Format version 1; readers should
+check the magic exactly and reject unknown versions. Writers may add
+new top-level keys to the JSON header — readers ignore unknown keys
+to stay forward-compatible.
+
+#### Header schema
+
+The JSON header captures everything needed to interpret the records
+in isolation. Durations are encoded as microseconds in
+`*_micros`-suffixed fields:
+
+- `format_version` — currently `1`.
+- `tool`, `tool_version`, `hostname`, `pid`, `start_unix_micros` —
+  provenance: which process produced this log, on which host, when.
+- `snapshot_interval_micros` — record cadence.
+- `auto_meta` — the controller tunables in effect (initial / min /
+  max `cwnd`, `alpha`, `beta`, increase and decrease steps, baseline
+  and current percentiles, long and short window durations, tick
+  interval).
+- `hdr` — the HDR configuration: lowest discernible value (1 µs),
+  highest trackable value (1 hour), three significant figures, unit
+  (`microseconds`).
+- `unit_labels` — enumeration of all 18 (side, op) pairs paired with
+  their human-readable label (`src-stat`, `dst-stat`, `mkdir`, …).
+
+#### Reconstructing any window
+
+To recover the distribution over `[T - W, T]` for any window `W`:
+filter records by their `unix_micros` and the `(side, op)` of
+interest, deserialize each HDR blob with a v2 deserializer, and fold
+them all into one histogram via the merge operation. That's exactly
+how the controller's own baseline (10s) and current (1s) windows are
+recovered offline from a single record stream.
+
+**Scoping in remote copy.**
+
+`--auto-meta-histogram` (the panel-only flag) is **local to the master
+process and does not change rcpd behavior**. The remote-progress renderer
+calls `render_panel_from_registry()` in both its interactive and
+non-interactive branches, so the panel wiring is in place. In current
+remote mode the master runs no controllers of its own (rcpd processes
+handle all metadata work), so the master's registry is empty and the
+panel shows nothing. The panel is rendered at no extra cost when empty,
+and will show real data automatically once a future feature plumbs rcpd
+histogram snapshots back to master via the existing tracing/progress
+protocol. The panel flag is deliberately not forwarded to rcpd, to
+avoid paying the synchronous accumulator lock cost on every remote
+metadata probe with no visible benefit today.
+
+Critically, `--auto-meta-histogram` alone does **not** enable the
+adaptive throttle pipeline on rcpd. At the CLI layer,
+`throttle_config()` implies `auto_meta` from the panel flag (so the
+master can run a local throttle loop when the panel is visible in a
+local copy). But when constructing the `RcpdConfig` for a remote copy,
+the rcp binary gates `auto_meta` propagation on the *explicit* flags:
+
+- `--auto-meta-throttle` (user asked for throttle) → propagated to rcpd.
+- `--auto-meta-histogram-log <PATH>` (user wants per-rcpd log files, which
+  require the throttle pipeline on rcpd to produce data) → propagated to
+  rcpd.
+- `--auto-meta-histogram` alone → **not** propagated. The panel flag is
+  purely observational; propagating it would silently change remote
+  concurrency while giving the user no histogram surface at all.
+
+The master's own `auto_meta` (from `throttle_config()`) is unaffected by
+this gating: the throttle pipeline runs locally on the master in all
+cases where any histogram flag is set, which is correct for local copies
+and harmless for remote copies (master has no metadata probes to throttle
+in remote mode).
+
+For distributed-run diagnostics, use `--auto-meta-histogram-log`
+instead: it captures per-rcpd distributions on each host and is the
+reliable surface for remote-copy histogram analysis.
+
+`--auto-meta-histogram-log` is forwarded to rcpd because it produces a
+concrete artifact. The master's path `/path/to/foo.hdr` becomes
+`foo.rcp-master.hdr` on the master, `foo.rcpd-source.hdr` on the
+source rcpd, and `foo.rcpd-destination.hdr` on the destination rcpd,
+mirroring the chrome-trace prefixing convention. Users on shared
+filesystems can collect all three from a single mountpoint; users on
+per-host paths collect them after the run.
+
 ## Pluggability
 
 The algorithm layer is behind a single trait. Shipping today:

--- a/rcp/src/bin/rcp.rs
+++ b/rcp/src/bin/rcp.rs
@@ -400,10 +400,36 @@ async fn run_rcpd_master(
         ops_throttle: args.common.ops_throttle,
         iops_throttle: args.common.iops_throttle,
         chunk_size: args.chunk_size.0 as usize,
-        auto_meta: args
+        // Gate rcpd's auto_meta on explicit throttle or log path.
+        //
+        // `throttle_config()` always enables auto_meta when any histogram flag
+        // is set (including the panel-only `--auto-meta-histogram`), which is
+        // correct for the master's local copy path.  But for remote copies we
+        // must not propagate the throttle pipeline to rcpd unless the user
+        // explicitly asked for it:
+        //
+        //   - `--auto-meta-throttle`: user explicitly wants throttle → propagate.
+        //   - `--auto-meta-histogram-log <PATH>`: user wants per-rcpd log files,
+        //     which require the throttle pipeline to fire on rcpd → propagate.
+        //   - `--auto-meta-histogram` alone: panel-only flag.  The master's
+        //     panel is empty in remote mode (master runs no controllers); rcpd's
+        //     panel never reaches the user; rcpd behavior should be unchanged.
+        auto_meta: if args.common.auto_meta_throttle
+            || args.common.auto_meta_histogram_log.is_some()
+        {
+            args.common
+                .throttle_config(args.max_open_files, args.chunk_size.0)
+                .auto_meta
+        } else {
+            None
+        },
+        auto_meta_histogram: args.common.auto_meta_histogram,
+        auto_meta_histogram_log: args
             .common
-            .throttle_config(args.max_open_files, args.chunk_size.0)
-            .auto_meta,
+            .auto_meta_histogram_log
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string()),
+        auto_meta_histogram_interval: args.common.auto_meta_histogram_interval.into(),
         dereference: args.dereference,
         overwrite: args.overwrite,
         overwrite_compare: args.overwrite_compare.clone(),

--- a/rcp/src/bin/rcp.rs
+++ b/rcp/src/bin/rcp.rs
@@ -1104,9 +1104,25 @@ fn main() -> Result<(), anyhow::Error> {
         .common
         .output_config(args.quiet, !is_dry_run && args.summary);
     let runtime = args.common.runtime_config();
-    let throttle = args
+    let mut throttle = args
         .common
         .throttle_config(args.max_open_files, args.chunk_size.0);
+    if is_remote_operation {
+        // In remote mode the master runs no metadata controllers — all probes
+        // fire inside rcpd on the remote hosts. Clear both histogram fields so
+        // that:
+        //   1. The master does not validate --auto-meta-histogram-log locally
+        //      against a path that may only exist on the remote hosts.
+        //   2. The master does not spawn a logger task that would write an empty
+        //      header-only log file at <PATH>.rcp-master.<ext> on the master's
+        //      filesystem.
+        //   3. The master does not spawn accumulators that will never receive a
+        //      sample (master has no controllers in remote mode).
+        // The RcpdConfig still carries the original path; each rcpd validates
+        // and writes its own log locally.
+        throttle.histogram_log_path = None;
+        throttle.histogram_enabled = false;
+    }
     let tracing = common::TracingConfig {
         remote_layer: None,
         debug_log_file: None,

--- a/remote/src/protocol/mod.rs
+++ b/remote/src/protocol/mod.rs
@@ -246,6 +246,14 @@ pub struct RcpdConfig {
     /// master's `--auto-meta-*` flags. `None` means the feature is off on
     /// this rcpd instance.
     pub auto_meta: Option<common::AutoMetaThrottleConfig>,
+    /// Mirror of master's --auto-meta-histogram flag.
+    pub auto_meta_histogram: bool,
+    /// Mirror of master's --auto-meta-histogram-log path. Each rcpd
+    /// suffixes its own trace identifier so the master and rcpds don't
+    /// collide on a localhost run.
+    pub auto_meta_histogram_log: Option<String>,
+    /// Mirror of master's --auto-meta-histogram-interval.
+    pub auto_meta_histogram_interval: std::time::Duration,
     // common::copy::Settings
     pub dereference: bool,
     pub overwrite: bool,
@@ -403,6 +411,20 @@ impl RcpdConfig {
                 humantime::format_duration(auto.tick_interval),
             ));
         }
+        // Only forward histogram flags when there's a log path: the panel-
+        // only flag (--auto-meta-histogram) makes rcpd pay the synchronous
+        // accumulator lock cost on every probe, but rcpd's panel never
+        // reaches the user (the master's remote-progress renderer doesn't
+        // read the rcpd histogram registry). The log path is different —
+        // it produces a concrete artifact on the rcpd's host that the user
+        // can collect after the run.
+        if let Some(path) = &self.auto_meta_histogram_log {
+            args.push(format!("--auto-meta-histogram-log={path}"));
+            args.push(format!(
+                "--auto-meta-histogram-interval={}",
+                humantime::format_duration(self.auto_meta_histogram_interval),
+            ));
+        }
         args
     }
 }
@@ -508,6 +530,9 @@ mod tests {
             iops_throttle: 0,
             chunk_size: 0,
             auto_meta: None,
+            auto_meta_histogram: false,
+            auto_meta_histogram_log: None,
+            auto_meta_histogram_interval: std::time::Duration::from_secs(1),
             dereference: false,
             overwrite: false,
             overwrite_compare: "size,mtime".to_string(),
@@ -534,12 +559,37 @@ mod tests {
     }
 
     #[test]
-    fn to_args_omits_auto_meta_when_none() {
+    fn to_args_omits_auto_meta_throttle_when_none() {
         let args = minimal_rcpd_config().to_args();
-        assert!(
-            !args.iter().any(|a| a.starts_with("--auto-meta")),
-            "no auto-meta flags should be emitted when auto_meta is None: {args:?}",
-        );
+        // throttle-specific flags must be absent when auto_meta is None
+        let throttle_flags = [
+            "--auto-meta-throttle",
+            "--auto-meta-initial-cwnd",
+            "--auto-meta-min-cwnd",
+            "--auto-meta-max-cwnd",
+            "--auto-meta-alpha",
+            "--auto-meta-beta",
+            "--auto-meta-baseline-percentile",
+            "--auto-meta-current-percentile",
+            "--auto-meta-increase-step",
+            "--auto-meta-decrease-step",
+            "--auto-meta-long-window",
+            "--auto-meta-short-window",
+            "--auto-meta-tick-interval",
+        ];
+        for flag in throttle_flags {
+            assert!(
+                !args.iter().any(|a| a.starts_with(flag)),
+                "throttle flag {flag} should not be emitted when auto_meta is None: {args:?}",
+            );
+        }
+        // histogram flag, log, and interval must all be absent when histograms are off
+        for arg in &args {
+            assert!(
+                !arg.starts_with("--auto-meta-histogram"),
+                "must not emit any histogram flag when histograms are off, found: {arg}",
+            );
+        }
     }
 
     #[test]
@@ -575,5 +625,62 @@ mod tests {
         assert!(has_prefix("--auto-meta-long-window="));
         assert!(has_prefix("--auto-meta-short-window="));
         assert!(has_prefix("--auto-meta-tick-interval="));
+    }
+
+    #[test]
+    fn to_args_omits_histogram_flags_when_disabled() {
+        // Critical for backward compatibility: existing rcpd binaries
+        // built without histogram support reject --auto-meta-histogram-*
+        // flags, so we must not emit them on every remote copy.
+        let mut config = minimal_rcpd_config();
+        config.auto_meta_histogram = false;
+        config.auto_meta_histogram_log = None;
+        let args = config.to_args();
+        for arg in &args {
+            assert!(
+                !arg.starts_with("--auto-meta-histogram"),
+                "must not emit histogram flag when disabled, found: {arg}",
+            );
+        }
+    }
+
+    #[test]
+    fn to_args_omits_panel_only_flag_when_no_log_path() {
+        // Panel-only --auto-meta-histogram is intentionally NOT forwarded
+        // to rcpd: the panel never reaches the user (no plumbing in remote
+        // progress), and forwarding would just add per-probe lock cost.
+        let mut config = minimal_rcpd_config();
+        config.auto_meta_histogram = true;
+        config.auto_meta_histogram_log = None;
+        let args = config.to_args();
+        for arg in &args {
+            assert!(
+                !arg.starts_with("--auto-meta-histogram"),
+                "panel-only flag must not be forwarded to rcpd, found: {arg}",
+            );
+        }
+    }
+
+    #[test]
+    fn to_args_forwards_histogram_log_and_interval_when_log_path_set() {
+        let mut config = minimal_rcpd_config();
+        config.auto_meta_histogram = false; // panel-only off
+        config.auto_meta_histogram_log = Some("/tmp/foo.hdr".into());
+        config.auto_meta_histogram_interval = std::time::Duration::from_millis(500);
+        let args = config.to_args();
+        assert!(
+            args.iter()
+                .any(|a| a == "--auto-meta-histogram-log=/tmp/foo.hdr")
+        );
+        assert!(
+            args.iter()
+                .any(|a| a.starts_with("--auto-meta-histogram-interval="))
+        );
+        // The bare panel flag is NOT pushed; the log flag at parse time on
+        // rcpd already implies the accumulator pipeline.
+        assert!(
+            !args.iter().any(|a| a == "--auto-meta-histogram"),
+            "panel-only flag must not be forwarded; the log flag implies the pipeline",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two independently-toggleable observability surfaces on top of the existing `--auto-meta-throttle` controller pipeline:

- `--auto-meta-histogram` — live in-terminal ASCII distribution panel beneath the existing one-line-per-controller summary
- `--auto-meta-histogram-log <PATH>` — binary log of per-(side, op) HDR histograms; self-describing JSON header + length-prefixed records carrying HDR v2 binary blobs (readable with standard `hdrhistogram` tooling after stripping the 18-byte fixed prefix)
- `--auto-meta-histogram-interval <DUR>` — snapshot cadence, default 1s

When neither flag is set, no accumulators are allocated and the hot path is unchanged. When active, probe completion synchronously records into the accumulator inside the `RoutingSink`, so the logger's final snapshot at shutdown captures every probe that completed (no async-queue drain race).

The format is documented in [`docs/superpowers/specs/2026-05-08-auto-meta-histogram-design.md`](docs/superpowers/specs/2026-05-08-auto-meta-histogram-design.md) and [`docs/congestion_control.md`](docs/congestion_control.md). Offline readers reconstruct the controller's baseline (10s) or current (1s) windows by filtering records by `(side, op)` and time range, deserializing each blob, and folding with `Histogram::add()`.

In remote copies, each rcpd writes its own log file suffixed by trace identifier (`foo.rcpd-source.hdr`, `foo.rcpd-destination.hdr`). The panel is local-only today — remote-copy users should rely on `--auto-meta-histogram-log` for per-host distributions.

## Test plan

- [ ] Unit + property tests pass (`just test`) — 491 tests on the touched crates, all green locally
- [ ] Lint clean (`just lint`)
- [ ] Doc build clean (`just doc`)
- [ ] Manual: `rcp --auto-meta-throttle --auto-meta-histogram /src /dst` shows the distribution panel under the summary
- [ ] Manual: `rcp --auto-meta-throttle --auto-meta-histogram-log /tmp/x.hdr /src /dst` writes a non-empty log; \`hdrhistogram\` consumers can read it
- [ ] Manual: existing remote copies without histogram flags still work against an unmodified rcpd binary (the `--auto-meta-histogram-interval` flag is no longer emitted unconditionally)
- [ ] Manual: `--auto-meta-histogram-log` to a path whose resolved target is a directory, symlink, or unwritable file is rejected at startup with a config error