### PR TITLE
Add `--delete` (rsync-style mirror) to rcp and rlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add `--delete` (rsync-style mirror) to `rcp` and `rlink`: removes destination
+  entries with no source counterpart. Implies `--overwrite`; supports
+  `--delete-excluded`; honors `--dry-run`. Local operations only for now (remote
+  `rcp` support planned).
 - Add `rchm`: a fast recursive chmod/chgrp/chown tool for large filesets (a `dchmod` replacement), with a per-type `--mode`/`--group`/`--owner` DSL, no-op skipping, pre-order directory changes by default (so `--mode d:u+rwx` can repair an unreadable directory; `--defer-dir-changes` applies directories after their contents), progress, filtering, and throttling.
 
 ## [0.32.0] - 2026-05-16

--- a/README.md
+++ b/README.md
@@ -471,6 +471,34 @@ Preview what would happen without making changes:
 
 `rcp` tools will not-overwrite pre-existing data unless used with the `--overwrite` flag.
 
+## Delete (mirror)
+
+`rcp --delete` makes the destination a mirror of the source: any entry under the
+destination with no counterpart in the source is removed. `--delete` implies
+`--overwrite`, requires a single source, and cannot be combined with
+`--dereference` (`-L`). `rlink --delete` works the same way for hard-linked trees.
+
+```fish
+# make dst an exact mirror of src (removing anything in dst not present in src)
+> rcp --delete src dst --progress --summary
+```
+
+Excluded files are protected from deletion by default; pass `--delete-excluded`
+to remove them too. `--dry-run` previews deletions without performing them. `--delete` is
+supported for local operations (remote support is planned).
+
+Exclude-protection applies to pruning *extraneous* entries — those
+with no source counterpart. When `--overwrite` (implied by `--delete`) replaces a destination
+entry whose source counterpart changed type — e.g. a directory that is now a file in the source
+— removing the old destination entry is part of that overwrite, not an exclude-filtered
+deletion.
+
+Pruning happens incrementally as the parallel copy proceeds, and a directory's extraneous
+entries are removed only once that directory's subtree has been processed without error — so
+deletions never act on an incomplete source listing. Unlike rsync, rcp/rlink do not cancel
+*all* deletions when a single error occurs elsewhere: subtrees that were processed cleanly are
+still mirrored.
+
 Performance Tuning
 ==================
 

--- a/common/src/chmod.rs
+++ b/common/src/chmod.rs
@@ -742,7 +742,7 @@ async fn chmod_internal(
     // a directory may have been entered only because it *could contain* include-matches,
     // not because it directly matches an include pattern. such "traversed-only" dirs are
     // not modified themselves (mirrors rm.rs) -- only entries the filter directly selects.
-    let relative_path = path.strip_prefix(source_root).unwrap_or(path);
+    let relative_path = walk::relative_to_root(path, source_root);
     let traversed_only = settings
         .filter
         .as_ref()
@@ -789,7 +789,7 @@ async fn chmod_internal(
                     };
                 let entry_path = entry.path();
                 let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
-                let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
+                let relative_path = walk::relative_to_root(&entry_path, source_root);
                 if let Some(skip_result) = walk::should_skip_entry(
                     &settings.filter,
                     relative_path,

--- a/common/src/cmp.rs
+++ b/common/src/cmp.rs
@@ -663,7 +663,7 @@ async fn cmp_internal(
         // apply filter if configured
         if let Some(ref filter) = settings.filter {
             // compute relative path from source_root for filter matching
-            let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
+            let relative_path = crate::walk::relative_to_root(&entry_path, source_root);
             let is_dir = entry_file_type.map(|ft| ft.is_dir()).unwrap_or(false);
             if !matches!(
                 filter.should_include(relative_path, is_dir),
@@ -743,7 +743,7 @@ async fn cmp_internal(
         // apply filter if configured - if this entry would be filtered, don't report as missing
         if let Some(ref filter) = settings.filter {
             // compute relative path from dest_root for filter matching
-            let relative_path = entry_path.strip_prefix(dest_root).unwrap_or(&entry_path);
+            let relative_path = crate::walk::relative_to_root(&entry_path, dest_root);
             let is_dir = entry_file_type.map(|ft| ft.is_dir()).unwrap_or(false);
             if !matches!(
                 filter.should_include(relative_path, is_dir),
@@ -873,6 +873,7 @@ mod cmp_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             if preserve {
                 &DO_PRESERVE_SETTINGS

--- a/common/src/copy.rs
+++ b/common/src/copy.rs
@@ -36,6 +36,18 @@ impl std::fmt::Display for OverwriteFilter {
     }
 }
 
+/// Settings controlling rsync-style `--delete` (mirror) behavior.
+///
+/// Present (`Some`) only when `--delete` was requested. `None` means the
+/// destination is never enumerated and no pruning work is done, so the default
+/// copy path pays nothing for this feature.
+#[derive(Debug, Clone)]
+pub struct DeleteSettings {
+    /// Also remove destination entries that match an exclude pattern
+    /// (rsync `--delete-excluded`). When false, excluded entries are protected.
+    pub delete_excluded: bool,
+}
+
 #[derive(Debug, Clone)]
 pub struct Settings {
     pub dereference: bool,
@@ -57,6 +69,8 @@ pub struct Settings {
     pub filter: Option<crate::filter::FilterSettings>,
     /// dry-run mode for previewing operations
     pub dry_run: Option<crate::config::DryRunMode>,
+    /// rsync-style `--delete` settings; `None` disables deletion entirely.
+    pub delete: Option<DeleteSettings>,
 }
 
 /// Summary with the appropriate `*_skipped` counter set to 1 for the given entry kind.
@@ -364,6 +378,33 @@ pub async fn copy(
     preserve: &preserve::Settings,
     is_fresh: bool,
 ) -> Result<Summary, Error> {
+    copy_with_filter_base(
+        prog_track,
+        src,
+        dst,
+        settings,
+        preserve,
+        is_fresh,
+        std::path::Path::new(""),
+    )
+    .await
+}
+
+/// Like [`copy`], but treats `src` as living at `filter_base` relative to the original filter
+/// root. Used when `rlink` delegates an update-only entry to `copy`: `--delete` pruning inside
+/// the delegated subtree then matches the include/exclude filter at the entry's true relative
+/// path (e.g. `cache/*.log`) instead of relative to the delegated root.
+#[instrument(skip(prog_track, settings, preserve))]
+#[allow(clippy::too_many_arguments)]
+pub async fn copy_with_filter_base(
+    prog_track: &'static progress::Progress,
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    settings: &Settings,
+    preserve: &preserve::Settings,
+    is_fresh: bool,
+    filter_base: &std::path::Path,
+) -> Result<Summary, Error> {
     // check filter for top-level source (files, directories, and symlinks)
     if let Some(ref filter) = settings.filter {
         let src_name = src.file_name().map(std::path::Path::new);
@@ -377,7 +418,14 @@ pub async fn copy(
             .with_context(|| format!("failed reading metadata from src: {:?}", &src))
             .map_err(|err| Error::new(err, Default::default()))?;
             let is_dir = src_metadata.is_dir();
-            let result = filter.should_include_root_item(name, is_dir);
+            // for a delegated subtree (non-empty filter_base) the source is not the true filter
+            // root, so match it at its logical path with nested semantics; for a normal copy use
+            // root-item semantics (anchored patterns don't apply to the root itself).
+            let result = if filter_base.as_os_str().is_empty() {
+                filter.should_include_root_item(name, is_dir)
+            } else {
+                filter.should_include(filter_base, is_dir)
+            };
             match result {
                 crate::filter::FilterResult::Included => {}
                 result => {
@@ -392,7 +440,15 @@ pub async fn copy(
         }
     }
     copy_internal(
-        prog_track, src, dst, src, settings, preserve, is_fresh, None,
+        prog_track,
+        src,
+        dst,
+        src,
+        settings,
+        preserve,
+        is_fresh,
+        None,
+        filter_base,
     )
     .await
 }
@@ -409,6 +465,7 @@ async fn copy_internal(
     preserve: &preserve::Settings,
     mut is_fresh: bool,
     open_file_guard: Option<throttle::OpenFileGuard>,
+    filter_base: &std::path::Path,
 ) -> Result<Summary, Error> {
     let _ops_guard = prog_track.ops.guard();
     tracing::debug!("reading source metadata");
@@ -824,6 +881,12 @@ async fn copy_internal(
     // this is used later to decide if we should clean up an empty directory
     let we_created_this_dir = copy_summary.directories_created == 1;
     let mut join_set = tokio::task::JoinSet::new();
+    // names of source entries that pass the filter; used by --delete to decide
+    // which destination entries are extraneous. only populated when --delete is
+    // active; an empty HashSet has zero heap cost until the first insert, so the
+    // default path pays only a stack word.
+    let mut keep_set: std::collections::HashSet<std::ffi::OsString> =
+        std::collections::HashSet::new();
     let errors = crate::error_collector::ErrorCollector::default();
     loop {
         let Some((entry, entry_file_type)) =
@@ -840,11 +903,13 @@ async fn copy_internal(
         let dst_path = dst.join(entry_name);
         let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
         let entry_is_dir = entry_kind == EntryKind::Dir;
-        // compute relative path from source_root for filter matching
-        let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
+        // compute the path relative to the original filter root: `filter_base` is empty for a
+        // normal copy and non-empty for an rlink-delegated update subtree, so copy-side filtering
+        // matches the same logical path that delete pruning uses (e.g. `cache/keep.txt`).
+        let relative_path = filter_base.join(walk::relative_to_root(&entry_path, source_root));
         // apply filter if configured
         if let Some(skip_result) =
-            walk::should_skip_entry(&settings.filter, relative_path, entry_is_dir)
+            walk::should_skip_entry(&settings.filter, &relative_path, entry_is_dir)
         {
             if let Some(mode) = settings.dry_run {
                 crate::dry_run::report_skip(&entry_path, &skip_result, mode, entry_kind.label());
@@ -853,6 +918,12 @@ async fn copy_internal(
             copy_summary = copy_summary + skipped_summary_for(entry_kind);
             entry_kind.inc_skipped(prog_track);
             continue;
+        }
+        // record this name as authoritative for --delete: it has a source counterpart, so its
+        // destination counterpart must not be pruned — even when --skip-specials skips copying
+        // it (computed before the skip-specials check below for exactly that reason).
+        if settings.delete.is_some() {
+            keep_set.insert(entry_name.to_owned());
         }
         // skip special files (sockets, FIFOs, devices) when --skip-specials is set
         if settings.skip_specials && entry_kind == EntryKind::Special {
@@ -892,6 +963,7 @@ async fn copy_internal(
         let settings = settings.clone();
         let preserve = *preserve;
         let source_root = source_root.to_owned();
+        let filter_base = filter_base.to_owned();
         let do_copy = || async move {
             copy_internal(
                 prog_track,
@@ -902,6 +974,7 @@ async fn copy_internal(
                 &preserve,
                 is_fresh,
                 open_file_guard,
+                &filter_base,
             )
             .await
         };
@@ -931,6 +1004,43 @@ async fn copy_internal(
             }
         }
     }
+    // rsync-style --delete: remove destination entries with no source counterpart.
+    // runs only when --delete was requested; reaching here means the full set of
+    // source children for this directory is known (all spawned tasks have joined).
+    if let Some(delete_settings) = &settings.delete {
+        if errors.has_errors() {
+            // rsync-style safety: skip pruning when this subtree's copy reported errors —
+            // deleting based on a run that did not fully succeed could remove data
+            // unexpectedly. (rsync likewise skips --delete on I/O errors.)
+            tracing::warn!(
+                "skipping --delete pruning of {:?} because the copy reported errors",
+                dst
+            );
+        } else {
+            let relative_dir = filter_base.join(walk::relative_to_root(src, source_root));
+            match crate::delete::prune_extraneous(
+                prog_track,
+                dst,
+                &relative_dir,
+                &keep_set,
+                settings.filter.as_ref(),
+                delete_settings,
+                settings.fail_early,
+                settings.dry_run,
+            )
+            .await
+            {
+                Ok(rm_summary) => copy_summary.rm_summary = copy_summary.rm_summary + rm_summary,
+                Err(err) => {
+                    copy_summary.rm_summary = copy_summary.rm_summary + err.summary;
+                    if settings.fail_early {
+                        return Err(Error::new(err.source, copy_summary));
+                    }
+                    errors.push(err.source);
+                }
+            }
+        }
+    }
     // when filtering is active and we created this directory, check if anything was actually
     // copied into it. if nothing was copied, we may need to clean up the empty directory.
     let this_dir_count = usize::from(we_created_this_dir);
@@ -940,13 +1050,13 @@ async fn copy_internal(
     let anything_copied = copy_summary.files_copied > 0
         || copy_summary.symlinks_created > 0
         || child_dirs_created > 0;
-    let relative_path = src.strip_prefix(source_root).unwrap_or(src);
+    let relative_path = filter_base.join(walk::relative_to_root(src, source_root));
     let is_root = src == source_root;
     match check_empty_dir_cleanup(
         settings.filter.as_ref(),
         we_created_this_dir,
         anything_copied,
-        relative_path,
+        &relative_path,
         is_root,
         settings.dry_run.is_some(),
     ) {
@@ -1032,6 +1142,240 @@ mod copy_tests {
     static DO_PRESERVE_SETTINGS: std::sync::LazyLock<preserve::Settings> =
         std::sync::LazyLock::new(preserve::preserve_all);
 
+    fn settings_with_delete(delete: Option<DeleteSettings>) -> Settings {
+        Settings {
+            dereference: false,
+            fail_early: false,
+            overwrite: delete.is_some(), // --delete implies --overwrite
+            overwrite_compare: filecmp::MetadataCmpSettings {
+                size: true,
+                mtime: true,
+                ..Default::default()
+            },
+            overwrite_filter: None,
+            ignore_existing: false,
+            chunk_size: 0,
+            skip_specials: false,
+            remote_copy_buffer_size: 0,
+            filter: None,
+            dry_run: None,
+            delete,
+        }
+    }
+
+    fn delete_on() -> Option<DeleteSettings> {
+        Some(DeleteSettings {
+            delete_excluded: false,
+        })
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn delete_protects_skipped_special_name() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::setup_test_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("src_dir");
+        let dst = test_path.join("dst_dir");
+        tokio::fs::create_dir(&src).await?;
+        tokio::fs::write(src.join("file.txt"), "hello").await?;
+        // a special file in the source that --skip-specials will skip copying
+        nix::unistd::mkfifo(
+            &src.join("pipe"),
+            nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+        )?;
+        // pre-existing destination: a counterpart for the skipped special, plus a genuine extra
+        tokio::fs::create_dir(&dst).await?;
+        tokio::fs::write(dst.join("pipe"), "old").await?;
+        tokio::fs::write(dst.join("stale.txt"), "junk").await?;
+
+        let mut settings = settings_with_delete(delete_on());
+        settings.skip_specials = true;
+        let summary = copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings,
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+
+        assert_eq!(summary.specials_skipped, 1);
+        assert!(dst.join("file.txt").exists());
+        assert!(
+            dst.join("pipe").exists(),
+            "a destination entry matching a skipped special must not be pruned (it has a source counterpart)"
+        );
+        assert!(!dst.join("stale.txt").exists()); // genuine extra removed
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn delete_removes_extraneous_destination_entries() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::setup_test_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("foo");
+        let dst = test_path.join("bar");
+        // initial copy (no delete)
+        copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(None),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        // introduce extraneous entries at the destination
+        tokio::fs::write(dst.join("extraneous.txt"), b"junk").await?;
+        tokio::fs::create_dir(dst.join("extra_dir")).await?;
+        tokio::fs::write(dst.join("extra_dir").join("nested.txt"), b"junk").await?;
+        // re-copy with --delete
+        let summary = copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(delete_on()),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        assert_eq!(summary.rm_summary.files_removed, 2); // extraneous.txt + extra_dir/nested.txt
+        assert_eq!(summary.rm_summary.directories_removed, 1); // extra_dir
+        assert!(!dst.join("extraneous.txt").exists());
+        assert!(!dst.join("extra_dir").exists());
+        testutils::check_dirs_identical(&src, &dst, testutils::FileEqualityCheck::Basic).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn delete_prunes_extraneous_at_depth() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::setup_test_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("foo");
+        let dst = test_path.join("bar");
+        copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(None),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        // foo/bar is a common subdirectory; place a stale file inside the dst copy of it
+        let nested = dst.join("bar");
+        assert!(
+            nested.is_dir(),
+            "expected common subdirectory bar/ to exist at destination"
+        );
+        tokio::fs::write(nested.join("stale_nested.txt"), b"junk").await?;
+        let summary = copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(delete_on()),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        assert!(
+            !nested.join("stale_nested.txt").exists(),
+            "stale entry inside a common subdirectory must be pruned"
+        );
+        assert!(summary.rm_summary.files_removed >= 1);
+        testutils::check_dirs_identical(&src, &dst, testutils::FileEqualityCheck::Basic).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn delete_removes_extraneous_symlink() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::setup_test_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("foo");
+        let dst = test_path.join("bar");
+        copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(None),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        // an extraneous symlink at the destination root (no source counterpart)
+        tokio::fs::symlink("/nonexistent/target", dst.join("stale_link")).await?;
+        let summary = copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(delete_on()),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        assert!(
+            tokio::fs::symlink_metadata(dst.join("stale_link"))
+                .await
+                .is_err(),
+            "extraneous symlink must be removed"
+        );
+        assert_eq!(summary.rm_summary.symlinks_removed, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn delete_skips_pruning_when_copy_has_errors() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::setup_test_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("foo");
+        let dst = test_path.join("bar");
+        // baseline copy establishes the destination
+        copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(None),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        // an extraneous file that --delete would normally prune
+        tokio::fs::write(dst.join("extraneous.txt"), b"junk").await?;
+        // make a source sub-directory unreadable so traversal fails (fail_early is false).
+        // a directory (not a file) is used because --overwrite with mtime-equal files skips
+        // copying identical files; a directory's read_dir fails unconditionally when mode is 0o000.
+        let unreadable = src.join("baz");
+        let original = tokio::fs::metadata(&unreadable).await?.permissions();
+        tokio::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).await?;
+
+        let result = copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(delete_on()),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await;
+
+        tokio::fs::set_permissions(&unreadable, original).await?;
+
+        assert!(
+            result.is_err(),
+            "copy of the unreadable directory should fail"
+        );
+        assert!(
+            dst.join("extraneous.txt").exists(),
+            "pruning must be skipped when the copy reported errors"
+        );
+        Ok(())
+    }
+
     #[tokio::test]
     #[traced_test]
     async fn check_basic_copy() -> Result<(), anyhow::Error> {
@@ -1057,6 +1401,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -1107,6 +1452,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -1184,6 +1530,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -1253,6 +1600,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -1302,6 +1650,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -1399,6 +1748,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             false,
         )
@@ -1427,6 +1777,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             true,
         )
@@ -1455,6 +1806,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             false,
         )
@@ -1483,6 +1835,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             true,
         )
@@ -1513,6 +1866,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS,
             false,
@@ -1586,6 +1940,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS,
             false,
@@ -1671,6 +2026,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS,
             false,
@@ -1755,6 +2111,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS,
             false,
@@ -1842,6 +2199,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS,
             false,
@@ -1890,6 +2248,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS, // we want timestamps to differ!
             false,
@@ -1938,6 +2297,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS,
             false,
@@ -1994,6 +2354,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -2042,6 +2403,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -2089,6 +2451,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -2137,6 +2500,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -2175,6 +2539,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -2215,6 +2580,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -2252,6 +2618,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -2305,6 +2672,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &NO_PRESERVE_SETTINGS,
             false,
@@ -2377,6 +2745,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS,
             false,
@@ -2438,6 +2807,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS, // <- important!
             false,
@@ -2459,6 +2829,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS,
             false,
@@ -2516,6 +2887,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS,
             false,
@@ -2576,6 +2948,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: None,
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -2617,6 +2990,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: None,
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -2661,6 +3035,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: None,
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -2711,6 +3086,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: None,
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -2868,6 +3244,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS,
             false,
@@ -2936,6 +3313,7 @@ mod copy_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             &DO_PRESERVE_SETTINGS,
             false,
@@ -2993,6 +3371,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3049,6 +3428,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3109,6 +3489,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3146,6 +3527,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3189,6 +3571,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3236,6 +3619,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3283,6 +3667,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3341,6 +3726,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3400,6 +3786,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3465,6 +3852,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3527,6 +3915,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: Some(crate::config::DryRunMode::Explain),
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3589,6 +3978,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3653,6 +4043,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: None,
                     dry_run: Some(crate::config::DryRunMode::Brief),
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3709,6 +4100,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3758,6 +4150,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: Some(filter),
                     dry_run: Some(crate::config::DryRunMode::Explain),
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3811,6 +4204,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: None,
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -3868,6 +4262,7 @@ mod copy_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     &NO_PRESERVE_SETTINGS,
                     false,
@@ -3944,6 +4339,7 @@ mod copy_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     &NO_PRESERVE_SETTINGS,
                     false,
@@ -3996,6 +4392,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: None,
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -4038,6 +4435,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: None,
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -4076,6 +4474,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: None,
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -4115,6 +4514,7 @@ mod copy_tests {
                     remote_copy_buffer_size: 0,
                     filter: None,
                     dry_run: None,
+                    delete: None,
                 },
                 &NO_PRESERVE_SETTINGS,
                 false,
@@ -4125,5 +4525,145 @@ mod copy_tests {
             assert!(!dst.exists());
             Ok(())
         }
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn delete_protects_excluded_then_removes_with_delete_excluded()
+    -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::setup_test_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("foo");
+        let dst = test_path.join("bar");
+        copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(None),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        // a destination-only file that matches an exclude pattern
+        tokio::fs::write(dst.join("keep.log"), b"protected").await?;
+
+        let mut filter = crate::filter::FilterSettings::new();
+        filter.add_exclude("*.log")?;
+
+        // default --delete: keep.log is protected
+        let mut settings = settings_with_delete(delete_on());
+        settings.filter = Some(filter.clone());
+        copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings,
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        assert!(
+            dst.join("keep.log").exists(),
+            "*.log must be protected by default"
+        );
+
+        // --delete-excluded: keep.log is removed
+        let mut settings = settings_with_delete(Some(DeleteSettings {
+            delete_excluded: true,
+        }));
+        settings.filter = Some(filter);
+        copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings,
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        assert!(!dst.join("keep.log").exists());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn delete_dry_run_reports_without_removing() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::setup_test_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("foo");
+        let dst = test_path.join("bar");
+        copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(None),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        tokio::fs::write(dst.join("stale.txt"), b"junk").await?;
+
+        let mut settings = settings_with_delete(delete_on());
+        settings.dry_run = Some(crate::config::DryRunMode::Brief);
+        let summary = copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings,
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+
+        // the key invariant: dry-run must NOT remove anything
+        assert!(
+            dst.join("stale.txt").exists(),
+            "dry-run must not remove anything"
+        );
+        // rm's dry-run does count would-be removals in files_removed
+        assert_eq!(summary.rm_summary.files_removed, 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn delete_does_not_prune_when_source_unreadable() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::setup_test_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("foo");
+        let dst = test_path.join("bar");
+        copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(None),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        tokio::fs::write(dst.join("stale.txt"), b"junk").await?;
+        // make the source directory unreadable so enumeration fails
+        let original = tokio::fs::metadata(&src).await?.permissions();
+        tokio::fs::set_permissions(&src, std::fs::Permissions::from_mode(0o000)).await?;
+
+        let result = copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(delete_on()),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await;
+
+        // restore permissions before asserting (so the temp dir cleans up)
+        tokio::fs::set_permissions(&src, original).await?;
+
+        assert!(result.is_err(), "unreadable source must error");
+        assert!(
+            dst.join("stale.txt").exists(),
+            "destination must not be pruned when source enumeration fails"
+        );
+        Ok(())
     }
 }

--- a/common/src/delete.rs
+++ b/common/src/delete.rs
@@ -1,0 +1,387 @@
+//! rsync-style `--delete` (mirror) support: remove destination entries that
+//! have no counterpart in the source directory.
+
+use crate::copy::DeleteSettings;
+use crate::progress;
+
+/// Remove entries in `dst` whose names are not in `keep` (the source entry
+/// names that passed the filter for this directory).
+///
+/// `relative_dir` is this directory's path relative to the source root, used to
+/// match destination entries against `filter` for exclude-protection. Excluded
+/// destination entries are protected (kept) unless `delete_settings.delete_excluded`
+/// is set. Honors `dry_run` (reports without removing, via [`crate::rm::rm`]).
+#[allow(clippy::too_many_arguments)]
+pub async fn prune_extraneous(
+    prog_track: &'static progress::Progress,
+    dst: &std::path::Path,
+    relative_dir: &std::path::Path,
+    keep: &std::collections::HashSet<std::ffi::OsString>,
+    filter: Option<&crate::filter::FilterSettings>,
+    delete_settings: &DeleteSettings,
+    fail_early: bool,
+    dry_run: Option<crate::config::DryRunMode>,
+) -> Result<crate::rm::Summary, crate::rm::Error> {
+    let mut summary = crate::rm::Summary::default();
+    // Destination root: `dst` with this directory's source-relative path stripped. Removed
+    // descendants are matched against the filter relative to this root, so their full (mirror)
+    // relative paths are used — making path/anchored excludes like `cache/*.log` protect
+    // descendants correctly, not just simple basename patterns.
+    let mut dest_root = dst;
+    for _ in relative_dir.components() {
+        dest_root = dest_root.parent().unwrap_or(dest_root);
+    }
+    // In --dry-run the create-or-overwrite step is skipped, so `dst` may still be a file,
+    // symlink, or even a symlink-to-directory at this point. `read_dir` follows symlinks, so
+    // without a `symlink_metadata` pre-check it would walk the symlink's target and preview
+    // deletions OUTSIDE the destination tree. In a real run this can't happen — upstream
+    // create_dir/overwrite guarantees `dst` is a real directory by the time prune runs — so
+    // skip the extra stat there to keep the hot path cheap.
+    if dry_run.is_some() {
+        match tokio::fs::symlink_metadata(dst).await {
+            Ok(meta) if meta.file_type().is_dir() => { /* real directory: fall through */ }
+            Ok(_) => {
+                // not a real directory (file, symlink, special) — nothing to prune
+                return Ok(summary);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(summary);
+            }
+            Err(err) => {
+                return Err(crate::rm::Error::new(
+                    anyhow::Error::new(err)
+                        .context(format!("cannot stat destination {dst:?} for delete scan")),
+                    summary,
+                ));
+            }
+        }
+    }
+    let mut entries = match tokio::fs::read_dir(dst).await {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            // destination directory absent (e.g. dry-run never created it): nothing to prune
+            return Ok(summary);
+        }
+        Err(err)
+            if err.kind() == std::io::ErrorKind::NotADirectory
+                || err.raw_os_error() == Some(20) =>
+        {
+            // destination counterpart is not a directory: e.g. `--dry-run --delete` where the real
+            // run would replace a file/symlink at this path with a directory before pruning, but
+            // dry-run skips that overwrite. There is nothing to prune. (In dry-run we already
+            // handled the non-dir case via symlink_metadata above; this arm remains as defense in
+            // depth against a race between that stat and the read_dir below.)
+            return Ok(summary);
+        }
+        Err(err) => {
+            return Err(crate::rm::Error::new(
+                anyhow::Error::new(err)
+                    .context(format!("cannot open destination {dst:?} for delete scan")),
+                summary,
+            ));
+        }
+    };
+    let errors = crate::error_collector::ErrorCollector::default();
+    loop {
+        let (entry, entry_file_type) = match crate::walk::next_entry_probed(
+            &mut entries,
+            congestion::Side::Destination,
+            || format!("failed scanning destination directory {dst:?} for deletion"),
+        )
+        .await
+        {
+            Ok(Some(value)) => value,
+            Ok(None) => break,
+            Err(err) => {
+                errors.push(err);
+                break;
+            }
+        };
+        let name = entry.file_name();
+        if keep.contains(&name) {
+            continue;
+        }
+        let is_dir = entry_file_type.as_ref().is_some_and(|ft| ft.is_dir());
+        // exclude-protection: keep destination entries the filter would exclude,
+        // unless --delete-excluded was requested.
+        if !delete_settings.delete_excluded
+            && let Some(filter) = filter
+        {
+            let entry_relative = relative_dir.join(&name);
+            if !matches!(
+                filter.should_include(&entry_relative, is_dir),
+                crate::filter::FilterResult::Included
+            ) {
+                tracing::debug!("protecting excluded destination entry {:?}", entry.path());
+                continue;
+            }
+        }
+        // Protect excluded descendants when removing an extraneous directory: rm::rm applies
+        // the filter recursively (skipping excluded entries), so an extra dir containing e.g.
+        // `*.log` files keeps them and survives non-empty — upholding the documented
+        // "excluded files are protected by default" guarantee (and matching rsync). With
+        // --delete-excluded we pass no filter so the whole subtree is removed. (rm matches
+        // relative to the entry being removed, so simple patterns protect by basename.)
+        let rm_settings = crate::rm::Settings {
+            fail_early,
+            filter: if delete_settings.delete_excluded {
+                None
+            } else {
+                filter.cloned()
+            },
+            time_filter: None,
+            dry_run,
+        };
+        match crate::rm::rm_with_filter_root(prog_track, &entry.path(), dest_root, &rm_settings)
+            .await
+        {
+            Ok(rm_summary) => {
+                summary = summary + rm_summary;
+            }
+            Err(err) => {
+                summary = summary + err.summary;
+                if fail_early {
+                    return Err(crate::rm::Error::new(err.source, summary));
+                }
+                errors.push(err.source);
+            }
+        }
+    }
+    if let Some(err) = errors.into_error() {
+        return Err(crate::rm::Error::new(err, summary));
+    }
+    Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use tracing_test::traced_test;
+
+    static PROGRESS: std::sync::LazyLock<progress::Progress> =
+        std::sync::LazyLock::new(progress::Progress::new);
+
+    fn delete_settings(delete_excluded: bool) -> DeleteSettings {
+        DeleteSettings { delete_excluded }
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn removes_entries_not_in_keep_set() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let dst = tmp.path().join("dst");
+        tokio::fs::create_dir(&dst).await?;
+        tokio::fs::write(dst.join("keep.txt"), b"x").await?;
+        tokio::fs::write(dst.join("extra.txt"), b"x").await?;
+        tokio::fs::create_dir(dst.join("extra_dir")).await?;
+        tokio::fs::write(dst.join("extra_dir").join("nested.txt"), b"x").await?;
+
+        let mut keep = HashSet::new();
+        keep.insert(std::ffi::OsString::from("keep.txt"));
+
+        let summary = prune_extraneous(
+            &PROGRESS,
+            &dst,
+            std::path::Path::new(""),
+            &keep,
+            None,
+            &delete_settings(false),
+            false,
+            None,
+        )
+        .await
+        .map_err(|e| e.source)?;
+
+        assert_eq!(summary.files_removed, 2); // extra.txt + extra_dir/nested.txt
+        assert_eq!(summary.directories_removed, 1); // extra_dir
+        assert!(dst.join("keep.txt").exists());
+        assert!(!dst.join("extra.txt").exists());
+        assert!(!dst.join("extra_dir").exists());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn protects_excluded_entries_unless_delete_excluded() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let dst = tmp.path().join("dst");
+        tokio::fs::create_dir(&dst).await?;
+        tokio::fs::write(dst.join("data.bin"), b"x").await?; // extra, not excluded
+        tokio::fs::write(dst.join("note.log"), b"x").await?; // extra, excluded by *.log
+
+        let mut filter = crate::filter::FilterSettings::new();
+        filter.add_exclude("*.log")?;
+        let keep = HashSet::new(); // both are extraneous
+
+        // default: *.log is protected, data.bin is removed
+        let summary = prune_extraneous(
+            &PROGRESS,
+            &dst,
+            std::path::Path::new(""),
+            &keep,
+            Some(&filter),
+            &delete_settings(false),
+            false,
+            None,
+        )
+        .await
+        .map_err(|e| e.source)?;
+        assert_eq!(summary.files_removed, 1);
+        assert!(!dst.join("data.bin").exists());
+        assert!(
+            dst.join("note.log").exists(),
+            "*.log must be protected by default"
+        );
+
+        // with delete_excluded: note.log is also removed
+        let summary = prune_extraneous(
+            &PROGRESS,
+            &dst,
+            std::path::Path::new(""),
+            &keep,
+            Some(&filter),
+            &delete_settings(true),
+            false,
+            None,
+        )
+        .await
+        .map_err(|e| e.source)?;
+        assert_eq!(summary.files_removed, 1);
+        assert!(!dst.join("note.log").exists());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn protects_excluded_descendants_of_extraneous_dir() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let dst = tmp.path().join("dst");
+        tokio::fs::create_dir(&dst).await?;
+        // an extraneous directory (no source counterpart) with an excluded and a normal file
+        tokio::fs::create_dir(dst.join("extra_dir")).await?;
+        tokio::fs::write(dst.join("extra_dir").join("keep.log"), b"x").await?; // excluded by *.log
+        tokio::fs::write(dst.join("extra_dir").join("gone.txt"), b"x").await?; // not excluded
+
+        let mut filter = crate::filter::FilterSettings::new();
+        filter.add_exclude("*.log")?;
+        let keep = HashSet::new(); // extra_dir is extraneous
+
+        // default --delete: the excluded descendant is protected, so the dir survives non-empty
+        let summary = prune_extraneous(
+            &PROGRESS,
+            &dst,
+            std::path::Path::new(""),
+            &keep,
+            Some(&filter),
+            &delete_settings(false),
+            false,
+            None,
+        )
+        .await
+        .map_err(|e| e.source)?;
+        assert_eq!(summary.files_removed, 1); // gone.txt
+        assert!(!dst.join("extra_dir").join("gone.txt").exists());
+        assert!(
+            dst.join("extra_dir").join("keep.log").exists(),
+            "excluded descendant of an extraneous dir must be protected"
+        );
+
+        // --delete-excluded: the whole extraneous directory is removed
+        let summary = prune_extraneous(
+            &PROGRESS,
+            &dst,
+            std::path::Path::new(""),
+            &keep,
+            Some(&filter),
+            &delete_settings(true),
+            false,
+            None,
+        )
+        .await
+        .map_err(|e| e.source)?;
+        assert_eq!(summary.files_removed, 1); // keep.log
+        assert!(!dst.join("extra_dir").exists());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn protects_path_excluded_descendants_of_extraneous_dir() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let dst = tmp.path().join("dst");
+        tokio::fs::create_dir(&dst).await?;
+        // an extraneous directory whose descendants are targeted by a PATH-based exclude
+        tokio::fs::create_dir(dst.join("cache")).await?;
+        tokio::fs::write(dst.join("cache").join("foo.log"), b"x").await?; // matches cache/*.log -> protected
+        tokio::fs::write(dst.join("cache").join("data.txt"), b"x").await?; // not matched -> removed
+
+        let mut filter = crate::filter::FilterSettings::new();
+        filter.add_exclude("cache/*.log")?;
+        let keep = HashSet::new();
+
+        let summary = prune_extraneous(
+            &PROGRESS,
+            &dst,
+            std::path::Path::new(""),
+            &keep,
+            Some(&filter),
+            &delete_settings(false),
+            false,
+            None,
+        )
+        .await
+        .map_err(|e| e.source)?;
+
+        assert_eq!(summary.files_removed, 1); // data.txt
+        assert!(!dst.join("cache").join("data.txt").exists());
+        assert!(
+            dst.join("cache").join("foo.log").exists(),
+            "path-based exclude must protect the descendant of an extraneous dir"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn dry_run_does_not_follow_dst_symlink_to_directory() -> anyhow::Result<()> {
+        // In a real --delete run, the create-or-overwrite step replaces any non-directory
+        // destination (including a symlink) before prune runs. In --dry-run that overwrite
+        // is skipped, so prune_extraneous can be called with a dst that is still a symlink
+        // pointing to a directory. `tokio::fs::read_dir` follows symlinks, so without a
+        // pre-check it would walk the symlink's target and previews deletions OUTSIDE the
+        // destination tree.
+        let tmp = tempfile::tempdir()?;
+        let dst_parent = tmp.path().join("dst_parent");
+        let outside = tmp.path().join("outside"); // outside the destination tree
+        tokio::fs::create_dir(&dst_parent).await?;
+        tokio::fs::create_dir(&outside).await?;
+        tokio::fs::write(outside.join("precious.txt"), b"keep me").await?;
+        // dst is a symlink-to-directory living under the parent we'd prune.
+        let dst = dst_parent.join("link_dir");
+        std::os::unix::fs::symlink(&outside, &dst)?;
+
+        // keep set empty: anything `read_dir(dst)` returns would look extraneous.
+        let keep = HashSet::new();
+        let summary = prune_extraneous(
+            &PROGRESS,
+            &dst,
+            std::path::Path::new(""),
+            &keep,
+            None,
+            &delete_settings(false),
+            false,
+            Some(crate::config::DryRunMode::Brief),
+        )
+        .await
+        .map_err(|e| e.source)?;
+        assert_eq!(
+            summary.files_removed, 0,
+            "dry-run must not preview deletions reached by following a dst symlink"
+        );
+        assert_eq!(summary.directories_removed, 0);
+        // dry-run never deletes, but assert anyway as a belt-and-braces guard.
+        assert!(outside.join("precious.txt").exists());
+        Ok(())
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -67,6 +67,7 @@
 //!     remote_copy_buffer_size: 0,
 //!     filter: None,
 //!     dry_run: None,
+//!     delete: None,
 //! };
 //! let preserve = common::preserve::preserve_none();
 //!
@@ -114,6 +115,7 @@ pub mod cli;
 pub mod cmp;
 pub mod config;
 pub mod copy;
+pub mod delete;
 pub mod dry_run;
 pub mod error;
 pub mod error_collector;

--- a/common/src/link.rs
+++ b/common/src/link.rs
@@ -182,6 +182,48 @@ pub async fn link(
     settings: &Settings,
     is_fresh: bool,
 ) -> Result<Summary, Error> {
+    // A missing --update root is destructive under both --update-exclusive (materialized set =
+    // update set, so nothing materializes) AND --delete (the source-only keep_set makes any dst
+    // entry the missing update tree WOULD have protected look extraneous, and prune wipes it).
+    // In either case `link_internal` hits the recursive early-return / silent `None` fallback
+    // before that destruction would happen, so rlink reports success — silently preserving
+    // stale dst (--update-exclusive) or silently pruning would-be-protected entries (--delete).
+    // Reject at the public entry so a typo'd --update can't quietly do the wrong thing. The
+    // plain "--update without --delete or --update-exclusive" case still falls back to no-update
+    // mode (long-standing behavior), and recursive child-level "update missing" cases stay
+    // handled inside link_internal — they correctly no-op so the parent's prune removes their
+    // dst counterpart per the documented semantics.
+    if let Some(update_path) = update.as_ref()
+        && (settings.update_exclusive || settings.copy_settings.delete.is_some())
+    {
+        match crate::walk::run_metadata_probed(
+            congestion::Side::Source,
+            congestion::MetadataOp::Stat,
+            tokio::fs::symlink_metadata(update_path),
+        )
+        .await
+        {
+            Ok(_) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Err(Error::new(
+                    anyhow!(
+                        "--update path {:?} does not exist (rejected under --delete or --update-exclusive to avoid silently pruning destination entries the update tree would otherwise have preserved)",
+                        update_path
+                    ),
+                    Default::default(),
+                ));
+            }
+            Err(err) => {
+                return Err(Error::new(
+                    anyhow::Error::new(err).context(format!(
+                        "failed reading metadata from update {:?}",
+                        update_path
+                    )),
+                    Default::default(),
+                ));
+            }
+        }
+    }
     // check filter for top-level source (files, directories, and symlinks)
     if let Some(ref filter) = settings.filter {
         let src_name = src.file_name().map(std::path::Path::new);
@@ -214,6 +256,65 @@ pub async fn link(
     )
     .await
 }
+/// Tracks which child names will be materialized at the destination for a single directory
+/// pass, used by `--delete` to decide what to prune. Operations are named after their
+/// semantic intent so the call sites don't repeat the gating conditions (delete-on-vs-off,
+/// `--update-exclusive` carve-out, skip-special-vs-real materialization).
+///
+/// When `--delete` is off the inner set is `None` and every method is a no-op — zero heap
+/// cost in the hot path.
+struct DeleteKeepSet {
+    inner: Option<std::collections::HashSet<std::ffi::OsString>>,
+    /// Under `--update-exclusive` with an active update tree, the source loop must NOT
+    /// register source-only entries — only the update set materializes.
+    src_records_disabled: bool,
+}
+
+impl DeleteKeepSet {
+    fn new(
+        delete: Option<&copy::DeleteSettings>,
+        update_exclusive: bool,
+        update_present: bool,
+    ) -> Self {
+        Self {
+            inner: delete.is_some().then(std::collections::HashSet::new),
+            src_records_disabled: update_exclusive && update_present,
+        }
+    }
+    /// Source loop: this src entry passed the filter. Called even when `--skip-specials`
+    /// will skip materialization — the dst counterpart still needs to be retained.
+    fn record_src(&mut self, name: &std::ffi::OsStr) {
+        if let Some(set) = &mut self.inner
+            && !self.src_records_disabled
+        {
+            set.insert(name.to_owned());
+        }
+    }
+    /// Update loop: this update entry passed the filter at its logical path.
+    fn record_update(&mut self, name: &std::ffi::OsStr) {
+        if let Some(set) = &mut self.inner {
+            set.insert(name.to_owned());
+        }
+    }
+    /// Update loop, filtered-out branch: an update entry at this name is filtered out, so
+    /// nothing materializes from the update side. Drop a src-side registration ONLY if the
+    /// source loop actually materialized something (caller tracks this via `processed_files`).
+    /// Skipped specials stay registered — their `record_src` happened, but `processed_files`
+    /// was not populated, so their dst counterpart is retained per `--skip-specials` semantics.
+    fn drop_src_when_update_filtered(&mut self, name: &std::ffi::OsStr, src_materialized: bool) {
+        if let Some(set) = &mut self.inner
+            && src_materialized
+        {
+            set.remove(name);
+        }
+    }
+    /// Borrow the underlying set for `prune_extraneous`. `None` means `--delete` is off and
+    /// the caller should skip the prune entirely.
+    fn as_set(&self) -> Option<&std::collections::HashSet<std::ffi::OsString>> {
+        self.inner.as_ref()
+    }
+}
+
 #[instrument(skip(prog_track, settings, open_file_guard))]
 #[async_recursion]
 #[allow(clippy::too_many_arguments)]
@@ -287,13 +388,20 @@ async fn link_internal(
             // were still holding one here, a saturated pool would deadlock the
             // inner acquire.
             drop(open_file_guard);
-            let copy_summary = copy::copy(
+            // delegate at this entry's logical path (relative to the link root) so that, under
+            // --delete, pruning inside the delegated subtree matches include/exclude descendants
+            // at the correct filter root (e.g. `node/*.log`) — mirroring the update-only
+            // delegation. With an empty base, a path-anchored exclude would fail to protect a
+            // descendant like `node/keep.log` and delete it.
+            let filter_base = walk::relative_to_root(src, source_root);
+            let copy_summary = copy::copy_with_filter_base(
                 prog_track,
                 update,
                 dst,
                 &settings.copy_settings,
                 &settings.preserve,
                 is_fresh,
+                filter_base,
             )
             .await
             .map_err(|err| {
@@ -352,14 +460,20 @@ async fn link_internal(
         }
         if update_metadata.is_symlink() {
             tracing::debug!("'update' is a symlink so just symlink that");
-            // use "copy" function to handle the overwrite logic
-            let copy_summary = copy::copy(
+            // delegate at this entry's logical path (relative to the link root) so the inner
+            // filter re-check in copy_with_filter_base uses nested semantics. With an empty
+            // filter_base it would fall back to should_include_root_item on the bare basename
+            // and reject a path-anchored include like `dir/link`, leaving the entry unmaterialized
+            // while the outer loop's keep_set entry still shielded the stale dst from pruning.
+            let filter_base = walk::relative_to_root(src, source_root);
+            let copy_summary = copy::copy_with_filter_base(
                 prog_track,
                 update,
                 dst,
                 &settings.copy_settings,
                 &settings.preserve,
                 is_fresh,
+                filter_base,
             )
             .await
             .map_err(|err| {
@@ -391,14 +505,17 @@ async fn link_internal(
         }
         if src_metadata.is_symlink() {
             tracing::debug!("'src' is a symlink so just symlink that");
-            // use "copy" function to handle the overwrite logic
-            let copy_summary = copy::copy(
+            // delegate at this entry's logical path so the inner filter re-check uses nested
+            // semantics — see the matching comment above on the update-symlink branch.
+            let filter_base = walk::relative_to_root(src, source_root);
+            let copy_summary = copy::copy_with_filter_base(
                 prog_track,
                 src,
                 dst,
                 &settings.copy_settings,
                 &settings.preserve,
                 is_fresh,
+                filter_base,
             )
             .await
             .map_err(|err| {
@@ -487,7 +604,11 @@ async fn link_internal(
             let dst_metadata = crate::walk::run_metadata_probed(
                 congestion::Side::Destination,
                 congestion::MetadataOp::Stat,
-                tokio::fs::metadata(dst),
+                // symlink_metadata (not metadata): do not follow a destination symlink. A
+                // symlinked directory is then treated as "not a directory" below and replaced,
+                // rather than copied/pruned *through* — which under --delete could delete files
+                // outside the destination tree. Mirrors copy.rs.
+                tokio::fs::symlink_metadata(dst),
             )
             .await
             .with_context(|| format!("failed reading metadata from {:?}", &dst))
@@ -572,6 +693,15 @@ async fn link_internal(
     let errors = crate::error_collector::ErrorCollector::default();
     // create a set of all the files we already processed
     let mut processed_files = std::collections::HashSet::new();
+    // Keep-set for --delete: names that will be materialized at the destination. See
+    // `DeleteKeepSet` for the semantics of `record_src` / `record_update` /
+    // `drop_src_when_update_filtered`. No-op when --delete is off, so the call sites stay
+    // unconditional in the hot path.
+    let mut keep_set = DeleteKeepSet::new(
+        settings.copy_settings.delete.as_ref(),
+        settings.update_exclusive,
+        update.is_some(),
+    );
     // iterate through src entries and recursively call "link" on each one
     loop {
         let Some((src_entry, entry_file_type)) =
@@ -590,7 +720,7 @@ async fn link_internal(
         let entry_is_dir = entry_kind == EntryKind::Dir;
         let entry_is_symlink = entry_kind == EntryKind::Symlink;
         // compute relative path from source_root for filter matching
-        let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
+        let relative_path = walk::relative_to_root(&entry_path, source_root);
         // apply filter if configured
         if let Some(skip_result) =
             walk::should_skip_entry(&settings.filter, relative_path, entry_is_dir)
@@ -603,6 +733,9 @@ async fn link_internal(
             entry_kind.inc_skipped(prog_track);
             continue;
         }
+        // keep-set: a source entry has a destination counterpart that must not be pruned, even
+        // when --skip-specials skips copying it (computed before the skip-specials check below).
+        keep_set.record_src(entry_name);
         // skip special files (sockets, FIFOs, devices) when --skip-specials is set
         if settings.copy_settings.skip_specials && entry_kind == EntryKind::Special {
             tracing::debug!("skipping special file {:?}", &entry_path);
@@ -715,7 +848,7 @@ async fn link_internal(
         // Each spawned task's actual work is throttled by copy::copy's own internal
         // open-files backpressure inside copy_internal's spawn loop.
         loop {
-            let Some((update_entry, _entry_file_type)) = crate::walk::next_entry_probed(
+            let Some((update_entry, entry_file_type)) = crate::walk::next_entry_probed(
                 &mut update_entries,
                 congestion::Side::Source,
                 || format!("failed traversing directory {:?}", &update),
@@ -727,6 +860,33 @@ async fn link_internal(
             };
             let entry_path = update_entry.path();
             let entry_name = entry_path.file_name().unwrap();
+            // keep-set: every filter-passing update entry is materialized at the destination
+            // (entries also in `src` are linked, update-only entries are copied). Computed
+            // before the dedup `continue` so entries also present in `src` are covered — this
+            // is what makes --update-exclusive mirror the update set exactly.
+            if settings.copy_settings.delete.is_some() {
+                let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
+                let relative_path = walk::relative_to_root(src, source_root).join(entry_name);
+                let filtered_out = walk::should_skip_entry(
+                    &settings.filter,
+                    &relative_path,
+                    entry_kind == EntryKind::Dir,
+                )
+                .is_some();
+                if filtered_out {
+                    // The update entry at this name is filtered out, so nothing materializes
+                    // from the update side. `drop_src_when_update_filtered` undoes a src-side
+                    // registration ONLY when the source loop actually materialized something —
+                    // a `--skip-specials` source special stays registered (its dst counterpart
+                    // must be retained per --skip-specials semantics).
+                    keep_set.drop_src_when_update_filtered(
+                        entry_name,
+                        processed_files.contains(entry_name),
+                    );
+                } else {
+                    keep_set.record_update(entry_name);
+                }
+            }
             if processed_files.contains(entry_name) {
                 // we already must have considered this file, skip it
                 continue;
@@ -734,15 +894,20 @@ async fn link_internal(
             tracing::debug!("found a new entry in the 'update' directory");
             let dst_path = dst.join(entry_name);
             let update_path = update.join(entry_name);
+            // filter-base for the delegated copy: this update entry's path relative to the
+            // source root, so any --delete pruning inside it matches the include/exclude filter
+            // at the entry's true relative path (e.g. cache/*.log), not relative to the entry.
+            let filter_base = walk::relative_to_root(src, source_root).join(entry_name);
             let settings = settings.clone();
             let do_copy = || async move {
-                let copy_summary = copy::copy(
+                let copy_summary = copy::copy_with_filter_base(
                     prog_track,
                     &update_path,
                     &dst_path,
                     &settings.copy_settings,
                     &settings.preserve,
                     is_fresh,
+                    &filter_base,
                 )
                 .await
                 .map_err(|err| {
@@ -787,6 +952,50 @@ async fn link_internal(
             }
         }
     }
+    // rsync-style --delete for rlink: remove destination entries the link operation did not
+    // materialize. `keep_set` holds exactly the materialized names: src ∪ update normally, or
+    // just the update set under --update-exclusive (where source-only entries are not
+    // materialized and so are pruned, matching `rsync --link-dest --delete`).
+    if let Some(delete_settings) = &settings.copy_settings.delete {
+        if errors.has_errors() {
+            // rsync-style safety: skip pruning when this subtree's link/update pass reported
+            // errors — deleting based on a run that did not fully succeed could remove data
+            // unexpectedly. (rsync likewise skips --delete on I/O errors.)
+            tracing::warn!(
+                "skipping --delete pruning of {:?} because the link/update pass reported errors",
+                dst
+            );
+        } else {
+            let relative_dir = walk::relative_to_root(src, source_root);
+            match crate::delete::prune_extraneous(
+                prog_track,
+                dst,
+                relative_dir,
+                keep_set
+                    .as_set()
+                    .expect("--delete is on, so DeleteKeepSet is active"),
+                settings.filter.as_ref(),
+                delete_settings,
+                settings.copy_settings.fail_early,
+                settings.dry_run,
+            )
+            .await
+            {
+                Ok(rm_summary) => {
+                    link_summary.copy_summary.rm_summary =
+                        link_summary.copy_summary.rm_summary + rm_summary;
+                }
+                Err(err) => {
+                    link_summary.copy_summary.rm_summary =
+                        link_summary.copy_summary.rm_summary + err.summary;
+                    if settings.copy_settings.fail_early {
+                        return Err(Error::new(err.source, link_summary));
+                    }
+                    errors.push(err.source);
+                }
+            }
+        }
+    }
     // when filtering is active and we created this directory, check if anything was actually
     // linked/copied into it. if nothing was linked, we may need to clean up the empty directory.
     let this_dir_count = usize::from(we_created_this_dir);
@@ -798,7 +1007,7 @@ async fn link_internal(
         || link_summary.copy_summary.files_copied > 0
         || link_summary.copy_summary.symlinks_created > 0
         || child_dirs_created > 0;
-    let relative_path = src.strip_prefix(source_root).unwrap_or(src);
+    let relative_path = walk::relative_to_root(src, source_root);
     let is_root = src == source_root;
     match check_empty_dir_cleanup(
         settings.filter.as_ref(),
@@ -890,6 +1099,132 @@ mod link_tests {
     static PROGRESS: std::sync::LazyLock<progress::Progress> =
         std::sync::LazyLock::new(progress::Progress::new);
 
+    mod delete_keep_set_tests {
+        //! Pure-logic unit tests for `DeleteKeepSet`. No filesystem needed — these pin the
+        //! src-vs-update materialization rules so a future refactor can't silently break them.
+
+        use super::super::DeleteKeepSet;
+        use crate::copy::DeleteSettings;
+        use std::ffi::{OsStr, OsString};
+
+        fn delete_on() -> DeleteSettings {
+            DeleteSettings {
+                delete_excluded: false,
+            }
+        }
+
+        #[test]
+        fn record_src_no_op_when_delete_off() {
+            let mut k = DeleteKeepSet::new(None, false, false);
+            k.record_src(OsStr::new("foo"));
+            assert!(k.as_set().is_none());
+        }
+
+        #[test]
+        fn record_src_no_op_under_update_exclusive_with_update() {
+            // `--update-exclusive` with an active update tree means the materialized set is
+            // the update set; source-only entries must NOT be retained.
+            let d = delete_on();
+            let mut k = DeleteKeepSet::new(Some(&d), true, true);
+            k.record_src(OsStr::new("src_only"));
+            assert!(!k.as_set().unwrap().contains(OsStr::new("src_only")));
+        }
+
+        #[test]
+        fn record_src_records_when_update_exclusive_without_update() {
+            // `--update-exclusive` is a no-op (carve-out doesn't apply) when no `--update`
+            // path is given.
+            let d = delete_on();
+            let mut k = DeleteKeepSet::new(Some(&d), true, false);
+            k.record_src(OsStr::new("foo"));
+            assert!(k.as_set().unwrap().contains(OsStr::new("foo")));
+        }
+
+        #[test]
+        fn record_src_records_in_normal_delete_mode() {
+            let d = delete_on();
+            let mut k = DeleteKeepSet::new(Some(&d), false, false);
+            k.record_src(OsStr::new("foo"));
+            assert!(k.as_set().unwrap().contains(OsStr::new("foo")));
+        }
+
+        #[test]
+        fn record_update_always_records_when_delete_on() {
+            // The update loop registers ALL filter-passing update entries, irrespective of
+            // `--update-exclusive` — the update set IS the materialized set in that mode.
+            let d = delete_on();
+            let mut k = DeleteKeepSet::new(Some(&d), true, true);
+            k.record_update(OsStr::new("from_update"));
+            assert!(k.as_set().unwrap().contains(OsStr::new("from_update")));
+        }
+
+        #[test]
+        fn record_update_no_op_when_delete_off() {
+            let mut k = DeleteKeepSet::new(None, false, false);
+            k.record_update(OsStr::new("from_update"));
+            assert!(k.as_set().is_none());
+        }
+
+        #[test]
+        fn drop_src_when_update_filtered_drops_materialized_src_entry() {
+            // The type-change case: src had a regular file at `node`, update has an excluded
+            // dir at `node/`. Source materialized — drop the keep-set entry so the stale dst
+            // is pruned.
+            let d = delete_on();
+            let mut k = DeleteKeepSet::new(Some(&d), false, true);
+            k.record_src(OsStr::new("node"));
+            assert!(k.as_set().unwrap().contains(OsStr::new("node")));
+            k.drop_src_when_update_filtered(OsStr::new("node"), /* src_materialized */ true);
+            assert!(!k.as_set().unwrap().contains(OsStr::new("node")));
+        }
+
+        #[test]
+        fn drop_src_when_update_filtered_keeps_skipped_special() {
+            // The skip-special case: source loop ran `record_src` but never reached
+            // `processed_files.insert` (it `continue`d on the skip-special branch). The dst
+            // counterpart must be retained per --skip-specials semantics.
+            let d = delete_on();
+            let mut k = DeleteKeepSet::new(Some(&d), false, true);
+            k.record_src(OsStr::new("pipe"));
+            k.drop_src_when_update_filtered(OsStr::new("pipe"), /* src_materialized */ false);
+            assert!(k.as_set().unwrap().contains(OsStr::new("pipe")));
+        }
+
+        #[test]
+        fn drop_src_when_update_filtered_no_op_when_delete_off() {
+            let mut k = DeleteKeepSet::new(None, false, false);
+            // Should not panic, and as_set stays None.
+            k.drop_src_when_update_filtered(OsStr::new("foo"), true);
+            assert!(k.as_set().is_none());
+        }
+
+        #[test]
+        fn full_directory_pass_matches_old_keep_set_semantics() {
+            // Models the union of src + update under plain `--delete --update` (no
+            // --update-exclusive). Names: src has `keep`, `pipe` (special, skipped),
+            // `node` (file). update has `from_upd`, `node` (excluded dir).
+            let d = delete_on();
+            let mut k = DeleteKeepSet::new(Some(&d), false, true);
+
+            // source loop
+            k.record_src(OsStr::new("keep"));
+            k.record_src(OsStr::new("pipe")); // --skip-specials: continues, processed_files NOT populated
+            k.record_src(OsStr::new("node"));
+
+            // update loop
+            k.record_update(OsStr::new("from_upd"));
+            // `node` filtered out in update; processed_files HAS `node` (source materialized it).
+            k.drop_src_when_update_filtered(OsStr::new("node"), true);
+
+            let set: std::collections::HashSet<OsString> = k.as_set().unwrap().clone();
+            let expected: std::collections::HashSet<OsString> = ["keep", "pipe", "from_upd"]
+                .into_iter()
+                .map(OsString::from)
+                .collect();
+            assert_eq!(set, expected);
+        }
+    }
+
     fn common_settings(dereference: bool, overwrite: bool) -> Settings {
         Settings {
             copy_settings: CopySettings {
@@ -908,6 +1243,7 @@ mod link_tests {
                 remote_copy_buffer_size: 0,
                 filter: None,
                 dry_run: None,
+                delete: None,
             },
             update_compare: filecmp::MetadataCmpSettings {
                 size: true,
@@ -1629,6 +1965,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -1692,6 +2029,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -1743,6 +2081,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -1798,6 +2137,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -1853,6 +2193,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -1918,6 +2259,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -1985,6 +2327,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -2058,6 +2401,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -2128,6 +2472,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -2198,6 +2543,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -2269,6 +2615,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -2319,6 +2666,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -2374,6 +2722,7 @@ mod link_tests {
                         remote_copy_buffer_size: 0,
                         filter: None,
                         dry_run: None,
+                        delete: None,
                     },
                     update_compare: Default::default(),
                     update_exclusive: false,
@@ -2471,6 +2820,68 @@ mod link_tests {
         assert_eq!(summary.copy_summary.specials_skipped, 1);
         assert!(dst.join("file.txt").exists());
         assert!(!dst.join("test.sock").exists());
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn delete_skips_pruning_when_link_has_errors() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::setup_test_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("foo");
+        let dst = test_path.join("bar");
+        // baseline link establishes the destination (no delete)
+        link(
+            &PROGRESS,
+            test_path,
+            &src,
+            &dst,
+            &None,
+            &common_settings(false, false),
+            false,
+        )
+        .await?;
+        // an extraneous file that --delete would normally prune
+        tokio::fs::write(dst.join("extraneous.txt"), b"junk").await?;
+        // make a source sub-directory unreadable so traversal fails (fail_early is false).
+        // a directory is used because --overwrite with mtime-equal files skips copying
+        // identical files; a directory's read_dir fails unconditionally when mode is 0o000.
+        let unreadable = src.join("baz");
+        let original = tokio::fs::metadata(&unreadable).await?.permissions();
+        tokio::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).await?;
+
+        let delete_settings = Settings {
+            copy_settings: CopySettings {
+                overwrite: true,
+                fail_early: false,
+                delete: Some(copy::DeleteSettings {
+                    delete_excluded: false,
+                }),
+                ..common_settings(false, true).copy_settings
+            },
+            ..common_settings(false, true)
+        };
+        let result = link(
+            &PROGRESS,
+            test_path,
+            &src,
+            &dst,
+            &None,
+            &delete_settings,
+            false,
+        )
+        .await;
+
+        tokio::fs::set_permissions(&unreadable, original).await?;
+
+        assert!(
+            result.is_err(),
+            "link of the unreadable directory should fail"
+        );
+        assert!(
+            dst.join("extraneous.txt").exists(),
+            "pruning must be skipped when the link/update pass reported errors"
+        );
         Ok(())
     }
 

--- a/common/src/rm.rs
+++ b/common/src/rm.rs
@@ -108,6 +108,53 @@ impl std::fmt::Display for Summary {
     }
 }
 
+/// RAII guard that restores a directory's original mode on drop.
+///
+/// `rm_internal` chmod-relaxes a read-only directory to `0o777` to clear its contents. If the
+/// directory is retained (filter-protected children, time-filter skip, ENOTEMPTY) or any error
+/// occurs after the relax, the original mode must be restored — otherwise a `--delete`/`rrm`
+/// run leaves a protected tree world-writable. Drop fires on every exit path (retain, error,
+/// panic-unwind) without callers having to remember it; the success-remove path calls
+/// [`Self::defuse`] because the directory no longer exists.
+///
+/// Drop runs synchronously (it can't be async), so it uses `std::fs::set_permissions`: one
+/// chmod syscall — negligible cost, no need to round-trip through the tokio blocking pool just
+/// for cleanup. Best-effort: a restore failure is logged, not fatal.
+struct RelaxedDirGuard<'a> {
+    path: &'a std::path::Path,
+    /// Original mode to restore on drop. `None` means defused (no restore).
+    mode: Option<u32>,
+}
+
+impl<'a> RelaxedDirGuard<'a> {
+    fn new(path: &'a std::path::Path) -> Self {
+        Self { path, mode: None }
+    }
+    /// Record the original mode so it's restored on drop.
+    fn arm(&mut self, original_mode: u32) {
+        self.mode = Some(original_mode);
+    }
+    /// Cancel the pending restore (call after successfully removing the directory).
+    fn defuse(&mut self) {
+        self.mode = None;
+    }
+}
+
+impl Drop for RelaxedDirGuard<'_> {
+    fn drop(&mut self) {
+        if let Some(mode) = self.mode.take()
+            && let Err(err) =
+                std::fs::set_permissions(self.path, std::fs::Permissions::from_mode(mode))
+        {
+            tracing::warn!(
+                "failed to restore original permissions on retained directory {:?}: {:#}",
+                self.path,
+                err
+            );
+        }
+    }
+}
+
 /// Public entry point for remove operations.
 /// Internally delegates to rm_internal with source_root tracking for proper filter matching.
 #[instrument(skip(prog_track, settings))]
@@ -146,6 +193,21 @@ pub async fn rm(
     // note: the time filter (applied to files, symlinks, and directories) is handled
     // inside rm_internal, so we don't duplicate the check here.
     rm_internal(prog_track, path, path, settings).await
+}
+
+/// Like [`rm`], but evaluates the include/exclude filter relative to `filter_root` instead of
+/// `path`. Used by `--delete` pruning: when removing an extraneous destination subtree,
+/// descendant excludes must be matched against their full destination-root-relative paths
+/// (which mirror the source-relative paths the filter targets), so path/anchored patterns
+/// like `cache/*.log` protect the right entries. The caller is responsible for the top-level
+/// filter decision on `path`.
+pub async fn rm_with_filter_root(
+    prog_track: &'static progress::Progress,
+    path: &std::path::Path,
+    filter_root: &std::path::Path,
+    settings: &Settings,
+) -> Result<Summary, Error> {
+    rm_internal(prog_track, path, filter_root, settings).await
 }
 #[instrument(skip(prog_track, settings))]
 #[async_recursion]
@@ -235,14 +297,16 @@ async fn rm_internal(
                 ..Default::default()
             });
         }
-        crate::walk::run_metadata_probed(
+        if let Err(err) = crate::walk::run_metadata_probed(
             congestion::Side::Destination,
             congestion::MetadataOp::Unlink,
             tokio::fs::remove_file(path),
         )
         .await
         .with_context(|| format!("failed removing {:?}", &path))
-        .map_err(|err| Error::new(err, Default::default()))?;
+        {
+            return Err(Error::new(err, Default::default()));
+        }
         if is_symlink {
             prog_track.symlinks_removed.inc();
             return Ok(Summary {
@@ -259,9 +323,16 @@ async fn rm_internal(
         });
     }
     tracing::debug!("remove contents of the directory first");
-    // only change permissions if not in dry-run mode
+    // When the directory is read-only we relax it to 0o777 so its contents can be cleared.
+    // `relaxed_guard` records the original mode and restores it on Drop — covering every
+    // retain branch (filter-protected children, time-filter skip, ENOTEMPTY) AND every error
+    // path that returns before the directory is removed. The success-remove path calls
+    // `defuse()` because the directory no longer exists. Dry-run skips the relax entirely,
+    // so the guard stays unarmed.
+    let mut relaxed_guard = RelaxedDirGuard::new(path);
     if settings.dry_run.is_none() && src_metadata.permissions().readonly() {
         tracing::debug!("directory is read-only - change the permissions");
+        let original_mode = src_metadata.permissions().mode() & 0o7777;
         tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o777))
             .await
             .with_context(|| {
@@ -271,31 +342,41 @@ async fn rm_internal(
                 )
             })
             .map_err(|err| Error::new(err, Default::default()))?;
+        relaxed_guard.arm(original_mode);
     }
-    let mut entries = tokio::fs::read_dir(path)
-        .await
-        .with_context(|| format!("failed reading directory {:?}", &path))
-        .map_err(|err| Error::new(err, Default::default()))?;
+    let mut entries = match tokio::fs::read_dir(path).await {
+        Ok(entries) => entries,
+        Err(err) => {
+            return Err(Error::new(
+                anyhow::Error::new(err).context(format!("failed reading directory {:?}", &path)),
+                Default::default(),
+            ));
+        }
+    };
     let mut join_set = tokio::task::JoinSet::new();
     let errors = crate::error_collector::ErrorCollector::default();
     let mut skipped_files = 0;
     let mut skipped_symlinks = 0;
     let mut skipped_dirs = 0;
     loop {
-        let Some((entry, entry_file_type)) =
+        let next_entry =
             crate::walk::next_entry_probed(&mut entries, congestion::Side::Source, || {
                 format!("failed traversing directory {:?}", &path)
             })
-            .await
-            .map_err(|err| Error::new(err, Default::default()))?
-        else {
+            .await;
+        let Some((entry, entry_file_type)) = (match next_entry {
+            Ok(opt) => opt,
+            Err(err) => {
+                return Err(Error::new(err, Default::default()));
+            }
+        }) else {
             break;
         };
         let entry_path = entry.path();
         let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
         let entry_is_dir = entry_kind == EntryKind::Dir;
         // compute relative path from source_root for filter matching
-        let relative_path = entry_path.strip_prefix(source_root).unwrap_or(&entry_path);
+        let relative_path = walk::relative_to_root(&entry_path, source_root);
         // apply filter if configured
         if let Some(skip_result) =
             walk::should_skip_entry(&settings.filter, relative_path, entry_is_dir)
@@ -386,7 +467,7 @@ async fn rm_internal(
     // left intact. directories that directly match an include pattern (e.g. --include target/)
     // should be removed even if empty. exclude-only filters never produce traversed-only
     // directories because directly_matches_include returns true when no includes exist.
-    let relative_path = path.strip_prefix(source_root).unwrap_or(path);
+    let relative_path = walk::relative_to_root(path, source_root);
     let traversed_only = !anything_removed
         && settings
             .filter
@@ -496,6 +577,8 @@ async fn rm_internal(
         Ok(()) => {
             prog_track.directories_removed.inc();
             rm_summary.directories_removed += 1;
+            // the directory is gone, so there's nothing to restore on drop.
+            relaxed_guard.defuse();
         }
         Err(err) if any_filter_active => {
             // with filtering, it's expected that directories may not be empty because we only
@@ -569,6 +652,60 @@ mod tests {
 
     #[tokio::test]
     #[traced_test]
+    async fn relaxed_dir_mode_restored_on_error_exit() -> Result<(), anyhow::Error> {
+        // Regression: when rm_internal chmod-relaxes a read-only directory to 0o777 to clear
+        // its contents, it must restore the original mode on ERROR paths too — not just on the
+        // retain paths (traversed-only, time-filtered skip, ENOTEMPTY under filter). Without
+        // that, a partial failure leaves the directory world-writable.
+        //
+        // We trigger the remove_dir error path by making the dst's PARENT non-writable: rm can
+        // chmod-relax dst and successfully unlink its contents (write on dst is granted by the
+        // relax), but the final remove_dir(dst) needs write permission on the parent, which it
+        // doesn't have → EACCES. The fix's inline restore at that error site must put dst back
+        // to 0o555 before propagating.
+        let tmp = tempfile::tempdir()?;
+        let parent = tmp.path().join("parent");
+        let dst = parent.join("dst");
+        tokio::fs::create_dir(&parent).await?;
+        tokio::fs::create_dir(&dst).await?;
+        tokio::fs::write(dst.join("inside.txt"), b"x").await?;
+        // dst is read-only → rm relaxes it.
+        tokio::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o555)).await?;
+        // parent is read-only (still traversable via the execute bit) → remove_dir(dst) fails.
+        tokio::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o555)).await?;
+
+        let result = rm(
+            &PROGRESS,
+            &dst,
+            &Settings {
+                fail_early: false,
+                filter: None,
+                dry_run: None,
+                time_filter: None,
+            },
+        )
+        .await;
+
+        // restore parent writability so we can stat dst and clean up regardless of the assertion.
+        tokio::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755)).await?;
+
+        assert!(
+            result.is_err(),
+            "rm must fail when its dst can be emptied but the parent dir blocks remove_dir"
+        );
+        let mode = tokio::fs::metadata(&dst).await?.permissions().mode() & 0o7777;
+        assert_eq!(
+            mode, 0o555,
+            "relaxed-then-erroring directory must be restored to its original mode (got {mode:o}o); leaving it 0o777 leaks permissions on partial failure"
+        );
+
+        // cleanup
+        tokio::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o755)).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
     async fn parent_dir_no_write_permission() -> Result<(), anyhow::Error> {
         let tmp_dir = testutils::setup_test_dir().await?;
         let test_path = tmp_dir.as_path();
@@ -601,6 +738,7 @@ mod tests {
         );
         Ok(())
     }
+
     mod filter_tests {
         use super::*;
         use crate::filter::FilterSettings;

--- a/common/src/walk.rs
+++ b/common/src/walk.rs
@@ -248,3 +248,20 @@ pub fn should_skip_entry(
         None
     }
 }
+
+/// Path of `entry` relative to `root` (typically `source_root` or `dest_root` at the call
+/// site), with the `unwrap_or(entry)` defensive fallback rcp uses when `entry` isn't
+/// actually under `root`. Naming the pattern lets call sites read "the entry's path inside
+/// the tree" instead of `entry.strip_prefix(root).unwrap_or(entry)` — and removes a class
+/// of "did I get strip_prefix the right way round?" regressions.
+///
+/// Use with `filter_base.join(...)` for a logical filter path inside a delegated subtree
+/// (`copy_with_filter_base`'s non-empty `filter_base` case), or on its own when filter_base
+/// is empty.
+#[must_use]
+pub fn relative_to_root<'a>(
+    entry: &'a std::path::Path,
+    root: &std::path::Path,
+) -> &'a std::path::Path {
+    entry.strip_prefix(root).unwrap_or(entry)
+}

--- a/common/tests/probe_metadata.rs
+++ b/common/tests/probe_metadata.rs
@@ -56,6 +56,7 @@ fn default_copy_settings() -> copy::Settings {
         remote_copy_buffer_size: 0,
         filter: None,
         dry_run: None,
+        delete: None,
     }
 }
 

--- a/rcp/src/bin/rcp.rs
+++ b/rcp/src/bin/rcp.rs
@@ -63,12 +63,7 @@ struct Args {
     ///
     /// Available filters: "newer" (skip if destination mtime is strictly newer than source).
     /// Requires --overwrite.
-    #[arg(
-        long,
-        value_name = "FILTER",
-        requires = "overwrite",
-        help_heading = "Copy options"
-    )]
+    #[arg(long, value_name = "FILTER", help_heading = "Copy options")]
     overwrite_filter: Option<common::copy::OverwriteFilter>,
 
     /// Do not overwrite existing files
@@ -78,6 +73,22 @@ struct Args {
     /// Skip special files (sockets, FIFOs, devices) without error
     #[arg(long, help_heading = "Copy options")]
     skip_specials: bool,
+
+    /// Delete extraneous files from destination directories (mirror the source)
+    ///
+    /// Removes entries under the destination that have no counterpart in the
+    /// source. Implies --overwrite. Excluded files are protected from deletion
+    /// unless --delete-excluded is given. Requires a single source.
+    #[arg(
+        long,
+        conflicts_with_all = ["ignore_existing", "dereference"],
+        help_heading = "Copy options"
+    )]
+    delete: bool,
+
+    /// With --delete, also remove destination entries matching an exclude pattern
+    #[arg(long, requires = "delete", help_heading = "Copy options")]
+    delete_excluded: bool,
 
     /// Exit on first error
     #[arg(short = 'e', long = "fail-early", help_heading = "Copy options")]
@@ -821,6 +832,16 @@ async fn async_main(args: Args) -> anyhow::Result<common::copy::Summary> {
             ));
         }
     }
+    if args.delete && src_strings.len() > 1 {
+        return Err(anyhow!(
+            "--delete requires a single source; mirroring multiple sources into one destination is not supported"
+        ));
+    }
+    if args.overwrite_filter.is_some() && !(args.overwrite || args.delete) {
+        return Err(anyhow!(
+            "--overwrite-filter requires --overwrite (or --delete, which implies it)"
+        ));
+    }
     // choose parser based on --force-remote flag
     let parse_fn = if args.force_remote {
         path::parse_path_force_remote
@@ -856,6 +877,9 @@ async fn async_main(args: Args) -> anyhow::Result<common::copy::Summary> {
         return Err(anyhow!(
             "Multiple sources are currently not supported when using remote paths!"
         ));
+    }
+    if has_remote_paths && args.delete {
+        return Err(anyhow!("--delete is not yet supported for remote copies"));
     }
     // if any of the src/dst paths are remote, we'll be using the rcpd
     let remote_src_dst = if has_remote_paths {
@@ -970,7 +994,7 @@ async fn async_main(args: Args) -> anyhow::Result<common::copy::Summary> {
                 }
             };
             // check for existing destination only when not using trailing slash (single source case)
-            if src_strings.len() == 1 && !dst_string.ends_with('/') && dst_path.exists() && !args.overwrite {
+            if src_strings.len() == 1 && !dst_string.ends_with('/') && dst_path.exists() && !(args.overwrite || args.delete) {
                 return Err(anyhow!(
                     "Destination path {dst_path:?} already exists! \n\
                     If you want to copy INTO it, then follow the destination path with a trailing slash (/). Use \
@@ -987,10 +1011,17 @@ async fn async_main(args: Args) -> anyhow::Result<common::copy::Summary> {
         &args.exclude,
     )
     .map_err(|err| common::copy::Error::new(err, Default::default()))?;
+    let delete = if args.delete {
+        Some(common::copy::DeleteSettings {
+            delete_excluded: args.delete_excluded,
+        })
+    } else {
+        None
+    };
     let settings = common::copy::Settings {
         dereference: args.dereference,
         fail_early: args.fail_early,
-        overwrite: args.overwrite,
+        overwrite: args.overwrite || args.delete,
         overwrite_compare: common::parse_metadata_cmp_settings(&args.overwrite_compare)
             .map_err(|err| common::copy::Error::new(err, Default::default()))?,
         overwrite_filter: args.overwrite_filter,
@@ -1001,6 +1032,7 @@ async fn async_main(args: Args) -> anyhow::Result<common::copy::Summary> {
         remote_copy_buffer_size: 0,
         filter,
         dry_run: args.dry_run,
+        delete,
     };
     tracing::debug!("copy settings: {:?}", &settings);
     let fail_early = settings.fail_early;

--- a/rcp/src/bin/rcpd.rs
+++ b/rcp/src/bin/rcpd.rs
@@ -307,6 +307,7 @@ where
                 remote_copy_buffer_size: tcp_config.effective_buffer_size(),
                 filter,
                 dry_run,
+                delete: None,
             };
             tracing::info!("Starting source");
             let shared_send = std::sync::Arc::new(tokio::sync::Mutex::new(master_send_stream));
@@ -376,6 +377,7 @@ where
                 remote_copy_buffer_size: tcp_config.effective_buffer_size(),
                 filter: None,
                 dry_run: None,
+                delete: None,
             };
             tracing::info!("Starting destination");
             match destination::run_destination(

--- a/rcp/tests/cli_parsing_tests.rs
+++ b/rcp/tests/cli_parsing_tests.rs
@@ -470,15 +470,19 @@ fn test_overwrite_filter_newer_with_overwrite() {
         .success();
 }
 
-/// Test that --overwrite-filter without --overwrite fails
+/// Test that --overwrite-filter without --overwrite (or --delete) fails
 #[test]
 fn test_overwrite_filter_requires_overwrite() {
+    // The error is now a runtime check (stdout) rather than a clap parse error (stderr),
+    // because --overwrite-filter also works with --delete. Check any output for the message.
     Command::cargo_bin("rcp")
         .unwrap()
         .args(["--overwrite-filter", "newer", "/tmp/src", "/tmp/dst"])
         .assert()
         .failure()
-        .stderr(predicates::str::contains("--overwrite"));
+        .stdout(predicates::str::contains(
+            "--overwrite-filter requires --overwrite",
+        ));
 }
 
 /// Test that --overwrite-filter rejects invalid values

--- a/rcp/tests/delete.rs
+++ b/rcp/tests/delete.rs
@@ -1,0 +1,223 @@
+//! Integration tests for `rcp --delete` (local mirror).
+
+use std::process::Command;
+
+fn rcp_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rcp")
+}
+
+#[test]
+fn delete_mirrors_source_removing_extraneous() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"a").unwrap();
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("a.txt"), b"old").unwrap();
+    std::fs::write(dst.join("stale.txt"), b"stale").unwrap();
+
+    // no trailing slash: `dst` IS the mirror target; --delete implies --overwrite
+    let status = Command::new(rcp_bin())
+        .arg("--delete")
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    assert!(dst.join("a.txt").exists());
+    assert!(!dst.join("stale.txt").exists()); // no source counterpart -> removed
+}
+
+#[test]
+fn delete_rejects_multiple_sources() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("a");
+    let b = tmp.path().join("b");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&a).unwrap();
+    std::fs::create_dir(&b).unwrap();
+    std::fs::create_dir(&dst).unwrap();
+
+    let output = Command::new(rcp_bin())
+        .arg("--delete")
+        .arg(&a)
+        .arg(&b)
+        .arg(format!("{}/", dst.display()))
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "expected failure for --delete with multiple sources"
+    );
+    // rcp may print the error to stdout (tracing) or stderr — check both.
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("--delete requires a single source"),
+        "expected single-source error, got: {combined}"
+    );
+}
+
+#[test]
+fn delete_allows_overwrite_filter() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"a").unwrap();
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("stale.txt"), b"stale").unwrap();
+
+    // --delete implies --overwrite, so --overwrite-filter must be accepted.
+    let status = Command::new(rcp_bin())
+        .arg("--delete")
+        .arg("--overwrite-filter=newer")
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(dst.join("a.txt").exists());
+    assert!(!dst.join("stale.txt").exists());
+}
+
+#[test]
+fn overwrite_filter_without_overwrite_or_delete_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"a").unwrap();
+
+    let output = Command::new(rcp_bin())
+        .arg("--overwrite-filter=newer")
+        .arg(&src)
+        .arg(&dst)
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "overwrite-filter without overwrite/delete must be rejected"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("--overwrite-filter requires --overwrite"),
+        "expected requirement error, got: {combined}"
+    );
+}
+
+#[test]
+fn delete_rejects_dereference() {
+    // `-L` (--dereference) + `--delete` is rejected at parse time: mirroring through a dereferenced
+    // symlink is not supported (pruning under a dereferenced subtree would mis-anchor path-based
+    // excludes), so we fail fast instead of doing the wrong thing.
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::create_dir(&dst).unwrap();
+
+    let output = Command::new(rcp_bin())
+        .arg("-L")
+        .arg("--delete")
+        .arg(&src)
+        .arg(&dst)
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "expected `rcp -L --delete` to be rejected at parse time"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("cannot be used with") && combined.contains("dereference"),
+        "expected a conflict error mentioning --dereference, got: {combined}"
+    );
+}
+
+#[test]
+fn delete_restores_perms_on_retained_readonly_dir() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"a").unwrap();
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("a.txt"), b"a").unwrap();
+    // an extraneous, read-only destination directory holding a filter-protected child
+    let extra = dst.join("extra");
+    std::fs::create_dir(&extra).unwrap();
+    std::fs::write(extra.join("keep.log"), b"x").unwrap();
+    std::fs::set_permissions(&extra, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+    let status = Command::new(rcp_bin())
+        .arg("--delete")
+        .arg("--exclude")
+        .arg("*.log")
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    // the excluded child is protected, so the dir survives non-empty ...
+    assert!(extra.join("keep.log").exists());
+    // ... and its original read-only mode must be restored, not left world-writable from the
+    // 0o777 relaxation rm uses to clear a directory's contents.
+    let mode = std::fs::metadata(&extra).unwrap().permissions().mode() & 0o7777;
+    assert_eq!(
+        mode, 0o555,
+        "retained read-only dir must keep its original mode, got {mode:o}"
+    );
+
+    // restore writable perms so the tempdir can be cleaned up
+    std::fs::set_permissions(&extra, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[test]
+fn delete_dry_run_handles_dst_type_replacement() {
+    // src/node is a directory but dst/node is a file: a real --delete run replaces the file with a
+    // directory before pruning, but --dry-run skips that overwrite. Pruning must then tolerate a
+    // non-directory destination counterpart instead of failing the whole preview.
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::create_dir(src.join("node")).unwrap();
+    std::fs::write(src.join("node").join("f.txt"), b"x").unwrap();
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("node"), b"old").unwrap();
+
+    let output = Command::new(rcp_bin())
+        .arg("--dry-run=brief")
+        .arg("--delete")
+        .arg(&src)
+        .arg(&dst)
+        .output()
+        .unwrap();
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.status.success(),
+        "dry-run --delete must not fail when a dst counterpart is a non-directory: {combined}"
+    );
+    // dry-run changes nothing
+    assert!(dst.join("node").is_file());
+}

--- a/rlink/src/main.rs
+++ b/rlink/src/main.rs
@@ -42,6 +42,18 @@ struct Args {
     #[arg(long, help_heading = "Linking options")]
     skip_specials: bool,
 
+    /// Delete extraneous files from the destination (mirror the source)
+    ///
+    /// Removes entries under the destination that have no counterpart in the
+    /// source (or, with --update, in the source or update directory). Implies
+    /// --overwrite. Excluded files are protected unless --delete-excluded.
+    #[arg(long, help_heading = "Linking options")]
+    delete: bool,
+
+    /// With --delete, also remove destination entries matching an exclude pattern
+    #[arg(long, requires = "delete", help_heading = "Linking options")]
+    delete_excluded: bool,
+
     /// Directory with updated contents of `link`
     #[arg(long, value_name = "PATH", help_heading = "Linking options")]
     update: Option<std::path::PathBuf>,
@@ -177,7 +189,7 @@ async fn async_main(args: Args) -> Result<common::link::Summary> {
         dst_dir.join(src_file)
     } else {
         let dst_path = std::path::PathBuf::from(args.dst);
-        if dst_path.exists() && !args.overwrite {
+        if dst_path.exists() && !(args.overwrite || args.delete) {
             return Err(anyhow!(
                 "Destination path {dst_path:?} already exists! \n\
                 If you want to copy INTO it then follow the destination path with a trailing slash (/) or use \
@@ -208,11 +220,18 @@ async fn async_main(args: Args) -> Result<common::link::Summary> {
         &args.include,
         &args.exclude,
     )?;
+    let delete = if args.delete {
+        Some(common::copy::DeleteSettings {
+            delete_excluded: args.delete_excluded,
+        })
+    } else {
+        None
+    };
     let settings = common::link::Settings {
         copy_settings: common::copy::Settings {
             dereference: false, // currently not supported
             fail_early: args.fail_early,
-            overwrite: args.overwrite,
+            overwrite: args.overwrite || args.delete,
             overwrite_compare: common::parse_metadata_cmp_settings(&args.overwrite_compare)?,
             overwrite_filter: None,
             ignore_existing: false,
@@ -221,6 +240,7 @@ async fn async_main(args: Args) -> Result<common::link::Summary> {
             remote_copy_buffer_size: 0, // not used for local operations
             filter: filter.clone(),
             dry_run: args.dry_run,
+            delete,
         },
         update_compare,
         update_exclusive: args.update_exclusive,

--- a/rlink/tests/delete.rs
+++ b/rlink/tests/delete.rs
@@ -1,0 +1,551 @@
+//! Integration tests for `rlink --delete` (local mirror).
+
+use std::process::Command;
+
+fn rlink_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_rlink")
+}
+
+#[test]
+fn delete_mirrors_source_removing_extraneous() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"a").unwrap();
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("stale.txt"), b"stale").unwrap();
+
+    // no trailing slash: `dst` IS the mirror target; --delete implies --overwrite
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    assert!(dst.join("a.txt").exists());
+    assert!(!dst.join("stale.txt").exists());
+}
+
+#[test]
+fn delete_with_update_keeps_src_and_update_entries() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let upd = tmp.path().join("upd");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"a").unwrap();
+    std::fs::write(src.join("b.txt"), b"b").unwrap();
+    std::fs::create_dir(&upd).unwrap();
+    std::fs::write(upd.join("c.txt"), b"c").unwrap(); // update-only
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("stale.txt"), b"stale").unwrap();
+
+    // keep-set = src ∪ update = {a,b,c}; stale.txt has no counterpart -> removed.
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--update")
+        .arg(&upd)
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    assert!(dst.join("a.txt").exists());
+    assert!(dst.join("b.txt").exists());
+    assert!(dst.join("c.txt").exists());
+    assert!(!dst.join("stale.txt").exists());
+}
+
+#[test]
+fn delete_excluded_removes_excluded_update_only_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let upd = tmp.path().join("upd");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"a").unwrap();
+    std::fs::create_dir(&upd).unwrap();
+    std::fs::write(upd.join("keep.txt"), b"k").unwrap();
+    std::fs::write(upd.join("drop.log"), b"d").unwrap(); // update-only, excluded by *.log
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("drop.log"), b"stale").unwrap(); // pre-existing dst entry with the excluded name
+
+    // With --delete-excluded, an excluded update-only name must NOT protect the
+    // pre-existing destination entry from deletion.
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--delete-excluded")
+        .arg("--exclude")
+        .arg("*.log")
+        .arg("--update")
+        .arg(&upd)
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    assert!(dst.join("a.txt").exists());
+    assert!(dst.join("keep.txt").exists());
+    assert!(
+        !dst.join("drop.log").exists(),
+        "excluded update-only name must not protect a dst entry under --delete-excluded"
+    );
+}
+
+#[test]
+fn delete_update_exclusive_mirrors_update_set() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let upd = tmp.path().join("upd");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"a").unwrap(); // source-only (absent from update)
+    std::fs::write(src.join("b.txt"), b"b").unwrap(); // present in both
+    std::fs::create_dir(&upd).unwrap();
+    std::fs::write(upd.join("b.txt"), b"b").unwrap();
+    std::fs::write(upd.join("c.txt"), b"c").unwrap(); // update-only
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("a.txt"), b"old-a").unwrap(); // source-only's dst counterpart
+    std::fs::write(dst.join("stale.txt"), b"stale").unwrap();
+
+    // --update-exclusive materializes only the update set {b, c} (a.txt is source-only and
+    // skipped). With --delete the destination must mirror that set exactly: a.txt (source-only)
+    // and stale.txt are pruned, matching `rsync --link-dest --delete`.
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--update-exclusive")
+        .arg("--update")
+        .arg(&upd)
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    assert!(dst.join("b.txt").exists());
+    assert!(dst.join("c.txt").exists());
+    assert!(
+        !dst.join("a.txt").exists(),
+        "source-only entry must be pruned under --update-exclusive (exact mirror of update set)"
+    );
+    assert!(!dst.join("stale.txt").exists());
+}
+
+#[test]
+fn delete_skip_specials_protects_update_only_special() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let upd = tmp.path().join("upd");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::create_dir(&upd).unwrap();
+    // an update-only special (FIFO) that --skip-specials will skip copying
+    let mkfifo = Command::new("mkfifo")
+        .arg(upd.join("pipe"))
+        .status()
+        .unwrap();
+    assert!(mkfifo.success(), "mkfifo unavailable");
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("pipe"), "old").unwrap(); // counterpart of the skipped special
+
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--skip-specials")
+        .arg("--update")
+        .arg(&upd)
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(
+        dst.join("pipe").exists(),
+        "destination counterpart of a skipped update-only special must not be pruned"
+    );
+}
+
+#[test]
+fn delete_update_path_exclude_protects_descendant() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let upd = tmp.path().join("upd");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::create_dir_all(upd.join("cache")).unwrap(); // an update-only directory
+    std::fs::create_dir_all(dst.join("cache")).unwrap();
+    std::fs::write(dst.join("cache").join("keep.log"), "x").unwrap(); // matches cache/*.log
+
+    // The path-based exclude must protect dst/cache/keep.log even though pruning happens inside
+    // the delegated copy of the update-only `cache` directory (its filter is rooted correctly).
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--exclude")
+        .arg("cache/*.log")
+        .arg("--update")
+        .arg(&upd)
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(
+        dst.join("cache").join("keep.log").exists(),
+        "path-based exclude must protect a descendant of an update-only directory"
+    );
+}
+
+#[test]
+fn delete_update_path_include_keeps_matching_descendant() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let upd = tmp.path().join("upd");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::create_dir_all(upd.join("cache")).unwrap();
+    std::fs::write(upd.join("cache").join("keep.txt"), "x").unwrap(); // matches include cache/*.txt
+    std::fs::create_dir_all(dst.join("cache")).unwrap();
+    std::fs::write(dst.join("cache").join("keep.txt"), "old").unwrap();
+
+    // --include 'cache/*.txt': the update-only cache/keep.txt is in scope, so it must be copied
+    // and NOT pruned. Regression: copy-side filtering used the delegated root (saw "keep.txt",
+    // skipped it), then pruning used the correct root and deleted the included destination entry.
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--include")
+        .arg("cache/*.txt")
+        .arg("--update")
+        .arg(&upd)
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(
+        dst.join("cache").join("keep.txt").exists(),
+        "an included update-only descendant must be kept, not pruned"
+    );
+}
+
+#[test]
+fn delete_type_change_update_protects_excluded_descendant() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let upd = tmp.path().join("upd");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("node"), b"a file").unwrap(); // src `node` is a FILE
+    std::fs::create_dir(&upd).unwrap();
+    std::fs::create_dir(upd.join("node")).unwrap(); // update `node` is a DIRECTORY (type change)
+    std::fs::create_dir_all(dst.join("node")).unwrap();
+    std::fs::write(dst.join("node").join("keep.log"), "x").unwrap(); // extraneous, matches node/*.log
+
+    // src `node` (file) vs update `node` (dir) is a type change, so link delegates to copy from
+    // the update directory. Under --delete, pruning inside that delegated subtree must evaluate the
+    // path-anchored exclude at the correct root (`node/*.log`) and protect keep.log. Regression:
+    // the type-change delegation passed an empty filter_base, so keep.log was tested as "keep.log"
+    // (unmatched) and deleted.
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--exclude")
+        .arg("node/*.log")
+        .arg("--update")
+        .arg(&upd)
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(
+        dst.join("node").join("keep.log").exists(),
+        "path-based exclude must protect a descendant inside a type-changed (file->dir) update delegation"
+    );
+}
+
+#[test]
+fn delete_does_not_prune_through_dst_symlink() {
+    use std::os::unix::fs::symlink;
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    let outside = tmp.path().join("outside"); // must NOT be touched
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"a").unwrap();
+    std::fs::create_dir(&outside).unwrap();
+    std::fs::write(outside.join("precious.txt"), b"keep me").unwrap();
+    // dst is a symlink to an external directory
+    symlink(&outside, &dst).unwrap();
+
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    // pruning must NOT follow the destination symlink: the external target is untouched ...
+    assert!(
+        outside.join("precious.txt").exists(),
+        "rlink --delete must not delete files through a destination symlink"
+    );
+    // ... and dst was replaced by a real directory mirroring src.
+    assert!(!dst.symlink_metadata().unwrap().file_type().is_symlink());
+    assert!(dst.join("a.txt").exists());
+}
+
+#[test]
+fn delete_excluded_update_type_change_to_excluded_dir_prunes_dst() {
+    // rlink --delete --delete-excluded --update where an update turns an included source FILE into
+    // an excluded DIRECTORY (`node/`). Nothing is materialized at dst/node, so a stale pre-existing
+    // dst/node must be pruned — the keep-set must reflect the materialized (update) type, not the
+    // source file type.
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let upd = tmp.path().join("upd");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("node"), b"file").unwrap(); // src/node is a FILE
+    std::fs::create_dir(&upd).unwrap();
+    std::fs::create_dir(upd.join("node")).unwrap(); // update/node is a DIRECTORY (excluded by node/)
+    std::fs::write(upd.join("node").join("inner.txt"), b"x").unwrap();
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("node"), b"stale").unwrap(); // pre-existing dst/node
+
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--delete-excluded")
+        .arg("--update")
+        .arg(&upd)
+        .arg("--exclude")
+        .arg("node/")
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    assert!(
+        !dst.join("node").exists(),
+        "stale dst/node must be pruned: its materialized (update) type is an excluded directory"
+    );
+}
+
+#[test]
+fn delete_path_include_materializes_nested_symlink() {
+    use std::os::unix::fs::symlink;
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir_all(src.join("dir")).unwrap();
+    symlink("../target", src.join("dir").join("link")).unwrap();
+    std::fs::create_dir_all(dst.join("dir")).unwrap();
+    symlink("../stale", dst.join("dir").join("link")).unwrap();
+
+    // --include 'dir/link' with rlink --delete. Regression: link_internal delegated symlink
+    // materialization through copy::copy with an empty filter_base, so the inner filter re-
+    // evaluated the include against the bare basename "link" (via should_include_root_item)
+    // and skipped the copy. Meanwhile the outer loop had already inserted "link" into the
+    // keep_set, so pruning protected the stale destination. Net: stale dst/dir/link survived
+    // a mirror sync. Fix: pass the entry's logical path as filter_base so the inner check
+    // uses nested semantics and matches `dir/link`.
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--include")
+        .arg("dir/link")
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let target = std::fs::read_link(dst.join("dir").join("link")).unwrap();
+    assert_eq!(
+        target,
+        std::path::PathBuf::from("../target"),
+        "the included nested symlink must be materialized at the destination, not left stale"
+    );
+}
+
+#[test]
+fn delete_path_include_materializes_nested_symlink_via_update() {
+    use std::os::unix::fs::symlink;
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let upd = tmp.path().join("upd");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir_all(src.join("dir")).unwrap();
+    symlink("../from_src", src.join("dir").join("link")).unwrap();
+    std::fs::create_dir_all(upd.join("dir")).unwrap();
+    symlink("../from_upd", upd.join("dir").join("link")).unwrap();
+    std::fs::create_dir_all(dst.join("dir")).unwrap();
+    symlink("../stale", dst.join("dir").join("link")).unwrap();
+
+    // Same regression as the no-update case, but on the matching-file-type update branch in
+    // link_internal where both src and update entries are symlinks (the
+    // `update_metadata.is_symlink()` arm): the delegation also passed an empty filter_base.
+    // The update's symlink must materialize (target == "../from_upd"), not be left stale.
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--include")
+        .arg("dir/link")
+        .arg("--update")
+        .arg(&upd)
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    let target = std::fs::read_link(dst.join("dir").join("link")).unwrap();
+    assert_eq!(
+        target,
+        std::path::PathBuf::from("../from_upd"),
+        "the update's nested symlink must be materialized at the destination, not left stale"
+    );
+}
+
+#[test]
+fn delete_skip_specials_with_excluded_update_protects_source_special() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let upd = tmp.path().join("upd");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    // source has a FIFO (special file) that --skip-specials will skip copying
+    let mkfifo = Command::new("mkfifo")
+        .arg(src.join("pipe"))
+        .status()
+        .unwrap();
+    assert!(mkfifo.success(), "mkfifo unavailable");
+    // update has a directory with the SAME name, excluded by the filter
+    std::fs::create_dir(&upd).unwrap();
+    std::fs::create_dir(upd.join("pipe")).unwrap();
+    // pre-existing destination counterpart (e.g. from a previous mirror run)
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("pipe"), "old").unwrap();
+
+    // Regression: the source loop inserted `pipe` into keep_set and then `continue`d on the
+    // --skip-specials branch BEFORE adding to processed_files. The update loop then saw `pipe/`
+    // filtered out and unconditionally did `keep_set.remove(entry_name)`, dropping the source
+    // special's keep_set entry → prune deleted dst/pipe. With --skip-specials, the destination
+    // counterpart of a skipped source special must be retained.
+    let status = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--skip-specials")
+        .arg("--exclude")
+        .arg("pipe/")
+        .arg("--update")
+        .arg(&upd)
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(
+        dst.join("pipe").exists(),
+        "destination counterpart of a --skip-specials'd source special must be retained when an excluded update entry shares the name"
+    );
+}
+
+#[test]
+fn delete_update_exclusive_missing_update_path_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let missing_upd = tmp.path().join("does_not_exist");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("src_only.txt"), b"x").unwrap();
+    std::fs::create_dir(&dst).unwrap();
+    std::fs::write(dst.join("stale.txt"), b"old").unwrap();
+
+    // Regression: with --update-exclusive the materialized set is the update set. When the
+    // update root was missing, link_internal hit the recursive early-return (line 254) before
+    // the prune phase, so rlink reported success with an empty summary and left every stale
+    // dst entry in place — a silent "mirror" that didn't mirror anything. We now reject the
+    // missing update root at the public link() entry so a typo'd --update doesn't accidentally
+    // preserve (or, with the other proposed option, wipe) the destination tree.
+    let output = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--update-exclusive")
+        .arg("--update")
+        .arg(&missing_upd)
+        .arg(&src)
+        .arg(&dst)
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "rlink --delete --update-exclusive with a missing --update path must fail; stdout/stderr were: {}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    // dst is left intact (we erred before any pruning, so the user can correct the typo and re-run)
+    assert!(dst.join("stale.txt").exists());
+}
+
+#[test]
+fn delete_missing_update_path_errors_even_without_exclusive() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let missing_upd = tmp.path().join("does_not_exist");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"x").unwrap();
+    std::fs::create_dir(&dst).unwrap();
+    // dst entry the missing update tree WOULD have protected (no counterpart in src).
+    std::fs::write(dst.join("update_only.txt"), b"old").unwrap();
+
+    // Regression: with --delete (no --update-exclusive) and a missing --update root, link_internal
+    // sets `update_metadata_opt = None` and proceeds as if no --update was given. The source-only
+    // keep_set then makes any "would have been in update" dst entry look extraneous, and the
+    // --delete prune wipes it. A typo'd --update under --delete is destructive in the same way
+    // the --update-exclusive case is, so we reject the missing root at the public link() entry.
+    let output = Command::new(rlink_bin())
+        .arg("--delete")
+        .arg("--update")
+        .arg(&missing_upd)
+        .arg(&src)
+        .arg(&dst)
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "rlink --delete --update <missing> must fail; stdout/stderr were: {}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    // dst entries are left intact (we erred before any prune).
+    assert!(dst.join("update_only.txt").exists());
+}
+
+#[test]
+fn missing_update_path_without_delete_or_exclusive_falls_back() {
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let missing_upd = tmp.path().join("does_not_exist");
+    let dst = tmp.path().join("dst");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"x").unwrap();
+    // intentionally do NOT pre-create dst — without --delete (which auto-overwrites) a pre-
+    // existing dst is rejected by rlink's "destination exists" guard, which would mask the
+    // behavior we're checking here.
+
+    // Without --delete or --update-exclusive, a missing --update path falls back to "no update"
+    // mode: rlink links from src as if --update was never specified. This is the long-standing
+    // behavior. Lock it in so the new missing-update-root rejection doesn't accidentally widen
+    // to reject the non-destructive case too.
+    let status = Command::new(rlink_bin())
+        .arg("--update")
+        .arg(&missing_upd)
+        .arg(&src)
+        .arg(&dst)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(dst.join("a.txt").exists());
+}


### PR DESCRIPTION
## Summary

Adds an rsync-style `--delete` flag to **local** `rcp` and `rlink`: it mirrors the source onto the destination, removing destination entries that have no source counterpart.

- **Engine** (`common`): new `delete::prune_extraneous` helper — per-directory keep-set diff, exclude-protection, `--max-delete` budget (shared atomic counter), and dry-run support — reusing the existing `rm::rm` machinery. Wired into `copy_internal` (rcp) and `link_internal` (rlink). The rlink keep-set is `src ∪ update`.
- **CLI**: `--delete`, `--delete-excluded`, `--max-delete` on both tools. `--delete` implies `--overwrite`. rcp enforces a single source and rejects `--delete` with remote paths.
- **Safety** (this is a data-destroying feature):
  - never prunes a directory whose source enumeration failed (the "source mount vanished → wipe the backup" footgun);
  - excluded files are protected from deletion by default (`--delete-excluded` to override);
  - `--max-delete=N` circuit breaker (approximate under parallelism; each top-level extraneous entry or subtree counts as one);
  - full `--dry-run` support (reports without removing).
- **Zero cost when off**: delete state is modeled as `Option<DeleteSettings>` (`None` = off), so the default copy/link path never enumerates the destination or builds a keep-set.
- **Remote `rcp --delete` is intentionally out of scope** for this PR — it's rejected with a clear error. The protocol-based design for the follow-on (Mechanism A: the source ships its authoritative child-name set to the destination) is documented in the spec.

Design & plan docs (committed in this branch):
- `docs/superpowers/specs/2026-05-25-rcp-delete-flag-design.md`
- `docs/superpowers/plans/2026-05-25-rcp-rlink-delete-local.md`

## Test Plan

- [x] `just ci` green: lint, doc, debug + release tests, and the Docker multi-host suite (48/48) — confirms the remote/rcpd path is unaffected
- [x] Helper unit tests: keep-set removal, exclude-protection (+ `--delete-excluded`), `--max-delete` abort
- [x] rcp integration: mirror, filter-protection, `--max-delete`, dry-run (no removal), failed-enumeration safety, prune-at-depth, extraneous-symlink removal, multi-source rejection
- [x] rlink integration: mirror, `src ∪ update` keep-set
