### PR TITLE
[codex] Add Codex review workflow

### DIFF
--- a/.github/codex/prompts/review.md
+++ b/.github/codex/prompts/review.md
@@ -1,0 +1,31 @@
+You are reviewing a GitHub pull request for RCP Tools.
+
+Review only the pull request changes from `PR_BASE_SHA` to `PR_HEAD_SHA`.
+Start by reading `AGENTS.md`, `CONVENTIONS.md`, and any relevant files or docs
+for the changed areas. Use read-only local commands such as:
+
+```bash
+git diff --stat "$PR_BASE_SHA...$PR_HEAD_SHA"
+git diff "$PR_BASE_SHA...$PR_HEAD_SHA"
+```
+
+Focus on actionable correctness risks:
+
+- Bugs, regressions, race conditions, data loss, security problems, or broken error handling.
+- Missing tests or docs when the changed behavior needs them.
+- Project convention violations from `AGENTS.md` and `CONVENTIONS.md`.
+- Remote copy protocol changes that do not stay aligned with `docs/remote_protocol.md`.
+
+Do not edit files, install dependencies, commit, push, or run commands that write build
+artifacts. Do not use the network. If the read-only sandbox prevents a verification
+step, continue with static review and mention the gap only when it affects confidence.
+
+Output format:
+
+- If there are actionable findings, list them first in descending severity.
+- For each finding include a severity tag, a concise title, file and line reference,
+  why it matters, and the smallest practical fix.
+- If there are no actionable findings, say `No actionable findings.`
+- End with a short `Review basis` section naming the diff range and the main files
+  or docs inspected.
+- Keep the full response short enough to post as one GitHub pull request comment.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,6 +11,21 @@ Runs on every push and pull request to `main`:
 - **documentation**: Builds documentation with strict warnings
 - **test**: Runs the full test suite using cargo-nextest
 
+### codex-review.yml
+Runs on pull request open, reopen, ready-for-review, and synchronize events for `main`.
+The synchronize event fires when new commits are pushed to the pull request branch.
+
+The workflow runs `openai/codex-action@v1` with `gpt-5.5`, `xhigh` effort, a
+read-only Codex sandbox, and `drop-sudo` runner hardening. The Codex job checks out
+the pull request merge commit with read-only repository permissions and does not
+persist checkout credentials. A separate posting job uses the GitHub token only to
+add the review result as a pull request comment. The workflow intentionally runs only
+for non-draft pull requests from this repository so repository secrets are not
+exposed to forked pull requests.
+
+**Setup:** add an `OPENAI_API_KEY` repository secret under Settings -> Secrets and
+variables -> Actions.
+
 ### release.yml
 Builds, publishes binary packages, and publishes to crates.io when a tag is pushed. Triggered by `v*` tag pushes.
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,71 @@
+name: Codex review
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  codex:
+    name: Run Codex review
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      final_message: ${{ steps.run_codex.outputs.final-message }}
+    steps:
+    - name: Check out pull request
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        ref: refs/pull/${{ github.event.pull_request.number }}/merge
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Run Codex
+      id: run_codex
+      uses: openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c # v1
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      with:
+        openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+        prompt-file: .github/codex/prompts/review.md
+        model: gpt-5.5
+        effort: xhigh
+        sandbox: read-only
+        safety-strategy: drop-sudo
+
+  post-feedback:
+    name: Post Codex feedback
+    needs: codex
+    if: needs.codex.outputs.final_message != ''
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - name: Post pull request comment
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        CODEX_FINAL_MESSAGE: ${{ needs.codex.outputs.final_message }}
+      run: |
+        review_file="$RUNNER_TEMP/codex-review.md"
+        {
+          printf '## Codex review for `%s`\n\n' "$PR_HEAD_SHA"
+          printf '%s\n' "$CODEX_FINAL_MESSAGE"
+        } > "$review_file"
+
+        gh pr comment "$PR_NUMBER" --body-file "$review_file"


### PR DESCRIPTION
## Summary

- Add a `codex-review.yml` GitHub Actions workflow that runs Codex review on pull request updates.
- Configure Codex with `gpt-5.5`, `xhigh` effort, a read-only sandbox, and `drop-sudo` runner hardening.
- Add a focused review prompt and document the required `OPENAI_API_KEY` secret.

## Validation

- `just ci` passed, including debug/release tests, doctests, and Docker tests.
- An initial sandboxed run failed on socket special-file fixtures with `Operation not permitted`; the full run passed outside the sandbox.