### PR TITLE
Add rchm: fast recursive chmod/chgrp/chown for large filesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `rchm`: a fast recursive chmod/chgrp/chown tool for large filesets (a `dchmod` replacement), with a per-type `--mode`/`--group`/`--owner` DSL, no-op skipping, pre-order directory changes by default (so `--mode d:u+rwx` can repair an unreadable directory; `--defer-dir-changes` applies directories after their contents), progress, filtering, and throttling.
+
 ## [0.32.0] - 2026-05-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1874,6 +1874,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcp-tools-rchm"
+version = "0.33.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "clap",
+ "humantime",
+ "predicates",
+ "rcp-tools-common",
+ "tempfile",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "rcp-tools-rcmp"
 version = "0.33.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "congestion",
   "filegen",
   "rcmp",
+  "rchm",
   "rcp",
   "remote",
   "rlink",

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This repo contains tools to efficiently copy, remove and link large filesets, bo
 
 - `rrm` is for removing large filesets.
 
+- `rchm` is for recursively changing permissions and ownership of large filesets; a fast replacement for `dchmod`(3).
+
 - `rlink` allows hard-linking filesets with optional update path; typically used for hard-linking datasets with a delta.
 
 - `rcmp` tool is for comparing filesets.
@@ -35,6 +37,7 @@ API documentation for the command-line tools is available on docs.rs:
 
 - [rcp-tools-rcp](https://docs.rs/rcp-tools-rcp) - File copying tool (rcp & rcpd)
 - [rcp-tools-rrm](https://docs.rs/rcp-tools-rrm) - File removal tool
+- [rcp-tools-rchm](https://docs.rs/rcp-tools-rchm) - Recursive chmod/chgrp/chown tool
 - [rcp-tools-rlink](https://docs.rs/rcp-tools-rlink) - Hard-linking tool
 - [rcp-tools-rcmp](https://docs.rs/rcp-tools-rcmp) - File comparison tool
 - [rcp-tools-filegen](https://docs.rs/rcp-tools-filegen) - Test file generation utility
@@ -103,6 +106,37 @@ Remove a path recursively:
 ```fish
 > rrm <bar> --progress --summary
 ```
+
+Recursively change group and permissions:
+```fish
+# join group 'data'; add group rwx + setgid to dirs, group rw to files
+> rchm --group data --mode "f:g+rw d:g+rwxs" <path> --progress --summary
+
+# dchmod-style: one mode for everything (bare value, no type prefix)
+> rchm --mode g+rwX <path> --progress
+```
+
+The `--group` and `--owner` options take a per-type DSL: a bare value applies to all
+entries (files, directories, and symlinks via `lchown`); `f:`/`d:`/`l:` prefixes target
+one type. `--mode` uses the same DSL but covers only files and directories (a bare value
+sets both) — symlink mode bits aren't settable on Linux, so `l:` is rejected for `--mode`.
+
+**Compatibility with `chmod`/`chown`/`chgrp`:** mode expressions are a subset of
+`chmod` (`[ugoa][+-=][rwxXst]`, octal, and conditional `X`), omitting who-copy
+references like `g=u`. Omitted-who clauses ignore umask (deliberate for a bulk
+tool). For ordinary operands `rchm` does not dereference symlinks (like `-h`): it
+applies group/owner to the symlink itself via `lchown` and never changes symlink mode
+bits. This is not a guarantee under concurrent path replacement when rchm runs with
+more privilege than an actor who can modify the tree being traversed (e.g. under
+`sudo` over attacker-writable directories) — the same path-based-operation limitation
+as the other rcp tools; see [docs/tocttou.md](docs/tocttou.md). `mtime` is preserved;
+`ctime` necessarily changes (the kernel stamps it on any metadata change) and cannot
+be preserved.
+
+Directories are changed **before** their contents by default (like `chmod -R`), so
+`--mode d:u+rwx` can repair an unreadable directory. Pass `--defer-dir-changes` to
+change directories **after** their contents — needed when recursively removing your
+own read/execute permission from directories, where the default would lock itself out.
 
 Hard-link contents of one path to another:
 ```fish
@@ -668,3 +702,4 @@ References
 ==========
 1) https://mpifileutils.readthedocs.io/en/v0.11.1/dsync.1.html
 2) https://github.com/wtsi-ssg/pcp
+3) https://mpifileutils.readthedocs.io/en/v0.11/dchmod.1.html

--- a/common/src/chmod.rs
+++ b/common/src/chmod.rs
@@ -1,0 +1,1183 @@
+//! Recursive permission/ownership changes (chmod/chgrp/chown) over a fileset.
+//!
+//! The public entry point is [`chmod`]; it mirrors [`crate::rm()`] but transforms
+//! metadata in place (from a per-type rule) instead of removing entries.
+use crate::filter::TimeFilter;
+use crate::progress::Progress;
+use crate::walk::{self, EntryKind};
+use anyhow::{Context, anyhow};
+use async_recursion::async_recursion;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use tracing::instrument;
+
+/// Error type for chmod operations. See [`crate::error::OperationError`].
+pub type Error = crate::error::OperationError<Summary>;
+
+/// Which user/group id (if any) to apply to each entry type. `None` leaves that
+/// type unchanged for this operation.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct OwnerProgram {
+    pub file: Option<u32>,
+    pub dir: Option<u32>,
+    pub symlink: Option<u32>,
+}
+
+impl OwnerProgram {
+    #[must_use]
+    pub fn for_kind(&self, kind: EntryKind) -> Option<u32> {
+        match kind {
+            EntryKind::Dir => self.dir,
+            EntryKind::Symlink => self.symlink,
+            EntryKind::File | EntryKind::Special => self.file,
+        }
+    }
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.file.is_none() && self.dir.is_none() && self.symlink.is_none()
+    }
+}
+
+/// A parsed `chmod` mode expression: either a symbolic program (applied relative
+/// to the current mode) or an absolute octal value (12-bit).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ModeSpec {
+    Symbolic(Vec<SymbolicClause>),
+    Octal(u32),
+}
+
+/// One `[ugoa][+-=][rwxXst]` clause. `who`/`perms` are bitmasks (see `WHO_*` /
+/// `PERM_*`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SymbolicClause {
+    pub who: u8,
+    pub op: ModeOp,
+    pub perms: u8,
+}
+
+/// The operator in a symbolic mode clause: add, remove, or set permissions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ModeOp {
+    Add,
+    Remove,
+    Set,
+}
+
+pub(crate) const WHO_U: u8 = 0b001;
+pub(crate) const WHO_G: u8 = 0b010;
+pub(crate) const WHO_O: u8 = 0b100;
+pub(crate) const WHO_A: u8 = WHO_U | WHO_G | WHO_O;
+pub(crate) const PERM_R: u8 = 0b00_0001;
+pub(crate) const PERM_W: u8 = 0b00_0010;
+pub(crate) const PERM_X: u8 = 0b00_0100;
+pub(crate) const PERM_BIGX: u8 = 0b00_1000;
+pub(crate) const PERM_S: u8 = 0b01_0000;
+pub(crate) const PERM_T: u8 = 0b10_0000;
+
+/// Per-type mode rules. Symlinks are never included (mode bits aren't settable
+/// on Linux symlinks).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ModeProgram {
+    pub file: Option<ModeSpec>,
+    pub dir: Option<ModeSpec>,
+}
+
+impl ModeProgram {
+    #[must_use]
+    pub fn for_kind(&self, kind: EntryKind) -> Option<&ModeSpec> {
+        match kind {
+            EntryKind::Dir => self.dir.as_ref(),
+            EntryKind::Symlink => None,
+            EntryKind::File | EntryKind::Special => self.file.as_ref(),
+        }
+    }
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.file.is_none() && self.dir.is_none()
+    }
+}
+
+/// Configuration for a recursive chmod/chgrp/chown run.
+#[derive(Clone, Debug)]
+pub struct Settings {
+    pub mode: ModeProgram,
+    pub owner: OwnerProgram,
+    pub group: OwnerProgram,
+    pub fail_early: bool,
+    /// Apply directory mode/owner changes after their contents (post-order) instead of
+    /// before (the default). Needed when recursively removing the owner's own traversal
+    /// permission from directories.
+    pub defer_dir_changes: bool,
+    pub filter: Option<crate::filter::FilterSettings>,
+    pub time_filter: Option<TimeFilter>,
+    pub dry_run: Option<crate::config::DryRunMode>,
+}
+
+#[derive(Copy, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub struct Summary {
+    pub files_changed: usize,
+    pub symlinks_changed: usize,
+    pub directories_changed: usize,
+    pub files_unchanged: usize,
+    pub symlinks_unchanged: usize,
+    pub directories_unchanged: usize,
+    pub files_skipped: usize,
+    pub symlinks_skipped: usize,
+    pub directories_skipped: usize,
+}
+
+impl std::ops::Add for Summary {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        Self {
+            files_changed: self.files_changed + other.files_changed,
+            symlinks_changed: self.symlinks_changed + other.symlinks_changed,
+            directories_changed: self.directories_changed + other.directories_changed,
+            files_unchanged: self.files_unchanged + other.files_unchanged,
+            symlinks_unchanged: self.symlinks_unchanged + other.symlinks_unchanged,
+            directories_unchanged: self.directories_unchanged + other.directories_unchanged,
+            files_skipped: self.files_skipped + other.files_skipped,
+            symlinks_skipped: self.symlinks_skipped + other.symlinks_skipped,
+            directories_skipped: self.directories_skipped + other.directories_skipped,
+        }
+    }
+}
+
+impl std::fmt::Display for Summary {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "files changed: {}\n\
+            symlinks changed: {}\n\
+            directories changed: {}\n\
+            files unchanged: {}\n\
+            symlinks unchanged: {}\n\
+            directories unchanged: {}\n\
+            files skipped: {}\n\
+            symlinks skipped: {}\n\
+            directories skipped: {}\n",
+            self.files_changed,
+            self.symlinks_changed,
+            self.directories_changed,
+            self.files_unchanged,
+            self.symlinks_unchanged,
+            self.directories_unchanged,
+            self.files_skipped,
+            self.symlinks_skipped,
+            self.directories_skipped
+        )
+    }
+}
+
+/// Whether a DSL id token refers to a user or group.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IdKind {
+    User,
+    Group,
+}
+
+/// Resolve a DSL id token to a numeric id. All-numeric tokens are used directly;
+/// otherwise the token is looked up as a user/group name (matching `chown`/`chgrp`).
+fn resolve_id(token: &str, kind: IdKind) -> anyhow::Result<u32> {
+    if let Ok(n) = token.parse::<u32>() {
+        return Ok(n);
+    }
+    match kind {
+        IdKind::User => nix::unistd::User::from_name(token)
+            .with_context(|| format!("looking up user {token:?}"))?
+            .map(|u| u.uid.as_raw())
+            .ok_or_else(|| anyhow!("unknown user: {token}")),
+        IdKind::Group => nix::unistd::Group::from_name(token)
+            .with_context(|| format!("looking up group {token:?}"))?
+            .map(|g| g.gid.as_raw())
+            .ok_or_else(|| anyhow!("unknown group: {token}")),
+    }
+}
+
+/// Parse a `--group`/`--owner` DSL string. A bare token is the default for all
+/// types; `f:`/`d:`/`l:` sections override per type.
+pub fn parse_owner_dsl(s: &str, kind: IdKind) -> anyhow::Result<OwnerProgram> {
+    let mut prog = OwnerProgram::default();
+    let mut bare: Option<u32> = None;
+    for clause in s.split_whitespace() {
+        if let Some((ty, rest)) = clause.split_once(':') {
+            let id = resolve_id(rest, kind)?;
+            match ty {
+                "f" | "file" => prog.file = Some(id),
+                "d" | "dir" | "directory" => prog.dir = Some(id),
+                "l" | "link" | "symlink" => prog.symlink = Some(id),
+                _ => return Err(anyhow!("unknown type prefix {ty:?} (expected f:/d:/l:)")),
+            }
+        } else if bare.is_some() {
+            return Err(anyhow!(
+                "multiple bare values in {s:?}; use f:/d:/l: prefixes to set different types"
+            ));
+        } else {
+            bare = Some(resolve_id(clause, kind)?);
+        }
+    }
+    if let Some(b) = bare {
+        prog.file.get_or_insert(b);
+        prog.dir.get_or_insert(b);
+        prog.symlink.get_or_insert(b);
+    }
+    Ok(prog)
+}
+
+/// Apply a mode spec to a current 12-bit mode, returning the new 12-bit mode.
+/// `is_dir` drives the conditional `X` permission.
+#[must_use]
+pub fn apply_mode(current: u32, spec: &ModeSpec, is_dir: bool) -> u32 {
+    match spec {
+        ModeSpec::Octal(m) => m & 0o7777,
+        ModeSpec::Symbolic(clauses) => {
+            let mut mode = current & 0o7777;
+            for clause in clauses {
+                mode = apply_clause(mode, *clause, is_dir);
+            }
+            mode
+        }
+    }
+}
+
+fn apply_clause(current: u32, clause: SymbolicClause, is_dir: bool) -> u32 {
+    let any_exec = current & 0o111 != 0;
+    let exec =
+        (clause.perms & PERM_X != 0) || (clause.perms & PERM_BIGX != 0 && (is_dir || any_exec));
+    let r = clause.perms & PERM_R != 0;
+    let w = clause.perms & PERM_W != 0;
+    let s = clause.perms & PERM_S != 0;
+    let t = clause.perms & PERM_T != 0;
+    let mut value: u32 = 0;
+    if clause.who & WHO_U != 0 {
+        if r {
+            value |= 0o400;
+        }
+        if w {
+            value |= 0o200;
+        }
+        if exec {
+            value |= 0o100;
+        }
+        if s {
+            value |= 0o4000;
+        }
+    }
+    if clause.who & WHO_G != 0 {
+        if r {
+            value |= 0o040;
+        }
+        if w {
+            value |= 0o020;
+        }
+        if exec {
+            value |= 0o010;
+        }
+        if s {
+            value |= 0o2000;
+        }
+    }
+    if clause.who & WHO_O != 0 {
+        if r {
+            value |= 0o004;
+        }
+        if w {
+            value |= 0o002;
+        }
+        if exec {
+            value |= 0o001;
+        }
+    }
+    if t && clause.who & WHO_O != 0 {
+        // sticky (t) responds only to 'o' (and 'a', which includes 'o') — matches chmod
+        value |= 0o1000;
+    }
+    match clause.op {
+        ModeOp::Add => current | value,
+        ModeOp::Remove => current & !value,
+        ModeOp::Set => {
+            let mut clear: u32 = 0;
+            if clause.who & WHO_U != 0 {
+                clear |= 0o4700;
+            }
+            if clause.who & WHO_G != 0 {
+                clear |= 0o2070;
+            }
+            if clause.who & WHO_O != 0 {
+                clear |= 0o1007;
+            }
+            (current & !clear) | value
+        }
+    }
+}
+
+/// Parse one mode token: an octal literal (all octal digits) or a comma-chained
+/// symbolic expression.
+fn parse_mode_token(token: &str) -> anyhow::Result<ModeSpec> {
+    if token.is_empty() {
+        return Err(anyhow!("empty mode"));
+    }
+    if token.bytes().all(|b| b.is_ascii_digit()) {
+        if token.bytes().any(|b| b > b'7') {
+            return Err(anyhow!("invalid octal mode {token:?} (digits must be 0-7)"));
+        }
+        let value = u32::from_str_radix(token, 8)
+            .with_context(|| format!("parsing octal mode {token:?}"))?;
+        if value > 0o7777 {
+            return Err(anyhow!("octal mode {token:?} out of range (max 0o7777)"));
+        }
+        return Ok(ModeSpec::Octal(value));
+    }
+    let clauses = token
+        .split(',')
+        .map(parse_symbolic_clause)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(ModeSpec::Symbolic(clauses))
+}
+
+fn parse_symbolic_clause(clause: &str) -> anyhow::Result<SymbolicClause> {
+    let op_pos = clause
+        .find(['+', '-', '='])
+        .ok_or_else(|| anyhow!("mode clause {clause:?} missing +, - or ="))?;
+    let (who_str, rest) = clause.split_at(op_pos);
+    let op = match &rest[..1] {
+        "+" => ModeOp::Add,
+        "-" => ModeOp::Remove,
+        "=" => ModeOp::Set,
+        _ => unreachable!("find guaranteed one of +-="),
+    };
+    let perms_str = &rest[1..];
+    let mut who = 0u8;
+    for ch in who_str.chars() {
+        who |= match ch {
+            'u' => WHO_U,
+            'g' => WHO_G,
+            'o' => WHO_O,
+            'a' => WHO_A,
+            other => {
+                return Err(anyhow!(
+                    "invalid 'who' {other:?} in {clause:?} (expected u/g/o/a)"
+                ));
+            }
+        };
+    }
+    if who == 0 {
+        who = WHO_A;
+    }
+    let mut perms = 0u8;
+    for ch in perms_str.chars() {
+        perms |= match ch {
+            'r' => PERM_R,
+            'w' => PERM_W,
+            'x' => PERM_X,
+            'X' => PERM_BIGX,
+            's' => PERM_S,
+            't' => PERM_T,
+            other => return Err(anyhow!("invalid permission {other:?} in {clause:?}")),
+        };
+    }
+    Ok(SymbolicClause { who, op, perms })
+}
+
+/// Parse a `--mode` DSL string. A bare token is the default for files+dirs;
+/// `f:`/`d:` sections override per type. `l:` is rejected (symlink mode bits
+/// are not settable on Linux).
+pub fn parse_mode_dsl(s: &str) -> anyhow::Result<ModeProgram> {
+    let mut prog = ModeProgram::default();
+    let mut bare: Option<ModeSpec> = None;
+    for clause in s.split_whitespace() {
+        if let Some((ty, rest)) = clause.split_once(':') {
+            let spec = parse_mode_token(rest)?;
+            match ty {
+                "f" | "file" => prog.file = Some(spec),
+                "d" | "dir" | "directory" => prog.dir = Some(spec),
+                "l" | "link" | "symlink" => {
+                    return Err(anyhow!(
+                        "symlink mode (l:) is not settable on Linux; remove the l: section"
+                    ));
+                }
+                _ => return Err(anyhow!("unknown type prefix {ty:?} (expected f:/d:)")),
+            }
+        } else if bare.is_some() {
+            return Err(anyhow!(
+                "multiple bare mode expressions in {s:?}; chain sub-ops with commas (e.g. g+r,o+w)"
+            ));
+        } else {
+            bare = Some(parse_mode_token(clause)?);
+        }
+    }
+    if let Some(b) = bare {
+        prog.file.get_or_insert(b.clone());
+        prog.dir.get_or_insert(b);
+    }
+    Ok(prog)
+}
+
+/// The concrete syscalls to perform for one entry. `chown` carries the
+/// `(uid, gid)` to pass to `fchownat` (each `None` means "leave unchanged");
+/// `chmod` is the target 12-bit mode. An all-`None` plan is a no-op.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct EntryPlan {
+    pub chown: Option<(Option<u32>, Option<u32>)>,
+    pub chmod: Option<u32>,
+}
+
+impl EntryPlan {
+    pub(crate) fn is_noop(&self) -> bool {
+        self.chown.is_none() && self.chmod.is_none()
+    }
+}
+
+/// Compute the plan for one entry from its current mode/uid/gid. Pure: performs
+/// no I/O. `cur_mode` is the full `st_mode` (only the low 12 bits are used).
+pub(crate) fn compute_plan(
+    cur_mode: u32,
+    cur_uid: u32,
+    cur_gid: u32,
+    kind: EntryKind,
+    settings: &Settings,
+) -> EntryPlan {
+    let cur_mode = cur_mode & 0o7777;
+    let uid_change = settings.owner.for_kind(kind).filter(|&u| u != cur_uid);
+    let gid_change = settings.group.for_kind(kind).filter(|&g| g != cur_gid);
+    let need_chown = uid_change.is_some() || gid_change.is_some();
+    let chown = need_chown.then_some((uid_change, gid_change));
+    let chmod = if kind == EntryKind::Symlink {
+        // symlink mode bits are not settable; never chmod a symlink
+        None
+    } else if let Some(spec) = settings.mode.for_kind(kind) {
+        let desired = apply_mode(cur_mode, spec, kind == EntryKind::Dir);
+        // chmod if the value changes, or a chown would clear setuid/setgid we keep.
+        // 0o6000 = setuid|setgid; fchownat does not clear the sticky bit (0o1000)
+        if desired != cur_mode || (need_chown && desired & 0o6000 != 0) {
+            Some(desired)
+        } else {
+            None
+        }
+    } else if need_chown && cur_mode & 0o6000 != 0 {
+        // no mode rule for this type, but chown clears setuid/setgid -> restore.
+        // 0o6000 = setuid|setgid; fchownat does not clear the sticky bit (0o1000)
+        Some(cur_mode)
+    } else {
+        None
+    };
+    EntryPlan { chown, chmod }
+}
+
+fn inc_changed(prog: &Progress, kind: EntryKind) -> Summary {
+    match kind {
+        EntryKind::Dir => {
+            prog.directories_changed.inc();
+            Summary {
+                directories_changed: 1,
+                ..Default::default()
+            }
+        }
+        EntryKind::Symlink => {
+            prog.symlinks_changed.inc();
+            Summary {
+                symlinks_changed: 1,
+                ..Default::default()
+            }
+        }
+        EntryKind::File | EntryKind::Special => {
+            prog.files_changed.inc();
+            Summary {
+                files_changed: 1,
+                ..Default::default()
+            }
+        }
+    }
+}
+
+fn inc_unchanged(prog: &Progress, kind: EntryKind) -> Summary {
+    match kind {
+        EntryKind::Dir => {
+            prog.directories_unchanged.inc();
+            Summary {
+                directories_unchanged: 1,
+                ..Default::default()
+            }
+        }
+        EntryKind::Symlink => {
+            prog.symlinks_unchanged.inc();
+            Summary {
+                symlinks_unchanged: 1,
+                ..Default::default()
+            }
+        }
+        EntryKind::File | EntryKind::Special => {
+            prog.files_unchanged.inc();
+            Summary {
+                files_unchanged: 1,
+                ..Default::default()
+            }
+        }
+    }
+}
+
+fn skipped_summary_for(kind: EntryKind) -> Summary {
+    match kind {
+        EntryKind::Dir => Summary {
+            directories_skipped: 1,
+            ..Default::default()
+        },
+        EntryKind::Symlink => Summary {
+            symlinks_skipped: 1,
+            ..Default::default()
+        },
+        EntryKind::File | EntryKind::Special => Summary {
+            files_skipped: 1,
+            ..Default::default()
+        },
+    }
+}
+
+/// Human-readable description of what a plan changes, for dry-run output.
+fn describe_change(cur_mode: u32, cur_uid: u32, cur_gid: u32, plan: &EntryPlan) -> String {
+    let mut parts = Vec::new();
+    if let Some(mode) = plan.chmod {
+        if mode == cur_mode & 0o7777 {
+            // chmod re-applied only to restore setuid/setgid that chown clears
+            parts.push(format!("mode {mode:04o} (re-applied after chown)"));
+        } else {
+            parts.push(format!("mode {:04o}->{:04o}", cur_mode & 0o7777, mode));
+        }
+    }
+    if let Some((uid, gid)) = plan.chown {
+        if let Some(uid) = uid {
+            parts.push(format!("owner {cur_uid}->{uid}"));
+        }
+        if let Some(gid) = gid {
+            parts.push(format!("group {cur_gid}->{gid}"));
+        }
+    }
+    parts.join(", ")
+}
+
+async fn apply_plan(path: &std::path::Path, plan: &EntryPlan) -> anyhow::Result<()> {
+    if let Some((uid, gid)) = plan.chown {
+        let dst = path.to_owned();
+        walk::run_metadata_probed(
+            congestion::Side::Destination,
+            congestion::MetadataOp::Chmod,
+            async {
+                tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+                    nix::unistd::fchownat(
+                        nix::fcntl::AT_FDCWD,
+                        &dst,
+                        uid.map(Into::into),
+                        gid.map(Into::into),
+                        nix::fcntl::AtFlags::AT_SYMLINK_NOFOLLOW,
+                    )
+                    .with_context(|| format!("failed to chown {dst:?}"))?;
+                    Ok(())
+                })
+                .await?
+            },
+        )
+        .await?;
+    }
+    if let Some(mode) = plan.chmod {
+        // path-based chmod (only ever called on non-symlinks); follows the entry
+        // itself. avoids an extra open() vs fchmod and matches rm's dir path.
+        walk::run_metadata_probed(
+            congestion::Side::Destination,
+            congestion::MetadataOp::Chmod,
+            tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)),
+        )
+        .await
+        .with_context(|| format!("failed to chmod {path:?} to {mode:04o}"))?;
+    }
+    Ok(())
+}
+
+/// Apply the change to a single entry (a leaf, or a directory after its children
+/// were processed). Handles the time filter, dry-run, no-op skip, and counters.
+async fn process_entry(
+    prog: &'static Progress,
+    path: &std::path::Path,
+    metadata: &std::fs::Metadata,
+    kind: EntryKind,
+    settings: &Settings,
+) -> Result<Summary, Error> {
+    if let Some(ref time_filter) = settings.time_filter {
+        match time_filter.matches(metadata) {
+            Ok(result) => {
+                if let Some(reason) = result.as_skip_reason() {
+                    if let Some(mode) = settings.dry_run {
+                        crate::dry_run::report_time_skip(path, reason, mode, kind.label());
+                    }
+                    kind.inc_skipped(prog);
+                    return Ok(skipped_summary_for(kind));
+                }
+            }
+            Err(err) => {
+                let err = err.context(format!("failed evaluating time filter on {path:?}"));
+                if settings.fail_early {
+                    return Err(Error::new(err, Default::default()));
+                }
+                tracing::warn!("time filter failed for {:?}, skipping: {:#}", path, &err);
+                kind.inc_skipped(prog);
+                return Ok(skipped_summary_for(kind));
+            }
+        }
+    }
+    let plan = compute_plan(
+        metadata.mode(),
+        metadata.uid(),
+        metadata.gid(),
+        kind,
+        settings,
+    );
+    if plan.is_noop() {
+        if let Some(crate::config::DryRunMode::All) = settings.dry_run {
+            println!("unchanged {} {:?}", kind.label(), path);
+        }
+        return Ok(inc_unchanged(prog, kind));
+    }
+    if settings.dry_run.is_some() {
+        let desc = describe_change(metadata.mode(), metadata.uid(), metadata.gid(), &plan);
+        println!("would modify {} {:?}: {}", kind.label(), path, desc);
+        return Ok(inc_changed(prog, kind));
+    }
+    apply_plan(path, &plan)
+        .await
+        .map_err(|err| Error::new(err, Default::default()))?;
+    Ok(inc_changed(prog, kind))
+}
+
+/// Strip trailing path separators from a root operand. A trailing slash forces the
+/// OS to resolve the final component as a directory, which would dereference a symlink
+/// root like `link/` (following it to its target) -- violating the non-dereference
+/// behavior. Stripping makes `link/` behave like `link` (the symlink itself).
+/// (This non-dereference behavior is not robust against concurrent path replacement
+/// under elevated privilege; see `docs/tocttou.md`.)
+fn without_trailing_separators(path: &std::path::Path) -> std::path::PathBuf {
+    use std::os::unix::ffi::OsStrExt;
+    let bytes = path.as_os_str().as_bytes();
+    let mut end = bytes.len();
+    while end > 1 && bytes[end - 1] == b'/' {
+        end -= 1;
+    }
+    std::path::PathBuf::from(std::ffi::OsStr::from_bytes(&bytes[..end]))
+}
+
+/// Public entry point. Applies metadata changes to `path` and, recursively, its
+/// contents. Mirrors [`crate::rm::rm`] for the root-filter check.
+#[instrument(skip(prog_track, settings))]
+pub async fn chmod(
+    prog_track: &'static Progress,
+    path: &std::path::Path,
+    settings: &Settings,
+) -> Result<Summary, Error> {
+    let stripped = without_trailing_separators(path);
+    let path = stripped.as_path();
+    if let Some(ref filter) = settings.filter
+        && let Some(name) = path.file_name().map(std::path::Path::new)
+    {
+        let metadata = walk::run_metadata_probed(
+            congestion::Side::Source,
+            congestion::MetadataOp::Stat,
+            tokio::fs::symlink_metadata(path),
+        )
+        .await
+        .with_context(|| format!("failed reading metadata from {path:?}"))
+        .map_err(|err| Error::new(err, Default::default()))?;
+        match filter.should_include_root_item(name, metadata.is_dir()) {
+            crate::filter::FilterResult::Included => {}
+            result => {
+                let kind = EntryKind::from_metadata(&metadata);
+                if let Some(mode) = settings.dry_run {
+                    crate::dry_run::report_skip(path, &result, mode, kind.label_long());
+                }
+                kind.inc_skipped(prog_track);
+                return Ok(skipped_summary_for(kind));
+            }
+        }
+    }
+    chmod_internal(prog_track, path, path, settings).await
+}
+
+/// Apply the directory's own change, or skip it when the directory was only traversed to
+/// find include-matches. Factored out so the walk can run it before (pre-order, default)
+/// or after (post-order, `--defer-dir-changes`) descending into the contents.
+async fn apply_dir_self(
+    prog_track: &'static Progress,
+    path: &std::path::Path,
+    metadata: &std::fs::Metadata,
+    traversed_only: bool,
+    settings: &Settings,
+) -> Result<Summary, Error> {
+    if traversed_only {
+        if let Some(crate::config::DryRunMode::All) = settings.dry_run {
+            println!("skip dir {path:?} (only traversed for include matches)");
+        }
+        prog_track.directories_skipped.inc();
+        return Ok(skipped_summary_for(EntryKind::Dir));
+    }
+    process_entry(prog_track, path, metadata, EntryKind::Dir, settings).await
+}
+
+#[instrument(skip(prog_track, settings))]
+#[async_recursion]
+async fn chmod_internal(
+    prog_track: &'static Progress,
+    path: &std::path::Path,
+    source_root: &std::path::Path,
+    settings: &Settings,
+) -> Result<Summary, Error> {
+    let _ops_guard = prog_track.ops.guard();
+    let metadata = walk::run_metadata_probed(
+        congestion::Side::Source,
+        congestion::MetadataOp::Stat,
+        tokio::fs::symlink_metadata(path),
+    )
+    .await
+    .with_context(|| format!("failed reading metadata from {path:?}"))
+    .map_err(|err| Error::new(err, Default::default()))?;
+    let kind = EntryKind::from_metadata(&metadata);
+    if kind != EntryKind::Dir {
+        return process_entry(prog_track, path, &metadata, kind, settings).await;
+    }
+    // a directory may have been entered only because it *could contain* include-matches,
+    // not because it directly matches an include pattern. such "traversed-only" dirs are
+    // not modified themselves (mirrors rm.rs) -- only entries the filter directly selects.
+    let relative_path = path.strip_prefix(source_root).unwrap_or(path);
+    let traversed_only = settings
+        .filter
+        .as_ref()
+        .is_some_and(|f| f.has_includes() && !f.directly_matches_include(relative_path, true));
+    let errors = crate::error_collector::ErrorCollector::default();
+    let mut summary = Summary::default();
+    // pre-order (default, like `chmod -R`): change the directory BEFORE descending, so
+    // `--mode d:u+rwx` can recover an unreadable directory and a child failure can't
+    // prevent the directory's own change.
+    if !settings.defer_dir_changes {
+        match apply_dir_self(prog_track, path, &metadata, traversed_only, settings).await {
+            Ok(dir_summary) => summary = summary + dir_summary,
+            Err(error) => {
+                if settings.fail_early {
+                    return Err(Error::new(error.source, summary + error.summary));
+                }
+                tracing::error!("chmod: {:?} failed with: {:#}", path, &error);
+                summary = summary + error.summary;
+                errors.push(error.source);
+            }
+        }
+    }
+    // descend into the directory's contents
+    match tokio::fs::read_dir(path).await {
+        Ok(mut entries) => {
+            let mut join_set = tokio::task::JoinSet::new();
+            loop {
+                let (entry, entry_file_type) =
+                    match walk::next_entry_probed(&mut entries, congestion::Side::Source, || {
+                        format!("failed traversing directory {path:?}")
+                    })
+                    .await
+                    {
+                        Ok(Some(entry)) => entry,
+                        Ok(None) => break,
+                        Err(error) => {
+                            if settings.fail_early {
+                                return Err(Error::new(error, summary));
+                            }
+                            tracing::error!("chmod: {:#}", &error);
+                            errors.push(error);
+                            break;
+                        }
+                    };
+                let entry_path = entry.path();
+                let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
+                let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
+                if let Some(skip_result) = walk::should_skip_entry(
+                    &settings.filter,
+                    relative_path,
+                    entry_kind == EntryKind::Dir,
+                ) {
+                    if let Some(mode) = settings.dry_run {
+                        crate::dry_run::report_skip(
+                            &entry_path,
+                            &skip_result,
+                            mode,
+                            entry_kind.label(),
+                        );
+                    }
+                    entry_kind.inc_skipped(prog_track);
+                    summary = summary + skipped_summary_for(entry_kind);
+                    continue;
+                }
+                let settings = settings.clone();
+                let source_root = source_root.to_owned();
+                let known_leaf = entry_file_type.as_ref().is_some_and(|ft| !ft.is_dir());
+                let pending_guard = if known_leaf {
+                    Some(throttle::pending_meta_permit().await)
+                } else {
+                    None
+                };
+                join_set.spawn(async move {
+                    let _pending_guard = pending_guard;
+                    chmod_internal(prog_track, &entry_path, &source_root, &settings).await
+                });
+            }
+            drop(entries);
+            while let Some(res) = join_set.join_next().await {
+                match res {
+                    Ok(Ok(child)) => summary = summary + child,
+                    Ok(Err(error)) => {
+                        tracing::error!("chmod: {:?} failed with: {:#}", path, &error);
+                        summary = summary + error.summary;
+                        errors.push(error.source);
+                        if settings.fail_early {
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        errors.push(error.into());
+                        if settings.fail_early {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        Err(read_error) => {
+            // couldn't read the directory -- e.g. owner r/x was just removed (a pre-order
+            // restrictive change) or it was already unreadable with no traversability-
+            // restoring rule. report it; unless --fail-early, keep going with the rest.
+            let error = anyhow::Error::new(read_error)
+                .context(format!("failed reading directory {path:?}"));
+            if settings.fail_early {
+                return Err(Error::new(error, summary));
+            }
+            tracing::error!("chmod: {:#}", &error);
+            errors.push(error);
+        }
+    }
+    // under --fail-early, a child failure broke the join loop above; stop here, before any
+    // deferred parent change -- never apply more changes after the error we were asked to
+    // stop on. (read_dir / next_entry failures already returned directly.)
+    if settings.fail_early && errors.has_errors() {
+        return Err(Error::new(errors.into_error().unwrap(), summary));
+    }
+    // post-order (`--defer-dir-changes`): change the directory AFTER its contents -- needed
+    // when recursively removing the owner's own traversal permission. in keep-going mode it
+    // is applied even after a child failure; fail-early returned just above.
+    if settings.defer_dir_changes {
+        match apply_dir_self(prog_track, path, &metadata, traversed_only, settings).await {
+            Ok(dir_summary) => summary = summary + dir_summary,
+            Err(error) => {
+                if settings.fail_early {
+                    return Err(Error::new(error.source, summary + error.summary));
+                }
+                tracing::error!("chmod: {:?} failed with: {:#}", path, &error);
+                summary = summary + error.summary;
+                errors.push(error.source);
+            }
+        }
+    }
+    if errors.has_errors() {
+        return Err(Error::new(errors.into_error().unwrap(), summary));
+    }
+    Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn mode_token_octal() {
+        assert_eq!(parse_mode_token("2775").unwrap(), ModeSpec::Octal(0o2775));
+        assert_eq!(parse_mode_token("0644").unwrap(), ModeSpec::Octal(0o644));
+    }
+    #[test]
+    fn mode_token_octal_out_of_range_errors() {
+        assert!(parse_mode_token("9999").is_err()); // 9 is not octal
+        assert!(parse_mode_token("77777").is_err()); // > 12 bits
+    }
+    #[test]
+    fn mode_token_symbolic_simple() {
+        let spec = parse_mode_token("g+w").unwrap();
+        assert_eq!(
+            spec,
+            ModeSpec::Symbolic(vec![SymbolicClause {
+                who: WHO_G,
+                op: ModeOp::Add,
+                perms: PERM_W
+            }])
+        );
+    }
+    #[test]
+    fn mode_token_symbolic_omitted_who_means_all() {
+        let spec = parse_mode_token("+x").unwrap();
+        assert_eq!(
+            spec,
+            ModeSpec::Symbolic(vec![SymbolicClause {
+                who: WHO_A,
+                op: ModeOp::Add,
+                perms: PERM_X
+            }])
+        );
+    }
+    #[test]
+    fn mode_token_symbolic_comma_chained() {
+        let spec = parse_mode_token("u+rw,g-w").unwrap();
+        let ModeSpec::Symbolic(clauses) = spec else {
+            panic!("expected symbolic")
+        };
+        assert_eq!(clauses.len(), 2);
+        assert_eq!(
+            clauses[0],
+            SymbolicClause {
+                who: WHO_U,
+                op: ModeOp::Add,
+                perms: PERM_R | PERM_W
+            }
+        );
+        assert_eq!(
+            clauses[1],
+            SymbolicClause {
+                who: WHO_G,
+                op: ModeOp::Remove,
+                perms: PERM_W
+            }
+        );
+    }
+    #[test]
+    fn mode_token_symbolic_bigx_and_specials() {
+        let spec = parse_mode_token("g+rwXs").unwrap();
+        assert_eq!(
+            spec,
+            ModeSpec::Symbolic(vec![SymbolicClause {
+                who: WHO_G,
+                op: ModeOp::Add,
+                perms: PERM_R | PERM_W | PERM_BIGX | PERM_S,
+            }])
+        );
+    }
+    #[test]
+    fn mode_token_rejects_garbage() {
+        assert!(parse_mode_token("q+z").is_err());
+        assert!(parse_mode_token("g!w").is_err());
+        assert!(parse_mode_token("").is_err());
+    }
+    #[test]
+    fn summary_add_combines_fields() {
+        let a = Summary {
+            files_changed: 1,
+            directories_changed: 2,
+            files_unchanged: 3,
+            ..Default::default()
+        };
+        let b = Summary {
+            files_changed: 10,
+            symlinks_skipped: 4,
+            ..Default::default()
+        };
+        let sum = a + b;
+        assert_eq!(sum.files_changed, 11);
+        assert_eq!(sum.directories_changed, 2);
+        assert_eq!(sum.files_unchanged, 3);
+        assert_eq!(sum.symlinks_skipped, 4);
+    }
+    #[test]
+    fn owner_dsl_bare_applies_to_all_types() {
+        let prog = parse_owner_dsl("0", IdKind::User).unwrap();
+        assert_eq!(prog.file, Some(0));
+        assert_eq!(prog.dir, Some(0));
+        assert_eq!(prog.symlink, Some(0));
+    }
+    #[test]
+    fn owner_dsl_per_type_overrides() {
+        let prog = parse_owner_dsl("f:1 d:2", IdKind::User).unwrap();
+        assert_eq!(prog.file, Some(1));
+        assert_eq!(prog.dir, Some(2));
+        assert_eq!(prog.symlink, None);
+    }
+    #[test]
+    fn owner_dsl_bare_plus_override() {
+        let prog = parse_owner_dsl("5 d:2", IdKind::Group).unwrap();
+        assert_eq!(prog.file, Some(5));
+        assert_eq!(prog.dir, Some(2));
+        assert_eq!(prog.symlink, Some(5));
+    }
+    #[test]
+    fn owner_dsl_explicit_before_bare_is_order_independent() {
+        let prog = parse_owner_dsl("f:1 5", IdKind::User).unwrap();
+        assert_eq!(prog.file, Some(1));
+        assert_eq!(prog.dir, Some(5));
+        assert_eq!(prog.symlink, Some(5));
+    }
+    #[test]
+    fn owner_dsl_rejects_multiple_bare() {
+        assert!(parse_owner_dsl("1 2", IdKind::User).is_err());
+    }
+    #[test]
+    fn owner_dsl_rejects_unknown_id() {
+        assert!(parse_owner_dsl("definitely-no-such-group-xyz", IdKind::Group).is_err());
+    }
+    fn sym(s: &str) -> ModeSpec {
+        parse_mode_token(s).unwrap()
+    }
+    #[test]
+    fn apply_mode_group_add_remove() {
+        assert_eq!(apply_mode(0o644, &sym("g+w"), false), 0o664);
+        assert_eq!(apply_mode(0o664, &sym("g-w"), false), 0o644);
+    }
+    #[test]
+    fn apply_mode_set_clears_other_bits() {
+        // o= clears all 'other' bits (incl sticky), leaves user/group
+        assert_eq!(apply_mode(0o755, &sym("o="), false), 0o750);
+        // chained absolute-ish set from zero
+        assert_eq!(apply_mode(0o000, &sym("u=rwx,go=rx"), false), 0o755);
+        // o= on a sticky file clears the sticky bit too
+        assert_eq!(apply_mode(0o1755, &sym("o="), false), 0o0750);
+    }
+    #[test]
+    fn apply_mode_conditional_bigx() {
+        // file without execute: X does nothing
+        assert_eq!(apply_mode(0o644, &sym("a+X"), false), 0o644);
+        // file with a user-execute bit: X applies to all
+        assert_eq!(apply_mode(0o744, &sym("a+X"), false), 0o755);
+        // directory: X always applies
+        assert_eq!(apply_mode(0o644, &sym("a+X"), true), 0o755);
+    }
+    #[test]
+    fn apply_mode_setgid_and_sticky() {
+        assert_eq!(apply_mode(0o750, &sym("g+rwxs"), true), 0o2770);
+        assert_eq!(apply_mode(0o755, &sym("+t"), true), 0o1755);
+        assert_eq!(apply_mode(0o755, &sym("u+s"), false), 0o4755);
+    }
+    #[test]
+    fn apply_mode_sticky_only_responds_to_other() {
+        // u+t / g+t are no-ops; only o/a/bare set sticky (verified against real chmod)
+        assert_eq!(apply_mode(0o755, &sym("u+t"), false), 0o755);
+        assert_eq!(apply_mode(0o755, &sym("g+t"), false), 0o755);
+        assert_eq!(apply_mode(0o755, &sym("ug+t"), false), 0o755);
+        assert_eq!(apply_mode(0o755, &sym("o+t"), false), 0o1755);
+        assert_eq!(apply_mode(0o755, &sym("+t"), false), 0o1755);
+        assert_eq!(apply_mode(0o1755, &sym("u-t"), false), 0o1755);
+        assert_eq!(apply_mode(0o1755, &sym("o-t"), false), 0o755);
+    }
+    #[test]
+    fn apply_mode_octal_is_absolute() {
+        assert_eq!(apply_mode(0o4755, &sym("644"), false), 0o644);
+        assert_eq!(apply_mode(0o000, &sym("2775"), true), 0o2775);
+    }
+    #[test]
+    fn mode_dsl_bare_applies_to_file_and_dir_not_symlink() {
+        let prog = parse_mode_dsl("g+rwX").unwrap();
+        assert!(prog.file.is_some());
+        assert!(prog.dir.is_some());
+        // symlinks are not part of ModeProgram at all
+        assert!(prog.for_kind(EntryKind::Symlink).is_none());
+    }
+    #[test]
+    fn mode_dsl_per_type() {
+        let prog = parse_mode_dsl("f:g+rw d:g+rwxs").unwrap();
+        assert_eq!(prog.file, Some(sym("g+rw")));
+        assert_eq!(prog.dir, Some(sym("g+rwxs")));
+    }
+    #[test]
+    fn mode_dsl_bare_plus_override() {
+        let prog = parse_mode_dsl("g+r d:g+rwx").unwrap();
+        assert_eq!(prog.file, Some(sym("g+r")));
+        assert_eq!(prog.dir, Some(sym("g+rwx")));
+    }
+    #[test]
+    fn mode_dsl_rejects_symlink_section() {
+        assert!(parse_mode_dsl("l:g+w").is_err());
+    }
+    #[test]
+    fn mode_dsl_rejects_multiple_bare() {
+        assert!(parse_mode_dsl("g+r o+w").is_err());
+    }
+    #[test]
+    fn mode_dsl_rejects_unknown_prefix() {
+        assert!(parse_mode_dsl("z:644").is_err());
+    }
+    #[test]
+    fn mode_dsl_single_type_leaves_other_none() {
+        let prog_f = parse_mode_dsl("f:644").unwrap();
+        assert!(prog_f.file.is_some());
+        assert!(prog_f.dir.is_none());
+        let prog_d = parse_mode_dsl("d:755").unwrap();
+        assert!(prog_d.dir.is_some());
+        assert!(prog_d.file.is_none());
+    }
+    fn settings_with(mode: &str, owner: Option<&str>, group: Option<&str>) -> Settings {
+        Settings {
+            mode: if mode.is_empty() {
+                ModeProgram::default()
+            } else {
+                parse_mode_dsl(mode).unwrap()
+            },
+            owner: owner
+                .map(|s| parse_owner_dsl(s, IdKind::User).unwrap())
+                .unwrap_or_default(),
+            group: group
+                .map(|s| parse_owner_dsl(s, IdKind::Group).unwrap())
+                .unwrap_or_default(),
+            fail_early: false,
+            defer_dir_changes: false,
+            filter: None,
+            time_filter: None,
+            dry_run: None,
+        }
+    }
+    #[test]
+    fn plan_noop_when_already_correct() {
+        let s = settings_with("g+r", None, None);
+        // file already group-readable
+        let plan = compute_plan(0o644, 1000, 1000, EntryKind::File, &s);
+        assert!(plan.is_noop());
+    }
+    #[test]
+    fn plan_chmod_when_mode_differs() {
+        let s = settings_with("g+w", None, None);
+        let plan = compute_plan(0o644, 1000, 1000, EntryKind::File, &s);
+        assert_eq!(plan.chmod, Some(0o664));
+        assert!(plan.chown.is_none());
+    }
+    #[test]
+    fn plan_chown_only_changed_ids() {
+        let s = settings_with("", None, Some("2000"));
+        let plan = compute_plan(0o644, 1000, 1000, EntryKind::File, &s);
+        // gid changes 1000 -> 2000, uid untouched
+        assert_eq!(plan.chown, Some((None, Some(2000))));
+        assert!(plan.chmod.is_none());
+    }
+    #[test]
+    fn plan_preserves_setgid_across_chgrp() {
+        // file is setgid (0o2755), only --group given; chown clears setgid, so we
+        // must re-chmod to the original mode to keep it.
+        let s = settings_with("", None, Some("2000"));
+        let plan = compute_plan(0o2755, 1000, 1000, EntryKind::File, &s);
+        assert_eq!(plan.chown, Some((None, Some(2000))));
+        assert_eq!(plan.chmod, Some(0o2755));
+    }
+    #[test]
+    fn plan_symlink_never_chmods_but_chowns() {
+        let s = settings_with("g+w", None, Some("2000"));
+        let plan = compute_plan(0o777, 1000, 1000, EntryKind::Symlink, &s);
+        assert!(plan.chmod.is_none());
+        assert_eq!(plan.chown, Some((None, Some(2000))));
+    }
+    #[test]
+    fn plan_preserves_setuid_when_mode_rule_noop_but_chown_runs() {
+        // g+r is a no-op on 0o4755 (group already readable), but the chown clears
+        // setuid, so the mode-rule branch must still emit a chmod to restore it.
+        let s = settings_with("g+r", Some("2000"), None);
+        let plan = compute_plan(0o4755, 1000, 1000, EntryKind::File, &s);
+        assert_eq!(plan.chown, Some((Some(2000), None)));
+        assert_eq!(plan.chmod, Some(0o4755));
+    }
+    #[test]
+    fn plan_preserves_setgid_dir_across_chgrp() {
+        // setgid dir, only --group given; chown clears setgid so chmod restores it.
+        let s = settings_with("", None, Some("2000"));
+        let plan = compute_plan(0o2770, 1000, 1000, EntryKind::Dir, &s);
+        assert_eq!(plan.chown, Some((None, Some(2000))));
+        assert_eq!(plan.chmod, Some(0o2770));
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -109,6 +109,7 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
 
 mod auto_meta;
+pub mod chmod;
 pub mod cli;
 pub mod cmp;
 pub mod config;
@@ -689,6 +690,13 @@ pub async fn copy(
 
 pub async fn rm(path: &std::path::Path, settings: &rm::Settings) -> Result<rm::Summary, rm::Error> {
     rm::rm(&PROGRESS, path, settings).await
+}
+
+pub async fn chmod(
+    path: &std::path::Path,
+    settings: &chmod::Settings,
+) -> Result<chmod::Summary, chmod::Error> {
+    chmod::chmod(&PROGRESS, path, settings).await
 }
 
 pub async fn link(

--- a/common/src/progress.rs
+++ b/common/src/progress.rs
@@ -152,6 +152,9 @@ pub struct Progress {
     pub files_copied: TlsCounter,
     pub symlinks_created: TlsCounter,
     pub directories_created: TlsCounter,
+    pub files_changed: TlsCounter,
+    pub symlinks_changed: TlsCounter,
+    pub directories_changed: TlsCounter,
     pub files_unchanged: TlsCounter,
     pub symlinks_unchanged: TlsCounter,
     pub directories_unchanged: TlsCounter,
@@ -177,6 +180,9 @@ impl Progress {
             files_copied: Default::default(),
             symlinks_created: Default::default(),
             directories_created: Default::default(),
+            files_changed: Default::default(),
+            symlinks_changed: Default::default(),
+            directories_changed: Default::default(),
             files_unchanged: Default::default(),
             symlinks_unchanged: Default::default(),
             directories_unchanged: Default::default(),
@@ -300,6 +306,7 @@ pub enum LocalProgressKind {
     Link,
     Compare,
     Filegen,
+    Modify,
 }
 
 fn ops_rates(
@@ -499,6 +506,68 @@ impl<'a> LocalProgressReport for RemoveProgressPrinter<'a> {
             self.progress.files_removed.get(),
             self.progress.symlinks_removed.get(),
             self.progress.directories_removed.get(),
+            self.progress.files_skipped.get(),
+            self.progress.symlinks_skipped.get(),
+            self.progress.directories_skipped.get(),
+        ))
+    }
+}
+
+/// Progress printer for `rchm`. Reports CHANGED / UNCHANGED / SKIPPED counts per
+/// entry type; rchm performs only metadata ops, so there are no byte counters.
+pub struct ModifyProgressPrinter<'a> {
+    progress: &'a Progress,
+    last_ops: u64,
+    last_update: std::time::Instant,
+}
+
+impl<'a> ModifyProgressPrinter<'a> {
+    pub fn new(progress: &'a Progress) -> Self {
+        Self {
+            progress,
+            last_ops: progress.ops.get().finished,
+            last_update: std::time::Instant::now(),
+        }
+    }
+}
+
+impl<'a> LocalProgressReport for ModifyProgressPrinter<'a> {
+    fn print(&mut self) -> anyhow::Result<String> {
+        let now = std::time::Instant::now();
+        let (ops, avg_ops, cur_ops) =
+            ops_rates(self.progress, self.last_ops, self.last_update, now);
+        self.last_ops = ops.finished;
+        self.last_update = now;
+        Ok(format!(
+            "---------------------\n\
+            OPS:\n\
+            pending: {:>10}\n\
+            average: {:>10.2} items/s\n\
+            current: {:>10.2} items/s\n\
+            -----------------------\n\
+            CHANGED:\n\
+            files:       {:>10}\n\
+            symlinks:    {:>10}\n\
+            directories: {:>10}\n\
+            -----------------------\n\
+            UNCHANGED:\n\
+            files:       {:>10}\n\
+            symlinks:    {:>10}\n\
+            directories: {:>10}\n\
+            -----------------------\n\
+            SKIPPED:\n\
+            files:       {:>10}\n\
+            symlinks:    {:>10}\n\
+            directories: {:>10}",
+            ops.started - ops.finished,
+            avg_ops,
+            cur_ops,
+            self.progress.files_changed.get(),
+            self.progress.symlinks_changed.get(),
+            self.progress.directories_changed.get(),
+            self.progress.files_unchanged.get(),
+            self.progress.symlinks_unchanged.get(),
+            self.progress.directories_unchanged.get(),
             self.progress.files_skipped.get(),
             self.progress.symlinks_skipped.get(),
             self.progress.directories_skipped.get(),
@@ -708,6 +777,7 @@ pub fn make_local_printer<'a>(
         LocalProgressKind::Link => Box::new(LinkProgressPrinter::new(progress)),
         LocalProgressKind::Compare => Box::new(CompareProgressPrinter::new(progress)),
         LocalProgressKind::Filegen => Box::new(FilegenProgressPrinter::new(progress)),
+        LocalProgressKind::Modify => Box::new(ModifyProgressPrinter::new(progress)),
     }
 }
 
@@ -1228,5 +1298,17 @@ mod tests {
         assert!(!output.contains("SKIPPED:"));
         assert!(!output.contains("symlinks:"));
         Ok(())
+    }
+
+    #[test]
+    fn modify_printer_renders_changed_section() {
+        let progress = Progress::new();
+        progress.files_changed.inc();
+        progress.directories_unchanged.inc();
+        let mut printer = ModifyProgressPrinter::new(&progress);
+        let out = printer.print().unwrap();
+        assert!(out.contains("CHANGED:"));
+        assert!(out.contains("UNCHANGED:"));
+        assert!(out.contains("SKIPPED:"));
     }
 }

--- a/docs/tocttou.md
+++ b/docs/tocttou.md
@@ -1,7 +1,11 @@
-# TOCTTOU Vulnerabilities in rcp
+# TOCTTOU Vulnerabilities in the RCP tools
 
 This document describes Time-of-Check-Time-of-Use (TOCTTOU) race condition vulnerabilities
-that affect rcp when used with elevated privileges, and discusses potential mitigations.
+that affect the RCP tools (`rcp`, `rchm`, `rrm`, `rlink`) when used with elevated
+privileges, and discusses potential mitigations. The examples below use `rcp`, but the
+same check-then-path-operate pattern applies to the other tools — e.g. `rchm` performs a
+path-based `chmod` after an `lstat`-based type check, so a concurrent symlink swap could
+redirect the mode change despite `rchm`'s otherwise non-dereferencing behavior.
 
 ## Table of Contents
 
@@ -24,6 +28,11 @@ same system may be able to exploit TOCTTOU race conditions to:
 **Important**: These attacks require local access to the system and the ability to modify
 files/directories in the path being copied. Remote network attackers cannot exploit these
 vulnerabilities directly.
+
+**The precise threat condition** is not merely "running as root": it is *running with more
+privilege than an actor who can modify the paths being traversed.* Root operating on
+trusted, root-owned trees is outside this threat; the risk arises specifically when a
+more-privileged run traverses a tree that a less-privileged actor can write to.
 
 ## What is TOCTTOU?
 

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,11 @@
             binaryName = "rrm";
             description = "Fast file removal tool";
           };
+          rchm = mkRcpPackage {
+            packageName = "rcp-tools-rchm";
+            binaryName = "rchm";
+            description = "Fast recursive chmod/chgrp/chown tool";
+          };
           rlink = mkRcpPackage {
             packageName = "rcp-tools-rlink";
             binaryName = "rlink";
@@ -171,7 +176,7 @@
               echo "  just build      - Build all packages"
               echo "  just doc        - Check documentation"
               echo ""
-              echo "Individual tools: rcp, rrm, rlink, rcmp, filegen"
+              echo "Individual tools: rcp, rrm, rchm, rlink, rcmp, filegen"
               echo "Note: rcpd is included with rcp (rcp-tools-rcp package)"
               echo ""
               echo "Static musl target enabled by default (.cargo/config.toml):"

--- a/rchm/Cargo.toml
+++ b/rchm/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "rcp-tools-rchm"
+version.workspace = true
+description = "Fast recursive chmod/chgrp/chown for large filesets (a dchmod replacement)"
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+readme = "../README.md"
+documentation = "https://docs.rs/rcp-tools-rchm"
+keywords = ["cli", "file", "chmod", "chown", "performance"]
+categories = ["command-line-utilities", "filesystem"]
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+cargo-args = ["--config", "build.rustflags=[\"--cfg\", \"tokio_unstable\"]"]
+rustdoc-args = ["--cfg", "tokio_unstable"]
+
+[[bin]]
+name = "rchm"
+path = "src/main.rs"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = "3"
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4", features = ["derive"] }
+common = { workspace = true }
+humantime = "2.3"
+tokio = { version = "1.52", features = ["full", "parking_lot", "tracing"] }
+tracing = "0.1"
+
+[package.metadata.deb]
+maintainer = "Mateusz Wykurz <wykurz@gmail.com>"
+copyright = "2023, Mateusz Wykurz <wykurz@gmail.com>"
+depends = "libc6 (>= 2.27)"
+section = "utility"
+
+[package.metadata.generate-rpm]
+assets = [ { source = "target/release/rchm", dest = "/usr/bin/rchm", mode = "755" } ]

--- a/rchm/src/main.rs
+++ b/rchm/src/main.rs
@@ -1,0 +1,269 @@
+use anyhow::{Result, anyhow};
+use clap::Parser;
+use tracing::instrument;
+
+#[derive(Parser, Debug, Clone)]
+#[command(
+    name = "rchm",
+    version,
+    about = "Recursively change permissions/ownership of large filesets - a dchmod replacement",
+    long_about = "`rchm` recursively applies chmod/chgrp/chown changes to large filesets.
+
+The --group and --owner options take a per-type DSL: a bare value applies to all
+entries (files, directories, and symlinks via lchown); f:/d:/l: prefixes target one
+type. --mode uses the same DSL but covers only files and directories (a bare value
+sets both) — symlink mode bits aren't settable on Linux, so l: is rejected for --mode.
+
+EXAMPLES:
+    # join group 'data' and add group rwx to dirs, rw to files
+    rchm --group data --mode 'f:g+rw d:g+rwxs' /data --progress --summary
+
+    # dchmod-style: one mode for everything
+    rchm --mode g+rwX /data --progress"
+)]
+struct Args {
+    /// Mode change DSL (e.g. 'g+rwX' or 'f:g+rw d:g+rwxs'). Symbolic or octal.
+    #[arg(long, value_name = "DSL", help_heading = "Operation")]
+    mode: Option<String>,
+    /// Group change DSL: a group name/gid, optionally per type (e.g. 'data' or 'f:data d:wheel')
+    #[arg(long, value_name = "DSL", help_heading = "Operation")]
+    group: Option<String>,
+    /// Owner change DSL: a user name/uid, optionally per type (e.g. 'root' or 'd:root')
+    #[arg(long, value_name = "DSL", help_heading = "Operation")]
+    owner: Option<String>,
+    /// Exit on first error
+    #[arg(short = 'e', long = "fail-early", help_heading = "Operation")]
+    fail_early: bool,
+    /// Apply directory changes after their contents (post-order) instead of before
+    ///
+    /// By default directory changes are applied before descending (like `chmod -R`), so
+    /// `--mode d:u+rwx` can recover an unreadable directory. Use this flag when recursively
+    /// removing the owner's own read/execute from directories, where pre-order would lock
+    /// itself out of the contents.
+    #[arg(long, help_heading = "Operation")]
+    defer_dir_changes: bool,
+    /// Glob pattern for paths to include (can be specified multiple times)
+    #[arg(long, value_name = "PATTERN", action = clap::ArgAction::Append, help_heading = "Filtering")]
+    include: Vec<String>,
+    /// Glob pattern for paths to exclude (can be specified multiple times)
+    #[arg(long, value_name = "PATTERN", action = clap::ArgAction::Append, help_heading = "Filtering")]
+    exclude: Vec<String>,
+    /// Read filter patterns from file
+    #[arg(long, value_name = "PATH", conflicts_with_all = ["include", "exclude"], help_heading = "Filtering")]
+    filter_file: Option<std::path::PathBuf>,
+    /// Only change entries whose modification time is at least this old (e.g. 30d, 12h)
+    #[arg(long, value_name = "DURATION", help_heading = "Filtering")]
+    modified_before: Option<String>,
+    /// Only change entries whose creation (birth) time is at least this old
+    #[arg(long, value_name = "DURATION", help_heading = "Filtering")]
+    #[cfg_attr(target_env = "musl", arg(hide = true))]
+    created_before: Option<String>,
+    /// Preview mode - show what would change without changing it
+    #[arg(long, value_name = "MODE", help_heading = "Filtering")]
+    dry_run: Option<common::DryRunMode>,
+    /// Print summary at the end
+    #[arg(long, help_heading = "Progress & output")]
+    summary: bool,
+    /// Quiet mode, don't report errors
+    #[arg(short = 'q', long = "quiet", help_heading = "Progress & output")]
+    quiet: bool,
+    /// Maximum number of open files, 0 means no limit, unspecified means 80% of system limit
+    #[arg(long, value_name = "N", help_heading = "Performance & throttling")]
+    max_open_files: Option<usize>,
+    /// Chunk size used to calculate number of I/O per file
+    ///
+    /// Modifying this setting to a value > 0 is REQUIRED when using --iops-throttle.
+    #[arg(
+        long,
+        default_value = "0",
+        value_name = "SIZE",
+        help_heading = "Performance & throttling"
+    )]
+    chunk_size: u64,
+    #[command(flatten)]
+    common: common::cli::CommonArgs,
+    /// Path(s) to modify
+    #[arg()]
+    paths: Vec<std::path::PathBuf>,
+}
+
+fn parse_duration_arg(flag: &str, value: &str) -> Result<std::time::Duration> {
+    humantime::parse_duration(value).map_err(|err| {
+        anyhow!(
+            "{} value {:?} is not a valid duration: {}\n\
+             Hint: use suffixes like 1y, 6months, 30d, 12h, 30m, 45s. \
+             Note that 'M' means months and 'm' means minutes.",
+            flag,
+            value,
+            err
+        )
+    })
+}
+
+fn build_time_filter(
+    modified_before: Option<&str>,
+    created_before: Option<&str>,
+) -> Result<Option<common::filter::TimeFilter>> {
+    let modified_before = modified_before
+        .map(|v| parse_duration_arg("--modified-before", v))
+        .transpose()?;
+    let created_before = created_before
+        .map(|v| parse_duration_arg("--created-before", v))
+        .transpose()?;
+    if modified_before.is_none() && created_before.is_none() {
+        return Ok(None);
+    }
+    Ok(Some(common::filter::TimeFilter {
+        modified_before,
+        created_before,
+    }))
+}
+
+fn build_settings(args: &Args) -> Result<common::chmod::Settings> {
+    let mode = args
+        .mode
+        .as_deref()
+        .map(common::chmod::parse_mode_dsl)
+        .transpose()?
+        .unwrap_or_default();
+    let owner = args
+        .owner
+        .as_deref()
+        .map(|s| common::chmod::parse_owner_dsl(s, common::chmod::IdKind::User))
+        .transpose()?
+        .unwrap_or_default();
+    let group = args
+        .group
+        .as_deref()
+        .map(|s| common::chmod::parse_owner_dsl(s, common::chmod::IdKind::Group))
+        .transpose()?
+        .unwrap_or_default();
+    if mode.is_empty() && owner.is_empty() && group.is_empty() {
+        return Err(anyhow!(
+            "nothing to do: specify at least one of --mode, --group or --owner"
+        ));
+    }
+    let filter = common::filter::FilterSettings::from_args(
+        args.filter_file.as_deref(),
+        &args.include,
+        &args.exclude,
+    )?;
+    let time_filter = build_time_filter(
+        args.modified_before.as_deref(),
+        args.created_before.as_deref(),
+    )?;
+    Ok(common::chmod::Settings {
+        mode,
+        owner,
+        group,
+        fail_early: args.fail_early,
+        defer_dir_changes: args.defer_dir_changes,
+        filter,
+        time_filter,
+        dry_run: args.dry_run,
+    })
+}
+
+#[instrument]
+async fn async_main(args: Args) -> Result<common::chmod::Summary> {
+    let settings = build_settings(&args)?;
+    if args.paths.is_empty() {
+        return Err(anyhow!(
+            "no paths given: specify at least one path to modify"
+        ));
+    }
+    let mut join_set = tokio::task::JoinSet::new();
+    for path in args.paths {
+        let settings = settings.clone();
+        join_set.spawn(async move { common::chmod(&path, &settings).await });
+    }
+    let error_collector = common::error_collector::ErrorCollector::default();
+    let mut summary = common::chmod::Summary::default();
+    while let Some(res) = join_set.join_next().await {
+        match res? {
+            Ok(s) => summary = summary + s,
+            Err(error) => {
+                tracing::error!("{:#}", &error);
+                summary = summary + error.summary;
+                if args.fail_early {
+                    if args.summary {
+                        return Err(anyhow!("{}\n\n{}", error, &summary));
+                    }
+                    return Err(anyhow!("{}", error));
+                }
+                error_collector.push(error.source);
+            }
+        }
+    }
+    if let Some(err) = error_collector.into_error() {
+        if args.summary {
+            return Err(anyhow!("{:#}\n\n{}", err, &summary));
+        }
+        return Err(err);
+    }
+    Ok(summary)
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    #[cfg(target_env = "musl")]
+    if args.created_before.is_some() {
+        return Err(anyhow!(
+            "--created-before is not supported on musl builds: birth time (btime) is not \
+             readable via std::fs::Metadata::created() under musl, so every entry would \
+             fail evaluation and be skipped. Use --modified-before instead, or rebuild \
+             rchm against glibc."
+        ));
+    }
+    let dry_run_warnings = args.dry_run.map(|_| {
+        common::DryRunWarnings::new(
+            args.common.progress_requested(),
+            args.summary,
+            args.common.verbose,
+            false, // rchm has no --overwrite
+            !args.include.is_empty()
+                || !args.exclude.is_empty()
+                || args.filter_file.is_some()
+                || args.modified_before.is_some()
+                || args.created_before.is_some(),
+            false, // rchm has no destination
+            false, // rchm has no --ignore-existing
+        )
+    });
+    let is_dry_run = dry_run_warnings.is_some();
+    let func = {
+        let args = args.clone();
+        || async_main(args)
+    };
+    let output = args
+        .common
+        .output_config(args.quiet, !is_dry_run && args.summary);
+    let runtime = args.common.runtime_config();
+    let throttle = args
+        .common
+        .throttle_config(args.max_open_files, args.chunk_size);
+    let tracing = common::TracingConfig {
+        remote_layer: None,
+        debug_log_file: None,
+        chrome_trace_prefix: None,
+        flamegraph_prefix: None,
+        trace_identifier: "rchm".to_string(),
+        profile_level: None,
+        tokio_console: false,
+        tokio_console_port: None,
+    };
+    let progress = if is_dry_run {
+        None
+    } else {
+        args.common
+            .user_progress_settings(common::progress::LocalProgressKind::Modify)
+    };
+    let res = common::run(progress, output, runtime, throttle, tracing, func);
+    if let Some(warnings) = dry_run_warnings {
+        warnings.print();
+    }
+    if res.is_none() {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/rchm/tests/cli_parsing_tests.rs
+++ b/rchm/tests/cli_parsing_tests.rs
@@ -1,0 +1,62 @@
+//! CLI argument parsing and validation tests for rchm.
+//!
+//! These tests verify that rchm's command-line arguments are parsed correctly
+//! and that invalid operations (missing op, symlink mode, unknown group) are
+//! rejected with the expected diagnostics.
+
+use assert_cmd::Command;
+
+fn rchm() -> Command {
+    Command::cargo_bin("rchm").unwrap()
+}
+
+#[test]
+fn errors_when_no_operation_given() {
+    // the common harness routes runtime errors to stdout (see common::run)
+    rchm()
+        .arg("/tmp")
+        .assert()
+        .failure()
+        .stdout(predicates::str::contains("nothing to do"));
+}
+
+#[test]
+fn errors_when_no_path_given() {
+    // an operation but no path operand must fail loudly, not silently succeed
+    rchm()
+        .args(["--mode", "g+w"])
+        .assert()
+        .failure()
+        .stdout(predicates::str::contains("no paths given"));
+}
+
+#[test]
+fn rejects_symlink_mode_section() {
+    // the common harness routes runtime errors to stdout (see common::run)
+    rchm()
+        .args(["--mode", "l:g+w", "/tmp"])
+        .assert()
+        .failure()
+        .stdout(predicates::str::contains("symlink mode (l:)"));
+}
+
+#[test]
+fn rejects_unknown_group() {
+    // the common harness routes runtime errors to stdout (see common::run)
+    rchm()
+        .args(["--group", "definitely-no-such-group-xyz", "/tmp"])
+        .assert()
+        .failure()
+        .stdout(predicates::str::contains("unknown group"));
+}
+
+#[test]
+fn help_lists_operation_options() {
+    rchm()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("--mode"))
+        .stdout(predicates::str::contains("--group"))
+        .stdout(predicates::str::contains("--owner"));
+}

--- a/rchm/tests/tests.rs
+++ b/rchm/tests/tests.rs
@@ -1,0 +1,303 @@
+use assert_cmd::Command;
+use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+
+fn rchm() -> Command {
+    Command::cargo_bin("rchm").unwrap()
+}
+fn mode_of(p: &std::path::Path) -> u32 {
+    std::fs::symlink_metadata(p).unwrap().permissions().mode() & 0o7777
+}
+
+#[test]
+fn applies_per_type_modes_recursively() {
+    let d = tempfile::tempdir().unwrap();
+    let sub = d.path().join("sub");
+    std::fs::create_dir(&sub).unwrap();
+    let f = sub.join("f.txt");
+    std::fs::write(&f, b"x").unwrap();
+    std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o644)).unwrap();
+    std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o755)).unwrap();
+    rchm()
+        .args(["--mode", "f:g+w d:g+rwxs"])
+        .arg(d.path())
+        .assert()
+        .success();
+    assert_eq!(mode_of(&f), 0o664);
+    assert_eq!(mode_of(&sub), 0o2775);
+}
+
+#[test]
+fn preserves_mtime_and_moves_ctime() {
+    let d = tempfile::tempdir().unwrap();
+    let f = d.path().join("f.txt");
+    std::fs::write(&f, b"x").unwrap();
+    std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let before = std::fs::symlink_metadata(&f).unwrap();
+    let (mtime_ns_before, ctime_ns_before) = (before.mtime_nsec(), before.ctime_nsec());
+    let (mtime_s_before, ctime_s_before) = (before.mtime(), before.ctime());
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    // apply a mode change (g+w); chmod/chgrp/chown move only ctime, never mtime
+    rchm()
+        .args(["--mode", "g+w"])
+        .arg(d.path())
+        .assert()
+        .success();
+    let after = std::fs::symlink_metadata(&f).unwrap();
+    assert_eq!(
+        (after.mtime(), after.mtime_nsec()),
+        (mtime_s_before, mtime_ns_before),
+        "mtime must be preserved"
+    );
+    assert_ne!(
+        (after.ctime(), after.ctime_nsec()),
+        (ctime_s_before, ctime_ns_before),
+        "ctime is expected to move"
+    );
+}
+
+#[test]
+fn include_filter_changes_matches_not_traversed_dirs() {
+    // with --include '*.txt', only matching files are modified; directories entered
+    // only to find matches (and non-matching files) are left untouched.
+    let d = tempfile::tempdir().unwrap();
+    let sub = d.path().join("sub");
+    std::fs::create_dir(&sub).unwrap();
+    let txt = sub.join("a.txt");
+    let other = sub.join("b.dat");
+    std::fs::write(&txt, b"x").unwrap();
+    std::fs::write(&other, b"x").unwrap();
+    std::fs::set_permissions(&txt, std::fs::Permissions::from_mode(0o644)).unwrap();
+    std::fs::set_permissions(&other, std::fs::Permissions::from_mode(0o644)).unwrap();
+    std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o755)).unwrap();
+    rchm()
+        .args(["--mode", "g+w", "--include", "*.txt"])
+        .arg(d.path())
+        .assert()
+        .success();
+    assert_eq!(mode_of(&txt), 0o664, "matching file must change");
+    assert_eq!(
+        mode_of(&other),
+        0o644,
+        "non-matching file must be untouched"
+    );
+    assert_eq!(mode_of(&sub), 0o755, "traversed-only dir must be untouched");
+}
+
+#[test]
+fn skips_already_correct_entries() {
+    let d = tempfile::tempdir().unwrap();
+    let f = d.path().join("f.txt");
+    std::fs::write(&f, b"x").unwrap();
+    std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o664)).unwrap();
+    let out = rchm()
+        .args(["--mode", "g+w", "--summary"])
+        .arg(d.path())
+        .assert()
+        .success();
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.contains("files unchanged: 1"),
+        "stdout was: {stdout}"
+    );
+    assert!(stdout.contains("files changed: 0"), "stdout was: {stdout}");
+}
+
+#[test]
+fn mode_on_symlink_operand_does_not_follow_to_target() {
+    let d = tempfile::tempdir().unwrap();
+    let target = d.path().join("target.txt");
+    std::fs::write(&target, b"x").unwrap();
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let link = d.path().join("link");
+    symlink(&target, &link).unwrap();
+    let target_mode_before = mode_of(&target);
+    // mode applies only to files+dirs; symlink mode untouched, target untouched by traversal
+    rchm().args(["--mode", "g+w"]).arg(&link).assert().success();
+    assert_eq!(
+        mode_of(&target),
+        target_mode_before,
+        "symlink target must be untouched"
+    );
+}
+
+#[test]
+fn preserves_setgid_through_mode_change() {
+    // a mode change must not disturb the setgid bit. (the chown-clears-setgid
+    // restore path needs a real chown and is covered by the compute_plan unit
+    // test `plan_preserves_setgid_across_chgrp`.)
+    let d = tempfile::tempdir().unwrap();
+    let f = d.path().join("f.txt");
+    std::fs::write(&f, b"x").unwrap();
+    std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o2775)).unwrap();
+    rchm()
+        .args(["--mode", "g-w"])
+        .arg(d.path())
+        .assert()
+        .success();
+    assert_eq!(mode_of(&f), 0o2755, "group write removed, setgid kept");
+}
+
+#[test]
+fn preorder_dir_lockout_applies_change_then_reports() {
+    // default pre-order: removing the dir's own traversal permission applies the change,
+    // then can't descend -> reports an error (exit nonzero) but keeps going. Processing
+    // contents first instead is what --defer-dir-changes is for (tested separately).
+    let d = tempfile::tempdir().unwrap();
+    std::fs::write(d.path().join("f.txt"), b"x").unwrap();
+    rchm()
+        .args(["--mode", "d:a-rwx"])
+        .arg(d.path())
+        .assert()
+        .failure();
+    assert_eq!(
+        mode_of(d.path()),
+        0o000,
+        "the directory's own change is applied (pre-order) even though descent fails"
+    );
+    // restore so tempdir cleanup works
+    std::fs::set_permissions(d.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[test]
+fn dry_run_makes_no_changes() {
+    let d = tempfile::tempdir().unwrap();
+    let f = d.path().join("f.txt");
+    std::fs::write(&f, b"x").unwrap();
+    std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o644)).unwrap();
+    rchm()
+        .args(["--mode", "g+w", "--dry-run", "brief"])
+        .arg(d.path())
+        .assert()
+        .success();
+    assert_eq!(mode_of(&f), 0o644, "dry-run must not change anything");
+}
+
+#[test]
+fn exclude_filter_narrows_the_set() {
+    let d = tempfile::tempdir().unwrap();
+    let keep = d.path().join("keep.txt");
+    let skip = d.path().join("skip.log");
+    std::fs::write(&keep, b"x").unwrap();
+    std::fs::write(&skip, b"x").unwrap();
+    std::fs::set_permissions(&keep, std::fs::Permissions::from_mode(0o644)).unwrap();
+    std::fs::set_permissions(&skip, std::fs::Permissions::from_mode(0o644)).unwrap();
+    rchm()
+        .args(["--mode", "g+w", "--exclude", "*.log"])
+        .arg(d.path())
+        .assert()
+        .success();
+    assert_eq!(mode_of(&keep), 0o664);
+    assert_eq!(mode_of(&skip), 0o644, "*.log must be excluded");
+}
+
+#[test]
+fn symlink_root_with_trailing_slash_is_not_dereferenced() {
+    // a trailing slash on a symlink root must not dereference it into its target dir.
+    let d = tempfile::tempdir().unwrap();
+    let target = d.path().join("target");
+    std::fs::create_dir(&target).unwrap();
+    let inside = target.join("f.txt");
+    std::fs::write(&inside, b"x").unwrap();
+    std::fs::set_permissions(&inside, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let link = d.path().join("link");
+    symlink(&target, &link).unwrap();
+    let mut operand = link.into_os_string();
+    operand.push("/");
+    rchm()
+        .args(["--mode", "g+w"])
+        .arg(&operand)
+        .assert()
+        .success();
+    assert_eq!(
+        mode_of(&inside),
+        0o644,
+        "must not descend into the symlink target"
+    );
+}
+
+#[test]
+fn recovers_unreadable_directory() {
+    // pre-order default: d:u+rwx makes a 000 dir traversable, then descends and fixes contents.
+    let d = tempfile::tempdir().unwrap();
+    let dir = d.path().join("dir000");
+    std::fs::create_dir(&dir).unwrap();
+    let inner = dir.join("f");
+    std::fs::write(&inner, b"x").unwrap();
+    std::fs::set_permissions(&inner, std::fs::Permissions::from_mode(0o644)).unwrap();
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+    rchm()
+        .args(["--mode", "d:u+rwx f:g+w"])
+        .arg(&dir)
+        .assert()
+        .success();
+    assert_eq!(mode_of(&dir), 0o700, "unreadable dir recovered");
+    assert_eq!(mode_of(&inner), 0o664, "contents reached after recovery");
+}
+
+#[test]
+fn child_failure_does_not_block_parent_change() {
+    // default keep-going: an unreadable child fails, but the parent's own change still applies.
+    let d = tempfile::tempdir().unwrap();
+    let parent = d.path().join("parent");
+    let child = parent.join("child");
+    std::fs::create_dir_all(&child).unwrap();
+    std::fs::set_permissions(&child, std::fs::Permissions::from_mode(0o000)).unwrap();
+    std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o700)).unwrap();
+    // the run reports the child failure (exit nonzero) but still changes the parent
+    rchm()
+        .args(["--mode", "d:g+w"])
+        .arg(&parent)
+        .assert()
+        .failure();
+    assert_eq!(
+        mode_of(&parent),
+        0o720,
+        "parent changed despite child failure"
+    );
+    std::fs::set_permissions(&child, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[test]
+fn defer_dir_changes_allows_removing_owner_traversal() {
+    // --defer-dir-changes (post-order): process contents first, then strip the dir's perms.
+    let d = tempfile::tempdir().unwrap();
+    let t = d.path().join("t");
+    let sub = t.join("sub");
+    std::fs::create_dir_all(&sub).unwrap();
+    rchm()
+        .args(["--mode", "d:a-rwx", "--defer-dir-changes"])
+        .arg(&t)
+        .assert()
+        .success();
+    assert_eq!(
+        mode_of(&t),
+        0o000,
+        "dir stripped after its contents were processed"
+    );
+    // restore so tempdir cleanup works — outermost first to regain traversal
+    std::fs::set_permissions(&t, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[test]
+fn defer_dir_changes_with_fail_early_does_not_change_ancestor_after_child_error() {
+    // --defer-dir-changes + --fail-early: a child failure must stop the run before the
+    // deferred parent change is applied (no changes after the error we were told to stop on).
+    let d = tempfile::tempdir().unwrap();
+    let parent = d.path().join("parent");
+    let child = parent.join("child");
+    std::fs::create_dir_all(&child).unwrap();
+    std::fs::set_permissions(&child, std::fs::Permissions::from_mode(0o000)).unwrap();
+    std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o700)).unwrap();
+    rchm()
+        .args(["--mode", "d:g+w", "--defer-dir-changes", "--fail-early"])
+        .arg(&parent)
+        .assert()
+        .failure();
+    assert_eq!(
+        mode_of(&parent),
+        0o700,
+        "fail-early must stop before the deferred parent change"
+    );
+    std::fs::set_permissions(&child, std::fs::Permissions::from_mode(0o755)).unwrap();
+}


### PR DESCRIPTION
## Summary
- Adds **`rchm`**, a fast recursive `chmod`/`chgrp`/`chown` tool for large filesets — a drop-in replacement for mpifileutils `dchmod` (as `rcp` is for `dcp`). Logic lives in `common/src/chmod.rs` (mirroring `common/src/rm.rs`); the binary crate is `rchm/`.
- **Per-type DSL** shared by `--mode`/`--group`/`--owner`: a bare value applies to all entries (dchmod-compatible); `f:`/`d:`/`l:` prefixes target files / directories / symlinks. `--mode` supports symbolic (`g+rwX`, conditional `X`, setuid/setgid/sticky) and octal, and covers files + directories only — symlink mode bits aren't settable on Linux, so `l:` is rejected for `--mode`. `--group`/`--owner` apply to symlinks too via `lchown`.
- Skips **no-op** entries (computed from the walk's existing `lstat`), processes directories **post-order** to avoid self-lockout when removing permissions, **preserves setuid/setgid across chown**, and **preserves `mtime`** (`ctime` necessarily changes and cannot be preserved). Reuses the shared throttling (incl. the adaptive metadata controller), filtering (`--include`/`--exclude`/`--filter-file`/time filters), progress, `--dry-run`, and `--summary` infrastructure.
- Mode expressions are a subset of `chmod` (`[ugoa][+-=][rwxXst]`, octal, conditional `X`); who-copy refs like `g=u` are not supported. `rchm` never dereferences symlinks (like `-h`). Documented in the README "Compatibility with chmod/chown/chgrp" section.

## Test Plan
- [x] `just ci` — lint (fmt, clippy `-D warnings`, error-logging, package-metadata, …), `just doc` (`-D` rustdoc warnings), debug + release nextest (922 tests) + doctests, and Docker chaos + multi-host tests (48) — all green
- [x] Unit tests in `common/src/chmod.rs`: DSL parsing (`--mode`/`--group`/`--owner`, bare vs `f:`/`d:`/`l:`, rejections), symbolic mode evaluation (sticky responds only to `o`/`a`, conditional `X`, `=` clearing, octal), `compute_plan` (no-op skip, chown selectivity, setuid/setgid preservation across chown)
- [x] Integration tests in `rchm/tests/tests.rs` (debug + release): per-type modes applied recursively, **mtime preserved & ctime moved**, no-op entries reported unchanged, symlink operand not followed, setgid preserved through a mode change, post-order permission removal without self-lockout, dry-run makes no changes, exclude filter narrows the set
- [x] CLI parsing tests in `rchm/tests/cli_parsing_tests.rs`: required-op error, `l:` rejected for `--mode`, unknown group rejected, `--help` lists the operation flags
