### PR TITLE
Record progress snapshots in auto-meta histogram log (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `--auto-meta-histogram`, `--auto-meta-histogram-log <PATH>`, and
   `--auto-meta-histogram-interval <DUR>` for per-(side, op) HDR latency
-  histograms with live distribution panel and binary log file. See
-  `docs/congestion_control.md` for the format reference.
+  histograms with live distribution panel and binary log file. The log
+  also carries per-tick progress snapshots (ops/s, files copied, bytes
+  copied, etc.) interleaved with histogram records, so offline tools
+  can correlate latency distributions with throughput. Format bumped
+  to v2; see `docs/congestion_control.md` for the layout.
 
 ### Changed
 - Upgrade workspace to Rust 2024 edition; modernize code to use `let` chains and 2024 idioms

--- a/common/src/histogram_logger.rs
+++ b/common/src/histogram_logger.rs
@@ -10,8 +10,17 @@
 //! snapshot end time as the record's `unix_micros` field — readers see
 //! the true coverage even if the host was loaded.
 
-use congestion::format::{LogHeader, write_file_header, write_record};
+use congestion::format::{
+    LogHeader, write_file_header, write_histogram_record, write_progress_record,
+};
 use congestion::{HistogramAccumulator, MetadataOp, Side};
+
+/// Closure that, when called, returns the JSON-encoded current progress
+/// snapshot. The logger calls this once per tick (only when a log file
+/// is being written) and emits one Progress record. Boxed so the
+/// concrete snapshot type stays in the caller's crate — the logger
+/// doesn't depend on it.
+pub type ProgressSource = Box<dyn Fn() -> Vec<u8> + Send + Sync>;
 
 /// One slot the logger owns: the accumulator (shared with a ControlUnit)
 /// and the watch sender used to publish snapshots to the display.
@@ -28,6 +37,12 @@ pub struct LoggerConfig {
     pub interval: std::time::Duration,
     pub log_path: Option<std::path::PathBuf>,
     pub header: LogHeader,
+    /// Optional progress source. When set and a log file is open, the
+    /// logger calls it once per tick and writes one Progress record
+    /// carrying the returned JSON bytes — letting offline tools
+    /// correlate latency distributions with the throughput counters
+    /// from the progress bar.
+    pub progress_source: Option<ProgressSource>,
 }
 
 /// Run the logger task: ticks, snapshots, publishes, optionally writes
@@ -70,19 +85,20 @@ pub async fn run_logger(
         }
         None => None,
     };
+    let progress_source = config.progress_source;
     let mut interval = tokio::time::interval(config.interval);
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     interval.tick().await;
     loop {
         tokio::select! {
             _ = interval.tick() => {
-                writer = snapshot_and_publish_units(&units, writer);
+                writer = snapshot_and_publish_units(&units, progress_source.as_deref(), writer);
             }
             _ = cancel.changed() => {
                 if *cancel.borrow() {
                     // Flush any samples accumulated since the last tick
                     // so a short copy / partial final interval doesn't lose data.
-                    drop(snapshot_and_publish_units(&units, writer));
+                    drop(snapshot_and_publish_units(&units, progress_source.as_deref(), writer));
                     break;
                 }
             }
@@ -92,11 +108,14 @@ pub async fn run_logger(
 }
 
 /// Snapshot every accumulator, publish to its watch, optionally write
-/// to the log file. Returns the (possibly None'd) writer back to the
-/// caller — if a write or flush fails, the returned Option is None
-/// and a warning has been emitted.
+/// to the log file. When `progress_source` is set and a writer is
+/// active, append one Progress record per call carrying the
+/// JSON-encoded snapshot the closure returns. Returns the (possibly
+/// None'd) writer back to the caller — if a write or flush fails,
+/// the returned Option is None and a warning has been emitted.
 fn snapshot_and_publish_units(
     units: &[LoggerUnit],
+    progress_source: Option<&(dyn Fn() -> Vec<u8> + Send + Sync)>,
     mut writer: Option<std::io::BufWriter<std::fs::File>>,
 ) -> Option<std::io::BufWriter<std::fs::File>> {
     use std::io::Write;
@@ -118,15 +137,37 @@ fn snapshot_and_publish_units(
             continue;
         }
         if let Some(w) = writer.as_mut()
-            && let Err(err) = write_record(w, snapshot_micros, unit.side, unit.op, &snap)
+            && let Err(err) = write_histogram_record(w, snapshot_micros, unit.side, unit.op, &snap)
         {
             tracing::warn!(
-                "histogram-logger: write_record({label}) failed: {err:#}; \
+                "histogram-logger: write_histogram_record({label}) failed: {err:#}; \
                  disabling file output",
                 label = unit.label,
             );
             writer = None;
             break;
+        }
+    }
+    // emit a progress record after the unit loop so its timestamp
+    // bounds the tick from above: every preceding unit record is at or
+    // before this point. progress is monotonic, so we always write
+    // it — empty progress (all zeros) is meaningful at run start.
+    // an empty json payload is the source's "skip this tick" signal
+    // (e.g. transient encoding failure already logged inside src()); we
+    // drop the record rather than emit something unparseable.
+    if let Some(src) = progress_source
+        && let Some(w) = writer.as_mut()
+    {
+        let json = src();
+        let ts = unix_micros_now();
+        if !json.is_empty()
+            && let Err(err) = write_progress_record(w, ts, &json)
+        {
+            tracing::warn!(
+                "histogram-logger: write_progress_record failed: {err:#}; \
+                 disabling file output",
+            );
+            writer = None;
         }
     }
     if let Some(w) = writer.as_mut()
@@ -149,12 +190,13 @@ fn unix_micros_now() -> u64 {
 mod tests {
     use super::*;
     use congestion::format::{
-        AutoMetaSnapshot, HdrSnapshot, LogHeader, UnitLabel, read_file_header, read_record,
+        AutoMetaSnapshot, FORMAT_VERSION, HdrSnapshot, LogHeader, Record, UnitLabel,
+        read_file_header, read_record,
     };
 
     fn header() -> LogHeader {
         LogHeader {
-            format_version: 1,
+            format_version: FORMAT_VERSION,
             tool: "test".into(),
             tool_version: "0.0.0".into(),
             hostname: "h".into(),
@@ -216,6 +258,7 @@ mod tests {
             interval: std::time::Duration::from_millis(50),
             log_path: Some(path.clone()),
             header: header(),
+            progress_source: None,
         };
         let handle = tokio::spawn(run_logger(config, units, cancel_rx));
         // Wait for at least one tick to fire and write a record.
@@ -226,9 +269,13 @@ mod tests {
         let file = std::fs::File::open(&path).unwrap();
         let mut reader = std::io::BufReader::new(file);
         let _ = read_file_header(&mut reader).unwrap();
-        let rec = read_record(&mut reader)
+        let rec = match read_record(&mut reader)
             .unwrap()
-            .expect("at least one record written");
+            .expect("at least one record written")
+        {
+            Record::Histogram(h) => h,
+            Record::Progress(_) => panic!("unexpected progress record"),
+        };
         assert_eq!(rec.samples_count, 2);
         assert_eq!(rec.side, Side::Source);
         assert_eq!(rec.op, MetadataOp::Stat);
@@ -254,6 +301,7 @@ mod tests {
             interval: std::time::Duration::from_millis(50),
             log_path: Some(path.clone()),
             header: header(),
+            progress_source: None,
         };
         let handle = tokio::spawn(run_logger(config, units, cancel_rx));
         // Don't preload any samples; let the logger tick.
@@ -299,6 +347,7 @@ mod tests {
             interval: std::time::Duration::from_secs(60),
             log_path: Some(path.clone()),
             header: header(),
+            progress_source: None,
         };
         let handle = tokio::spawn(run_logger(config, units, cancel_rx));
         // Give the task a moment to start and consume the initial tick,
@@ -310,9 +359,13 @@ mod tests {
         let file = std::fs::File::open(&path).unwrap();
         let mut reader = std::io::BufReader::new(file);
         let _ = read_file_header(&mut reader).unwrap();
-        let rec = read_record(&mut reader)
+        let rec = match read_record(&mut reader)
             .unwrap()
-            .expect("cancellation must flush a final record");
+            .expect("cancellation must flush a final record")
+        {
+            Record::Histogram(h) => h,
+            Record::Progress(_) => panic!("unexpected progress record"),
+        };
         assert_eq!(rec.samples_count, 1);
     }
 
@@ -368,7 +421,7 @@ mod tests {
         ];
 
         let before_micros = unix_micros_now();
-        writer = snapshot_and_publish_units(&units, writer);
+        writer = snapshot_and_publish_units(&units, None, writer);
         let after_micros = unix_micros_now();
         drop(writer);
 
@@ -381,19 +434,65 @@ mod tests {
         let r2 = congestion::format::read_record(&mut reader)
             .unwrap()
             .expect("record 2");
+        let r1_ts = r1.unix_micros();
+        let r2_ts = r2.unix_micros();
         assert!(
-            r1.unix_micros >= before_micros && r1.unix_micros <= after_micros,
-            "record 1 ts {} not in [{}, {}]",
-            r1.unix_micros,
-            before_micros,
-            after_micros,
+            r1_ts >= before_micros && r1_ts <= after_micros,
+            "record 1 ts {r1_ts} not in [{before_micros}, {after_micros}]",
         );
         assert!(
-            r2.unix_micros >= r1.unix_micros && r2.unix_micros <= after_micros,
-            "record 2 ts {} must be >= record 1 ts {} and <= after {}",
-            r2.unix_micros,
-            r1.unix_micros,
-            after_micros,
+            r2_ts >= r1_ts && r2_ts <= after_micros,
+            "record 2 ts {r2_ts} must be >= record 1 ts {r1_ts} and <= after {after_micros}",
+        );
+    }
+
+    #[tokio::test]
+    async fn writes_progress_record_per_tick_when_source_set() {
+        // Even when the histogram accumulator is empty (no samples were
+        // recorded into it this tick), a configured progress source
+        // must still emit one Progress record per tick — progress
+        // counters are monotonic and meaningful from the first sample
+        // onward, including zero state.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.hdr");
+        let acc = std::sync::Arc::new(std::sync::Mutex::new(HistogramAccumulator::new()));
+        let (snap_tx, _snap_rx) = tokio::sync::watch::channel(
+            hdrhistogram::Histogram::<u64>::new_with_bounds(1, 3_600_000_000, 3).unwrap(),
+        );
+        let units = vec![LoggerUnit {
+            label: "src-stat",
+            side: Side::Source,
+            op: MetadataOp::Stat,
+            accumulator: acc,
+            snapshot_tx: snap_tx,
+        }];
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        let payload = br#"{"files_copied":3}"#.to_vec();
+        let payload_for_closure = payload.clone();
+        let config = LoggerConfig {
+            interval: std::time::Duration::from_millis(50),
+            log_path: Some(path.clone()),
+            header: header(),
+            progress_source: Some(Box::new(move || payload_for_closure.clone())),
+        };
+        let handle = tokio::spawn(run_logger(config, units, cancel_rx));
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        cancel_tx.send(true).unwrap();
+        handle.await.unwrap();
+
+        let f = std::fs::File::open(&path).unwrap();
+        let mut reader = std::io::BufReader::new(f);
+        let _ = read_file_header(&mut reader).unwrap();
+        let mut progress_count = 0;
+        while let Some(rec) = read_record(&mut reader).unwrap() {
+            if let Record::Progress(p) = rec {
+                assert_eq!(p.json, payload);
+                progress_count += 1;
+            }
+        }
+        assert!(
+            progress_count >= 1,
+            "expected ≥1 progress record, got {progress_count}",
         );
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1305,7 +1305,7 @@ fn build_histogram_header(
         }
     }
     LogHeader {
-        format_version: 1,
+        format_version: congestion::format::FORMAT_VERSION,
         tool: tool_name.to_string(),
         tool_version: env!("CARGO_PKG_VERSION").to_string(),
         hostname,
@@ -1500,11 +1500,29 @@ fn spawn_auto_meta_throttle(
         let header = build_histogram_header(&auto, trace_identifier, histogram_interval);
         let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
         store_logger_cancel(cancel_tx);
+        // Snapshot the global PROGRESS counters into JSON each tick so
+        // the binary log carries throughput/files-copied alongside the
+        // latency distributions — readers can time-align them via the
+        // shared unix_micros field. Encoding can't realistically fail
+        // for this struct shape, but on the off chance it does we log
+        // and return an empty Vec — the logger treats empty as "skip
+        // this tick" rather than writing a record readers can't parse.
+        let progress_source: histogram_logger::ProgressSource = Box::new(|| {
+            let snapshot = progress::SerializableProgress::from(&*PROGRESS);
+            serde_json::to_vec(&snapshot).unwrap_or_else(|err| {
+                tracing::warn!(
+                    "histogram-logger: SerializableProgress JSON encode failed: {err:#}; \
+                     dropping this tick's progress record"
+                );
+                Vec::new()
+            })
+        });
         let handle = runtime.spawn(histogram_logger::run_logger(
             histogram_logger::LoggerConfig {
                 interval: histogram_interval,
                 log_path: resolved_log_path,
                 header,
+                progress_source: Some(progress_source),
             },
             logger_units,
             cancel_rx,

--- a/common/tests/histogram_log_e2e.rs
+++ b/common/tests/histogram_log_e2e.rs
@@ -1,7 +1,8 @@
 //! End-to-end: spawn auto-meta with histogram logging, generate a few
 //! probes, terminate, parse the resulting log, assert structure.
 
-use congestion::format::{read_file_header, read_record};
+use common::SerializableProgress;
+use congestion::format::{FORMAT_VERSION, Record, read_file_header, read_record};
 use std::io::BufReader;
 
 #[test]
@@ -70,16 +71,34 @@ fn auto_meta_histogram_log_records_real_probes() {
         .unwrap_or_else(|e| panic!("expected log at {actual_path:?}: {e}"));
     let mut reader = BufReader::new(f);
     let header = read_file_header(&mut reader).expect("header parses");
-    assert_eq!(header.format_version, 1);
+    assert_eq!(header.format_version, FORMAT_VERSION);
     assert_eq!(header.tool, "rcp");
     assert_eq!(header.snapshot_interval_micros, 150_000);
 
     let mut total_samples = 0u64;
+    let mut progress_records = 0u64;
+    let mut last_progress: Option<SerializableProgress> = None;
     while let Some(rec) = read_record(&mut reader).expect("reads cleanly") {
-        total_samples += rec.samples_count;
+        match rec {
+            Record::Histogram(h) => total_samples += h.samples_count,
+            Record::Progress(p) => {
+                progress_records += 1;
+                // Each progress record must carry a SerializableProgress
+                // payload — the offline-correlation contract is that the
+                // same shape the progress bar consumes is what readers
+                // see in the log. This deserialization is the test.
+                last_progress =
+                    Some(serde_json::from_slice(&p.json).expect("progress JSON parses"));
+            }
+        }
     }
     assert!(
         total_samples > 0,
         "expected at least one sample recorded; got 0"
     );
+    assert!(
+        progress_records > 0,
+        "expected at least one progress record; got 0"
+    );
+    let _ = last_progress.expect("progress record must carry a valid snapshot");
 }

--- a/congestion/src/format.rs
+++ b/congestion/src/format.rs
@@ -1,34 +1,59 @@
-//! Binary log file format for auto-meta histogram recordings.
+//! Binary log file format for auto-meta recordings.
 //!
 //! See `docs/congestion_control.md` for the canonical format reference.
 //! The short version:
 //!
 //! ```text
-//!   "RCP-AUTOMETA-HIST-V1\n"  // 21 ASCII bytes (magic, includes \n)
+//!   "RCP-AUTOMETA-HIST-V2\n"  // 21 ASCII bytes (magic, includes \n)
 //!   <hdr_len: u32 LE>
 //!   <hdr_bytes: JSON, hdr_len bytes>
 //!   loop {
 //!       <rec_len: u32 LE>
-//!       <unix_micros: u64 LE>
-//!       <side: u8>            // 0 = Source, 1 = Destination
-//!       <op: u8>              // MetadataOp discriminant
-//!       <samples_count: u64 LE>
-//!       <hdr_v2_blob: rec_len - 18 bytes>
+//!       <kind: u8>                // 0 = Histogram, 1 = Progress
+//!       if kind == Histogram:
+//!         <unix_micros: u64 LE>
+//!         <side: u8>              // 0 = Source, 1 = Destination
+//!         <op: u8>                // MetadataOp discriminant
+//!         <samples_count: u64 LE>
+//!         <hdr_v2_blob: remaining bytes>
+//!       if kind == Progress:
+//!         <unix_micros: u64 LE>
+//!         <json_bytes: remaining bytes>   // SerializableProgress as JSON
 //!   }
 //! ```
 //!
 //! Multi-byte integers are little-endian. Records are length-prefixed so
 //! readers can detect partial writes (process killed mid-record) and stop
-//! cleanly at the last full record.
+//! cleanly at the last full record. The single `kind` byte after the
+//! length prefix lets one file carry multiple record types in
+//! time-ordered interleave.
 
 use crate::measurement::{MetadataOp, Side};
 
 /// Magic bytes at the start of every log file. Includes a trailing
 /// newline so `head -1 file.hdr` shows the version on a clean line.
-pub const MAGIC: &[u8; 21] = b"RCP-AUTOMETA-HIST-V1\n";
+pub const MAGIC: &[u8; 21] = b"RCP-AUTOMETA-HIST-V2\n";
 
-/// The fixed (non-blob) bytes per record: u64 timestamp + u8 side + u8 op + u64 count.
-pub const RECORD_FIXED_BYTES: usize = 8 + 1 + 1 + 8;
+/// On-disk format version. Bumped from 1 → 2 when the per-record
+/// `kind` byte and the `Progress` record variant were introduced.
+pub const FORMAT_VERSION: u32 = 2;
+
+/// Discriminant byte used as the first byte of every record body.
+/// Stable; new variants append. Readers reject unknown values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum RecordKind {
+    Histogram = 0,
+    Progress = 1,
+}
+
+/// Fixed-prefix size of a Histogram record body, *including* the kind
+/// byte: kind(1) + unix_micros(8) + side(1) + op(1) + samples_count(8).
+pub const HISTOGRAM_RECORD_FIXED_BYTES: usize = 1 + 8 + 1 + 1 + 8;
+
+/// Fixed-prefix size of a Progress record body, *including* the kind
+/// byte: kind(1) + unix_micros(8). The JSON payload occupies the rest.
+pub const PROGRESS_RECORD_FIXED_BYTES: usize = 1 + 8;
 
 /// Maximum accepted size of the JSON header in bytes. Real headers
 /// are a few hundred bytes; this cap is generous enough that any
@@ -37,8 +62,9 @@ pub const RECORD_FIXED_BYTES: usize = 8 + 1 + 1 + 8;
 pub const MAX_HEADER_BYTES: u32 = 1 << 20; // 1 MiB
 
 /// Maximum accepted size of a single record in bytes. HDR v2 blobs
-/// at the configured range and precision are ~few KiB; this cap
-/// catches obvious corruption while leaving generous headroom.
+/// at the configured range and precision are ~few KiB; progress JSON
+/// payloads are a few hundred bytes; this cap catches obvious
+/// corruption while leaving generous headroom.
 pub const MAX_RECORD_BYTES: u32 = 1 << 20; // 1 MiB
 
 /// Top-level header captured at file start. Mirrors the fields a reader
@@ -89,19 +115,44 @@ pub struct UnitLabel {
     pub label: String,
 }
 
-/// One record's worth of decoded data after parsing the binary frame.
-///
-/// `histogram` is the deserialized HDR; `samples_count` is what the
-/// writer recorded in the fixed prefix (it equals `histogram.len()`
-/// for valid records and is exposed redundantly for tools that want to
-/// scan a log without parsing each blob).
+/// One decoded histogram record.
 #[derive(Debug)]
-pub struct Record {
+pub struct HistogramRecord {
     pub unix_micros: u64,
     pub side: Side,
     pub op: MetadataOp,
+    /// What the writer recorded in the fixed prefix; equals
+    /// `histogram.len()` for valid records and is exposed redundantly
+    /// for tools that want to scan a log without parsing each blob.
     pub samples_count: u64,
     pub histogram: hdrhistogram::Histogram<u64>,
+}
+
+/// One decoded progress record. `json` is the raw `SerializableProgress`
+/// payload bytes — the format crate does not depend on the snapshot
+/// type, so the caller deserializes with the structure it expects.
+#[derive(Debug)]
+pub struct ProgressRecord {
+    pub unix_micros: u64,
+    pub json: Vec<u8>,
+}
+
+/// One record's worth of decoded data after parsing the binary frame.
+#[derive(Debug)]
+pub enum Record {
+    Histogram(HistogramRecord),
+    Progress(ProgressRecord),
+}
+
+impl Record {
+    /// Convenience accessor: the timestamp on the record, regardless of variant.
+    #[must_use]
+    pub fn unix_micros(&self) -> u64 {
+        match self {
+            Record::Histogram(h) => h.unix_micros,
+            Record::Progress(p) => p.unix_micros,
+        }
+    }
 }
 
 /// Errors returned by the binary format reader.
@@ -117,6 +168,8 @@ pub enum ReadError {
     BadSide(u8),
     #[error("invalid MetadataOp discriminant {0}")]
     BadOp(u8),
+    #[error("invalid record kind {0}")]
+    BadRecordKind(u8),
     #[error("hdr deserialization failed: {0}")]
     Hdr(String),
     #[error("json: {0:#}")]
@@ -168,17 +221,17 @@ pub fn read_file_header<R: std::io::Read>(input: &mut R) -> Result<LogHeader, Re
     let mut json = vec![0u8; len];
     input.read_exact(&mut json)?;
     let header: LogHeader = serde_json::from_slice(&json)?;
-    if header.format_version != 1 {
+    if header.format_version != FORMAT_VERSION {
         return Err(ReadError::UnsupportedVersion(header.format_version));
     }
     Ok(header)
 }
 
-/// Append one record to `out`, encoding `histogram` as HDR v2 binary.
-///
-/// The record body's fixed prefix (unix_micros + side + op + samples_count)
-/// occupies [`RECORD_FIXED_BYTES`] bytes; the rest is the HDR blob.
-pub fn write_record<W: std::io::Write>(
+/// Append one histogram record to `out`, encoding `histogram` as HDR v2
+/// binary. The record body's fixed prefix (kind + unix_micros + side +
+/// op + samples_count) occupies [`HISTOGRAM_RECORD_FIXED_BYTES`] bytes;
+/// the rest is the HDR blob.
+pub fn write_histogram_record<W: std::io::Write>(
     out: &mut W,
     unix_micros: u64,
     side: Side,
@@ -191,13 +244,30 @@ pub fn write_record<W: std::io::Write>(
     serializer
         .serialize(histogram, &mut blob)
         .map_err(|e| WriteError::Hdr(format!("{e:?}")))?;
-    let rec_len = u32::try_from(RECORD_FIXED_BYTES + blob.len()).expect("record < 4GB");
+    let rec_len = u32::try_from(HISTOGRAM_RECORD_FIXED_BYTES + blob.len()).expect("record < 4GB");
     out.write_all(&rec_len.to_le_bytes())?;
+    out.write_all(&[RecordKind::Histogram as u8])?;
     out.write_all(&unix_micros.to_le_bytes())?;
     out.write_all(&[side as u8])?;
     out.write_all(&[op as u8])?;
     out.write_all(&histogram.len().to_le_bytes())?;
     out.write_all(&blob)?;
+    Ok(())
+}
+
+/// Append one progress record to `out`. The body is the kind byte plus
+/// an 8-byte timestamp followed by an opaque JSON payload — readers
+/// pass `json` through to a `serde_json::from_slice` of their choice.
+pub fn write_progress_record<W: std::io::Write>(
+    out: &mut W,
+    unix_micros: u64,
+    json: &[u8],
+) -> Result<(), WriteError> {
+    let rec_len = u32::try_from(PROGRESS_RECORD_FIXED_BYTES + json.len()).expect("record < 4GB");
+    out.write_all(&rec_len.to_le_bytes())?;
+    out.write_all(&[RecordKind::Progress as u8])?;
+    out.write_all(&unix_micros.to_le_bytes())?;
+    out.write_all(json)?;
     Ok(())
 }
 
@@ -216,10 +286,10 @@ pub fn read_record<R: std::io::Read>(input: &mut R) -> Result<Option<Record>, Re
         return Err(ReadError::RecordTooLarge(rec_len));
     }
     let rec_len = rec_len as usize;
-    if rec_len < RECORD_FIXED_BYTES {
-        // Length too small to even fit the fixed prefix → corrupt or
-        // truncated; bail rather than erroring so callers preserve any
-        // earlier good records.
+    // every record body starts with at least kind(1) + unix_micros(8); a
+    // shorter prefix is either truncation or corruption — bail without
+    // erroring so callers preserve any earlier good records.
+    if rec_len < 1 + 8 {
         return Ok(None);
     }
     let mut body = vec![0u8; rec_len];
@@ -229,38 +299,51 @@ pub fn read_record<R: std::io::Read>(input: &mut R) -> Result<Option<Record>, Re
         }
         return Err(ReadError::Io(e));
     }
-    let unix_micros = u64::from_le_bytes(body[0..8].try_into().unwrap());
-    let side = match body[8] {
-        0 => Side::Source,
-        1 => Side::Destination,
-        x => return Err(ReadError::BadSide(x)),
-    };
-    let op = match body[9] {
-        0 => MetadataOp::Stat,
-        1 => MetadataOp::ReadLink,
-        2 => MetadataOp::MkDir,
-        3 => MetadataOp::RmDir,
-        4 => MetadataOp::Unlink,
-        5 => MetadataOp::HardLink,
-        6 => MetadataOp::Symlink,
-        7 => MetadataOp::Chmod,
-        8 => MetadataOp::OpenCreate,
-        x => return Err(ReadError::BadOp(x)),
-    };
-    let samples_count = u64::from_le_bytes(body[10..18].try_into().unwrap());
-    let blob = &body[18..];
-    let mut deserializer = hdrhistogram::serialization::Deserializer::new();
-    let mut blob_cursor = std::io::Cursor::new(blob);
-    let histogram: hdrhistogram::Histogram<u64> = deserializer
-        .deserialize(&mut blob_cursor)
-        .map_err(|e| ReadError::Hdr(format!("{e:?}")))?;
-    Ok(Some(Record {
-        unix_micros,
-        side,
-        op,
-        samples_count,
-        histogram,
-    }))
+    let kind = body[0];
+    let unix_micros = u64::from_le_bytes(body[1..9].try_into().unwrap());
+    match kind {
+        k if k == RecordKind::Histogram as u8 => {
+            if rec_len < HISTOGRAM_RECORD_FIXED_BYTES {
+                return Ok(None);
+            }
+            let side = match body[9] {
+                0 => Side::Source,
+                1 => Side::Destination,
+                x => return Err(ReadError::BadSide(x)),
+            };
+            let op = match body[10] {
+                0 => MetadataOp::Stat,
+                1 => MetadataOp::ReadLink,
+                2 => MetadataOp::MkDir,
+                3 => MetadataOp::RmDir,
+                4 => MetadataOp::Unlink,
+                5 => MetadataOp::HardLink,
+                6 => MetadataOp::Symlink,
+                7 => MetadataOp::Chmod,
+                8 => MetadataOp::OpenCreate,
+                x => return Err(ReadError::BadOp(x)),
+            };
+            let samples_count = u64::from_le_bytes(body[11..19].try_into().unwrap());
+            let blob = &body[HISTOGRAM_RECORD_FIXED_BYTES..];
+            let mut deserializer = hdrhistogram::serialization::Deserializer::new();
+            let mut blob_cursor = std::io::Cursor::new(blob);
+            let histogram: hdrhistogram::Histogram<u64> = deserializer
+                .deserialize(&mut blob_cursor)
+                .map_err(|e| ReadError::Hdr(format!("{e:?}")))?;
+            Ok(Some(Record::Histogram(HistogramRecord {
+                unix_micros,
+                side,
+                op,
+                samples_count,
+                histogram,
+            })))
+        }
+        k if k == RecordKind::Progress as u8 => {
+            let json = body[PROGRESS_RECORD_FIXED_BYTES..].to_vec();
+            Ok(Some(Record::Progress(ProgressRecord { unix_micros, json })))
+        }
+        x => Err(ReadError::BadRecordKind(x)),
+    }
 }
 
 #[cfg(test)]
@@ -269,7 +352,7 @@ mod tests {
 
     fn sample_header() -> LogHeader {
         LogHeader {
-            format_version: 1,
+            format_version: FORMAT_VERSION,
             tool: "rcp".to_string(),
             tool_version: "0.32.0".to_string(),
             hostname: "test-host".to_string(),
@@ -311,6 +394,20 @@ mod tests {
         }
     }
 
+    fn unwrap_histogram(record: Record) -> HistogramRecord {
+        match record {
+            Record::Histogram(h) => h,
+            Record::Progress(_) => panic!("expected Histogram, got Progress"),
+        }
+    }
+
+    fn unwrap_progress(record: Record) -> ProgressRecord {
+        match record {
+            Record::Histogram(_) => panic!("expected Progress, got Histogram"),
+            Record::Progress(p) => p,
+        }
+    }
+
     #[test]
     fn header_serde_roundtrip() {
         let h = sample_header();
@@ -325,7 +422,7 @@ mod tests {
         // break older readers. serde's default is to error on unknown
         // fields; we explicitly need the lenient behavior.
         let json = r#"{
-            "format_version": 1,
+            "format_version": 2,
             "tool": "rcp",
             "tool_version": "0.32.0",
             "hostname": "h",
@@ -349,20 +446,18 @@ mod tests {
             "extra": { "future_key": 42 }
         }"#;
         let parsed: LogHeader = serde_json::from_str(json).expect("must tolerate unknown keys");
-        assert_eq!(parsed.format_version, 1);
+        assert_eq!(parsed.format_version, FORMAT_VERSION);
     }
 
     #[test]
-    fn write_and_read_file_with_two_records_roundtrips() {
-        // Build a small file: header + two records + truncate. Read it back;
-        // both records present, both decode cleanly.
+    fn write_and_read_file_with_two_histogram_records_roundtrips() {
         let mut buf: Vec<u8> = Vec::new();
         let header = sample_header();
         write_file_header(&mut buf, &header).unwrap();
         let mut h1 = hdrhistogram::Histogram::<u64>::new_with_bounds(1, 1_000_000, 3).unwrap();
         h1.record(100).unwrap();
         h1.record(200).unwrap();
-        write_record(
+        write_histogram_record(
             &mut buf,
             1_700_000_000_500_000,
             Side::Source,
@@ -372,7 +467,7 @@ mod tests {
         .unwrap();
         let mut h2 = hdrhistogram::Histogram::<u64>::new_with_bounds(1, 1_000_000, 3).unwrap();
         h2.record(300).unwrap();
-        write_record(
+        write_histogram_record(
             &mut buf,
             1_700_000_001_500_000,
             Side::Destination,
@@ -384,17 +479,79 @@ mod tests {
         let mut cursor = std::io::Cursor::new(&buf);
         let parsed_header = read_file_header(&mut cursor).unwrap();
         assert_eq!(parsed_header, header);
-        let r1 = read_record(&mut cursor).unwrap().expect("first record");
+        let r1 = unwrap_histogram(read_record(&mut cursor).unwrap().expect("first record"));
         assert_eq!(r1.unix_micros, 1_700_000_000_500_000);
         assert_eq!(r1.side, Side::Source);
         assert_eq!(r1.op, MetadataOp::Stat);
         assert_eq!(r1.samples_count, 2);
-        let r2 = read_record(&mut cursor).unwrap().expect("second record");
+        let r2 = unwrap_histogram(read_record(&mut cursor).unwrap().expect("second record"));
         assert_eq!(r2.side, Side::Destination);
         assert_eq!(r2.op, MetadataOp::MkDir);
         assert_eq!(r2.samples_count, 1);
         // EOF after last record returns Ok(None).
         assert!(read_record(&mut cursor).unwrap().is_none());
+    }
+
+    #[test]
+    fn write_and_read_progress_record_roundtrips() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_file_header(&mut buf, &sample_header()).unwrap();
+        let payload = br#"{"ops_started":3,"ops_finished":2,"bytes_copied":1024}"#;
+        write_progress_record(&mut buf, 1_700_000_002_000_000, payload).unwrap();
+
+        let mut cursor = std::io::Cursor::new(&buf);
+        let _ = read_file_header(&mut cursor).unwrap();
+        let rec = unwrap_progress(read_record(&mut cursor).unwrap().expect("progress record"));
+        assert_eq!(rec.unix_micros, 1_700_000_002_000_000);
+        assert_eq!(rec.json, payload);
+        assert!(read_record(&mut cursor).unwrap().is_none());
+    }
+
+    #[test]
+    fn mixed_record_stream_preserves_order() {
+        // Interleave histogram + progress + histogram records and verify
+        // that read_record returns them in write order with the right
+        // variants. This is the offline-correlation contract: each
+        // record's timestamp + variant lets a reader reconstruct what
+        // was happening at any point in the run.
+        let mut buf: Vec<u8> = Vec::new();
+        write_file_header(&mut buf, &sample_header()).unwrap();
+        let mut h = hdrhistogram::Histogram::<u64>::new_with_bounds(1, 1_000_000, 3).unwrap();
+        h.record(50).unwrap();
+        write_histogram_record(&mut buf, 10, Side::Source, MetadataOp::Stat, &h).unwrap();
+        write_progress_record(&mut buf, 20, br#"{"files_copied":7}"#).unwrap();
+        write_histogram_record(&mut buf, 30, Side::Destination, MetadataOp::MkDir, &h).unwrap();
+
+        let mut cursor = std::io::Cursor::new(&buf);
+        let _ = read_file_header(&mut cursor).unwrap();
+        let r1 = unwrap_histogram(read_record(&mut cursor).unwrap().unwrap());
+        assert_eq!(r1.unix_micros, 10);
+        assert_eq!(r1.side, Side::Source);
+        let r2 = unwrap_progress(read_record(&mut cursor).unwrap().unwrap());
+        assert_eq!(r2.unix_micros, 20);
+        assert_eq!(r2.json, br#"{"files_copied":7}"#);
+        let r3 = unwrap_histogram(read_record(&mut cursor).unwrap().unwrap());
+        assert_eq!(r3.unix_micros, 30);
+        assert_eq!(r3.side, Side::Destination);
+        assert!(read_record(&mut cursor).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_record_rejects_unknown_kind() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_file_header(&mut buf, &sample_header()).unwrap();
+        // hand-craft a record with kind byte 99
+        let body: [u8; 9] = [99, 1, 0, 0, 0, 0, 0, 0, 0]; // kind=99, ts=1
+        let rec_len = u32::try_from(body.len()).unwrap();
+        buf.extend_from_slice(&rec_len.to_le_bytes());
+        buf.extend_from_slice(&body);
+        let mut cursor = std::io::Cursor::new(&buf);
+        let _ = read_file_header(&mut cursor).unwrap();
+        let err = read_record(&mut cursor).unwrap_err();
+        assert!(
+            matches!(err, ReadError::BadRecordKind(99)),
+            "expected BadRecordKind(99), got: {err:?}",
+        );
     }
 
     #[test]
@@ -407,7 +564,7 @@ mod tests {
         write_file_header(&mut buf, &header).unwrap();
         let mut h = hdrhistogram::Histogram::<u64>::new_with_bounds(1, 1_000_000, 3).unwrap();
         h.record(100).unwrap();
-        write_record(&mut buf, 0, Side::Source, MetadataOp::Stat, &h).unwrap();
+        write_histogram_record(&mut buf, 0, Side::Source, MetadataOp::Stat, &h).unwrap();
         // Truncate: drop the last 5 bytes.
         buf.truncate(buf.len() - 5);
         let mut cursor = std::io::Cursor::new(&buf);
@@ -426,13 +583,24 @@ mod tests {
     }
 
     #[test]
+    fn read_file_header_rejects_v1_magic() {
+        // Regression: the V1 magic must not be silently accepted now
+        // that we've bumped to V2 — record layouts differ.
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(b"RCP-AUTOMETA-HIST-V1\n");
+        let mut cursor = std::io::Cursor::new(&buf);
+        let err = read_file_header(&mut cursor).unwrap_err();
+        assert!(matches!(err, ReadError::BadMagic(_)), "got: {err:?}");
+    }
+
+    #[test]
     fn read_file_header_rejects_excessive_length() {
         let mut buf: Vec<u8> = Vec::new();
         buf.extend_from_slice(MAGIC);
         // pretend the header is 100 MiB
         buf.extend_from_slice(&(100u32 * 1024 * 1024).to_le_bytes());
         // append a few bytes of "header" so the read doesn't simply EOF
-        buf.extend_from_slice(b"{ \"format_version\": 1 }");
+        buf.extend_from_slice(b"{ \"format_version\": 2 }");
         let mut cursor = std::io::Cursor::new(&buf);
         let err = read_file_header(&mut cursor).unwrap_err();
         assert!(

--- a/congestion/tests/format_roundtrip.rs
+++ b/congestion/tests/format_roundtrip.rs
@@ -1,19 +1,23 @@
-//! Proptest coverage for the histogram log file format:
+//! Proptest coverage for the log file format:
 //! 1. Random sequences of records roundtrip exactly through write+read.
 //! 2. Splitting a sample sequence into N snapshots and merging the per-snapshot
 //!    histograms equals recording all samples into a single histogram (modulo
 //!    HDR sig-fig rounding, which is exact for repeated values and bounded
 //!    for distinct ones).
+//! 3. Mixed sequences of Histogram and Progress records preserve order
+//!    and payloads, with Progress JSON bytes returned verbatim.
 //!
 //! Property (1) is the durability contract: a process that survives long
 //! enough to flush at least one full record can have its log read back
 //! losslessly. Property (2) is the offline-reconstruction contract: the
 //! reader can recover any time window's distribution by merging the
-//! records that fall inside it.
+//! records that fall inside it. Property (3) is the offline-correlation
+//! contract: progress and histogram records share one time-ordered
+//! stream so readers can align throughput and latency at any tick.
 
 use congestion::format::{
-    AutoMetaSnapshot, HdrSnapshot, LogHeader, UnitLabel, read_file_header, read_record,
-    write_file_header, write_record,
+    AutoMetaSnapshot, FORMAT_VERSION, HdrSnapshot, LogHeader, Record, UnitLabel, read_file_header,
+    read_record, write_file_header, write_histogram_record, write_progress_record,
 };
 use congestion::{HistogramAccumulator, MetadataOp, Side};
 use proptest::prelude::*;
@@ -24,7 +28,7 @@ fn arb_latency_micros() -> impl Strategy<Value = u64> {
 
 fn fixed_header() -> LogHeader {
     LogHeader {
-        format_version: 1,
+        format_version: FORMAT_VERSION,
         tool: "test".into(),
         tool_version: "0.0.0".into(),
         hostname: "host".into(),
@@ -77,15 +81,78 @@ proptest! {
             }
             let snap = acc.snapshot_and_reset();
             expected_counts.push(snap.len());
-            write_record(&mut buf, i as u64, Side::Source, MetadataOp::Stat, &snap).unwrap();
+            write_histogram_record(&mut buf, i as u64, Side::Source, MetadataOp::Stat, &snap)
+                .unwrap();
         }
         let mut cursor = std::io::Cursor::new(&buf);
         let _h = read_file_header(&mut cursor).unwrap();
         let mut got_counts: Vec<u64> = Vec::new();
         while let Some(rec) = read_record(&mut cursor).unwrap() {
-            got_counts.push(rec.samples_count);
+            match rec {
+                Record::Histogram(h) => got_counts.push(h.samples_count),
+                Record::Progress(_) => prop_assert!(false, "no progress records expected"),
+            }
         }
         prop_assert_eq!(got_counts, expected_counts);
+    }
+
+    #[test]
+    fn mixed_histogram_and_progress_records_preserve_order(
+        // a sequence of write actions: true = histogram, false = progress
+        // each carrying a distinct timestamp (the vector index) plus a
+        // small payload — readers must return them in write order and
+        // forward progress JSON byte-for-byte.
+        actions in proptest::collection::vec(any::<bool>(), 1..16),
+    ) {
+        let mut buf: Vec<u8> = Vec::new();
+        write_file_header(&mut buf, &fixed_header()).unwrap();
+
+        // Pre-build a small reference histogram once; the property here
+        // is record kind ordering, not the histogram payload.
+        let mut h = hdrhistogram::Histogram::<u64>::new_with_bounds(1, 1_000_000, 3).unwrap();
+        h.record(42).unwrap();
+
+        // Each progress record carries its (synthetic) timestamp as JSON
+        // so we can verify byte-exact roundtrip in the reader.
+        let mut expected_kinds: Vec<bool> = Vec::with_capacity(actions.len());
+        let mut expected_timestamps: Vec<u64> = Vec::with_capacity(actions.len());
+        let mut expected_payloads: Vec<Vec<u8>> = Vec::with_capacity(actions.len());
+        for (i, &is_histogram) in actions.iter().enumerate() {
+            let ts = i as u64;
+            expected_kinds.push(is_histogram);
+            expected_timestamps.push(ts);
+            if is_histogram {
+                expected_payloads.push(Vec::new());
+                write_histogram_record(&mut buf, ts, Side::Source, MetadataOp::Stat, &h).unwrap();
+            } else {
+                let payload = format!(r#"{{"tick":{ts}}}"#).into_bytes();
+                expected_payloads.push(payload.clone());
+                write_progress_record(&mut buf, ts, &payload).unwrap();
+            }
+        }
+
+        let mut cursor = std::io::Cursor::new(&buf);
+        let _h = read_file_header(&mut cursor).unwrap();
+        let mut got_kinds: Vec<bool> = Vec::new();
+        let mut got_timestamps: Vec<u64> = Vec::new();
+        let mut got_payloads: Vec<Vec<u8>> = Vec::new();
+        while let Some(rec) = read_record(&mut cursor).unwrap() {
+            match rec {
+                Record::Histogram(h) => {
+                    got_kinds.push(true);
+                    got_timestamps.push(h.unix_micros);
+                    got_payloads.push(Vec::new());
+                }
+                Record::Progress(p) => {
+                    got_kinds.push(false);
+                    got_timestamps.push(p.unix_micros);
+                    got_payloads.push(p.json);
+                }
+            }
+        }
+        prop_assert_eq!(got_kinds, expected_kinds);
+        prop_assert_eq!(got_timestamps, expected_timestamps);
+        prop_assert_eq!(got_payloads, expected_payloads);
     }
 
     #[test]

--- a/docs/congestion_control.md
+++ b/docs/congestion_control.md
@@ -666,11 +666,13 @@ independently toggleable:
   monotonic within an interval rather than shrinking mid-fill.
 - **`--auto-meta-histogram-log <PATH>`** writes a binary record
   stream to `<PATH>` containing the same snapshots the panel reads.
-  Each record is a length-prefixed envelope around a standard
-  `hdrhistogram` v2 binary blob, so existing HDR tooling can read
-  the body after the 18-byte fixed prefix. If `<PATH>` already
-  exists it is truncated at the start of the run — rename or move
-  prior logs you want to keep.
+  Each record is a length-prefixed envelope tagged with a kind byte;
+  histogram records wrap a standard `hdrhistogram` v2 binary blob,
+  and progress records wrap a JSON `SerializableProgress` payload —
+  the same struct the progress bar consumes — so latency
+  distributions and throughput counters share one time-ordered
+  stream. If `<PATH>` already exists it is truncated at the start
+  of the run — rename or move prior logs you want to keep.
 - **`--auto-meta-histogram-interval <DUR>`** controls both the panel
   refresh and the per-record snapshot cadence. Range `[100ms, 60s]`,
   default `1s`.
@@ -684,36 +686,48 @@ no accumulator construction, no extra task, no extra hot-path lock.
 
 #### Log file layout
 
-One log file per run, written in a fixed framing:
+One log file per run, written in a fixed framing. The file carries two
+kinds of records — latency histograms and progress snapshots —
+interleaved in time order so readers can correlate distribution shape
+with the throughput / files-copied counters the progress bar shows:
 
 ```
-"RCP-AUTOMETA-HIST-V1\n"      21 ASCII bytes (magic, includes \n)
+"RCP-AUTOMETA-HIST-V2\n"      21 ASCII bytes (magic, includes \n)
 <hdr_len: u32 LE>             byte length of the JSON header
 <hdr_bytes: hdr_len bytes>    JSON document, UTF-8
 
 loop {                        zero or more records, time-ordered
   <rec_len: u32 LE>           byte length of the rest of the record
-  <unix_micros: u64 LE>       Unix epoch microseconds at snapshot end
-  <side: u8>                  0 = Source, 1 = Destination
-  <op: u8>                    MetadataOp discriminant
-  <samples_count: u64 LE>     count of samples in this snapshot
-  <hdr_blob: rec_len - 18>    HDR v2 serialized histogram
+  <kind: u8>                  0 = Histogram, 1 = Progress
+  if kind == 0:               Histogram record body
+    <unix_micros: u64 LE>     Unix epoch microseconds at snapshot end
+    <side: u8>                0 = Source, 1 = Destination
+    <op: u8>                  MetadataOp discriminant
+    <samples_count: u64 LE>   count of samples in this snapshot
+    <hdr_blob: remaining>     HDR v2 serialized histogram
+  if kind == 1:               Progress record body
+    <unix_micros: u64 LE>     Unix epoch microseconds at tick end
+    <json_bytes: remaining>   SerializableProgress as UTF-8 JSON
 }
 ```
 
 All multi-byte integers are little-endian. The 4-byte length prefix
-plus 18-byte fixed-field section let a reader scan records without
-parsing the HDR blob. Empty snapshots (`samples_count == 0`) are
-omitted — most (side, op) slots are inactive on any real workload,
-and absence of records in a time range means "no samples", never
-"data lost".
+plus single-byte `kind` plus per-variant fixed prefix let a reader
+scan records without parsing the variable-length payload. Empty
+histogram snapshots (`samples_count == 0`) are omitted — most (side,
+op) slots are inactive on any real workload, and absence of records
+in a time range means "no samples", never "data lost". Progress
+records are emitted once per tick, including at run start (the
+counters are monotonic and zero is a meaningful state).
 
 The writer flushes after every record; if the process is killed
 mid-record the tail can be partial, and readers detect that via the
-length prefix and stop cleanly. Format version 1; readers should
-check the magic exactly and reject unknown versions. Writers may add
-new top-level keys to the JSON header — readers ignore unknown keys
-to stay forward-compatible.
+length prefix and stop cleanly. Format version 2 — record framing was
+extended from v1 (single record kind, no kind byte) to carry the
+`kind` discriminant and the Progress variant. Readers should check
+the magic exactly and reject unknown versions. Writers may add new
+top-level keys to the JSON header — readers ignore unknown keys to
+stay forward-compatible.
 
 #### Header schema
 
@@ -721,7 +735,7 @@ The JSON header captures everything needed to interpret the records
 in isolation. Durations are encoded as microseconds in
 `*_micros`-suffixed fields:
 
-- `format_version` — currently `1`.
+- `format_version` — currently `2`.
 - `tool`, `tool_version`, `hostname`, `pid`, `start_unix_micros` —
   provenance: which process produced this log, on which host, when.
 - `snapshot_interval_micros` — record cadence.
@@ -735,14 +749,44 @@ in isolation. Durations are encoded as microseconds in
 - `unit_labels` — enumeration of all 18 (side, op) pairs paired with
   their human-readable label (`src-stat`, `dst-stat`, `mkdir`, …).
 
+#### Progress record payload
+
+Progress records carry a UTF-8 JSON encoding of the same
+`SerializableProgress` struct sent over the rcpd → master tracing
+channel and rendered by the progress bar. Fields include:
+
+- `ops_started`, `ops_finished` — in-flight and completed op counts.
+- `bytes_copied`, `bytes_removed` — byte-level throughput counters.
+- `files_copied`, `symlinks_created`, `directories_created`,
+  `hard_links_created` — per-kind creation tallies.
+- `files_unchanged`, `symlinks_unchanged`, `directories_unchanged`,
+  `hard_links_unchanged` — unchanged tallies for incremental modes.
+- `files_removed`, `symlinks_removed`, `directories_removed` — removal
+  tallies for `rrm` and overwrite modes.
+- `files_skipped`, `symlinks_skipped`, `directories_skipped`,
+  `specials_skipped` — skip tallies.
+- `current_time` — RFC 3339 / `SystemTime` snapshot at write time
+  (redundant with the record's `unix_micros`; kept for parity with the
+  in-process wire encoding).
+
+Readers should treat the JSON payload as forward-compatible: future
+versions may add fields. Use `serde(deny_unknown_fields)` only on the
+writer side of your tool; readers should ignore unknown keys.
+
 #### Reconstructing any window
 
 To recover the distribution over `[T - W, T]` for any window `W`:
-filter records by their `unix_micros` and the `(side, op)` of
-interest, deserialize each HDR blob with a v2 deserializer, and fold
-them all into one histogram via the merge operation. That's exactly
-how the controller's own baseline (10s) and current (1s) windows are
-recovered offline from a single record stream.
+filter Histogram records by their `unix_micros` and the `(side, op)`
+of interest, deserialize each HDR blob with a v2 deserializer, and
+fold them all into one histogram via the merge operation. That's
+exactly how the controller's own baseline (10s) and current (1s)
+windows are recovered offline from a single record stream.
+
+To plot throughput-vs-latency-percentile, walk the same time-ordered
+stream and join each Progress record with the histogram(s) that
+share its tick: take the Progress record's `ops_finished` delta
+since the prior tick (giving ops/s) and the merged histogram's
+chosen percentile over the same window.
 
 **Scoping in remote copy.**
 


### PR DESCRIPTION
## Summary

- Interleaves per-tick `SerializableProgress` JSON snapshots into the auto-meta histogram log alongside the existing per-(side, op) HDR histogram records, so offline tools can correlate latency distributions with the same throughput / files-copied counters the progress bar shows.
- Format bumped from v1 → v2 to add a per-record `kind` byte and the Progress variant. Magic is now `RCP-AUTOMETA-HIST-V2\n`; the JSON header shape is unchanged.
- `histogram_logger::LoggerConfig` gains an optional `ProgressSource` closure. The logger calls it once per tick when a log file is open and appends one Progress record carrying the JSON bytes. Always emitted — counters are monotonic and zero is a meaningful start state.

## Test plan

- [x] `just ci` — lint + doc + debug + release + Docker (48/48 passed)
- [x] Format unit tests: progress roundtrip, mixed histogram+progress order, unknown record kind rejection, V1 magic rejection
- [x] Proptest: `mixed_histogram_and_progress_records_preserve_order` covers kind ordering, timestamps, and byte-exact JSON roundtrip over random write sequences
- [x] Logger unit test: progress record emitted per tick when source is set
- [x] e2e test: at least one progress record present in real `rcp` run, parses cleanly as `SerializableProgress`
- [ ] Eyeball a captured `.hdr` file from a real local copy to confirm both record kinds interleave as expected