### PR TITLE
TOCTOU-safe walk: fd-based hardening across the rcp suite

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -48,6 +48,15 @@ jobs:
     - name: Check remote test naming
       run: ./scripts/check-remote-test-naming.sh
 
+    - name: Check walk-driver usage
+      run: ./scripts/check-walk-driver-usage.sh
+
+    - name: Check source-read fidelity
+      run: ./scripts/check-source-read-fidelity.sh
+
+    - name: Check package metadata
+      run: ./scripts/check-package-metadata.sh
+
     - name: Lint
       run: cargo clippy --workspace --all-targets -- -D warnings
       env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,6 +1920,7 @@ dependencies = [
  "filetime",
  "futures",
  "hex",
+ "libc",
  "predicates",
  "rand 0.10.1",
  "rcp-tools-common",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -39,7 +39,7 @@ hdrhistogram = { version = "7.5", default-features = false, features = ["seriali
 humantime = "2.3"
 indicatif = "0.18"
 libc = "0.2"
-nix = { version = "0.31", features = ["fs", "hostname", "user"] }
+nix = { version = "0.31", features = ["dir", "fs", "hostname", "user", "zerocopy"] }
 procfs = "0.18"
 rand = "0.10"
 sysinfo = "0.39"

--- a/common/src/chmod.rs
+++ b/common/src/chmod.rs
@@ -3,12 +3,27 @@
 //! The public entry point is [`chmod`]; it mirrors [`crate::rm()`] but transforms
 //! metadata in place (from a per-type rule) instead of removing entries.
 use crate::filter::TimeFilter;
+use crate::preserve::Metadata as _;
 use crate::progress::Progress;
-use crate::walk::{self, EntryKind};
+use crate::safedir::{self, Dir, FileMeta, Handle};
+use crate::walk::{EntryKind, LeafPermit, PermitKind};
+use crate::walk_driver::{
+    DirAction, DirPreResult, EntryCx, ProcessedChildren, WalkVisitor, process_entry,
+};
 use anyhow::{Context, anyhow};
-use async_recursion::async_recursion;
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::ffi::OsStr;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::sync::Arc;
 use tracing::instrument;
+
+/// The full 12-bit (`0o7777`) mode of a metadata snapshot, including the
+/// setuid/setgid/sticky bits. [`FileMeta`] exposes its mode only through
+/// `permissions()`, so this is the canonical way `compute_plan`'s inputs are
+/// derived from an fd-pinned [`Handle`].
+fn mode_of(meta: &FileMeta) -> u32 {
+    meta.permissions().mode() & 0o7777
+}
 
 /// Error type for chmod operations. See [`crate::error::OperationError`].
 pub type Error = crate::error::OperationError<Summary>;
@@ -554,54 +569,72 @@ fn describe_change(cur_mode: u32, cur_uid: u32, cur_gid: u32, plan: &EntryPlan) 
     parts.join(", ")
 }
 
-async fn apply_plan(path: &std::path::Path, plan: &EntryPlan) -> anyhow::Result<()> {
+/// Apply a computed plan to a single entry through the `O_PATH` [`Handle`] we
+/// already hold, never re-resolving the entry by path.
+///
+/// The handle is pinned to the exact inode (opened `O_NOFOLLOW`), so both syscalls
+/// act on that inode rather than on a name: there is no TOCTOU window and no
+/// `recheck` is needed (unlike copy's name-based overwrite). A concurrent
+/// rename/symlink swap of the directory entry cannot redirect either operation to a
+/// different target.
+///
+/// Syscall choice, following the documented chown → chmod ordering:
+/// * **chown** — [`safedir::fchown_handle`] (inode-exact `fchownat` with
+///   `AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW`). Applies to files, dirs, AND symlinks.
+/// * **chmod** — [`safedir::chmod_via_proc_fd`] (chmod of the inode via its
+///   `/proc/self/fd` magic symlink). Used for both files and directories: `fchmod`
+///   is `EBADF` on the `O_PATH` handle, and the `/proc` path is inode-exact, works
+///   on all kernels, and crucially works even on a `0000`-mode directory we own
+///   (so a pre-order `d:u+rwx` can recover an unreadable directory before we open
+///   it to recurse). Symlinks are never chmod'd — [`compute_plan`] guarantees
+///   `plan.chmod` is `None` for a symlink.
+async fn apply_plan(handle: &Handle, plan: &EntryPlan) -> anyhow::Result<()> {
     if let Some((uid, gid)) = plan.chown {
-        let dst = path.to_owned();
-        walk::run_metadata_probed(
-            congestion::Side::Destination,
-            congestion::MetadataOp::Chmod,
-            async {
-                tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-                    nix::unistd::fchownat(
-                        nix::fcntl::AT_FDCWD,
-                        &dst,
-                        uid.map(Into::into),
-                        gid.map(Into::into),
-                        nix::fcntl::AtFlags::AT_SYMLINK_NOFOLLOW,
-                    )
-                    .with_context(|| format!("failed to chown {dst:?}"))?;
-                    Ok(())
-                })
-                .await?
-            },
-        )
-        .await?;
+        safedir::fchown_handle(handle, congestion::Side::Destination, uid, gid)
+            .await
+            .with_context(|| format!("failed to chown via fd (uid={uid:?}, gid={gid:?})"))?;
     }
     if let Some(mode) = plan.chmod {
-        // path-based chmod (only ever called on non-symlinks); follows the entry
-        // itself. avoids an extra open() vs fchmod and matches rm's dir path.
-        walk::run_metadata_probed(
-            congestion::Side::Destination,
-            congestion::MetadataOp::Chmod,
-            tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)),
-        )
-        .await
-        .with_context(|| format!("failed to chmod {path:?} to {mode:04o}"))?;
+        safedir::chmod_via_proc_fd(handle, congestion::Side::Destination, mode)
+            .await
+            .with_context(|| format!("failed to chmod via fd to {mode:04o}"))?;
     }
     Ok(())
 }
 
 /// Apply the change to a single entry (a leaf, or a directory after its children
 /// were processed). Handles the time filter, dry-run, no-op skip, and counters.
-async fn process_entry(
+///
+/// `handle` is the entry's fd-pinned `O_PATH` [`Handle`]; its [`Handle::meta`]
+/// snapshot feeds [`compute_plan`] (replacing the old path-based `symlink_metadata`)
+/// and is the target of the inode-exact chown/chmod. `path` is the reconstructed
+/// display path used purely for dry-run output and diagnostics.
+async fn apply_entry_change(
     prog: &'static Progress,
     path: &std::path::Path,
-    metadata: &std::fs::Metadata,
+    handle: &Handle,
     kind: EntryKind,
     settings: &Settings,
 ) -> Result<Summary, Error> {
     if let Some(ref time_filter) = settings.time_filter {
-        match time_filter.matches(metadata) {
+        // the time filter needs full std metadata (btime for --created-before), which
+        // the fd snapshot does not carry; read it inode-exact through the pinned handle.
+        let metadata =
+            match safedir::stat_meta_via_proc_fd(handle, congestion::Side::Destination).await {
+                Ok(md) => md,
+                Err(err) => {
+                    let err = anyhow::Error::new(err).context(format!(
+                        "failed reading metadata for time filter on {path:?}"
+                    ));
+                    if settings.fail_early {
+                        return Err(Error::new(err, Default::default()));
+                    }
+                    tracing::warn!("time filter failed for {:?}, skipping: {:#}", path, &err);
+                    kind.inc_skipped(prog);
+                    return Ok(skipped_summary_for(kind));
+                }
+            };
+        match time_filter.matches(&metadata) {
             Ok(result) => {
                 if let Some(reason) = result.as_skip_reason() {
                     if let Some(mode) = settings.dry_run {
@@ -622,13 +655,9 @@ async fn process_entry(
             }
         }
     }
-    let plan = compute_plan(
-        metadata.mode(),
-        metadata.uid(),
-        metadata.gid(),
-        kind,
-        settings,
-    );
+    let meta = handle.meta();
+    let cur_mode = mode_of(meta);
+    let plan = compute_plan(cur_mode, meta.uid(), meta.gid(), kind, settings);
     if plan.is_noop() {
         if let Some(crate::config::DryRunMode::All) = settings.dry_run {
             println!("unchanged {} {:?}", kind.label(), path);
@@ -636,57 +665,66 @@ async fn process_entry(
         return Ok(inc_unchanged(prog, kind));
     }
     if settings.dry_run.is_some() {
-        let desc = describe_change(metadata.mode(), metadata.uid(), metadata.gid(), &plan);
+        let desc = describe_change(cur_mode, meta.uid(), meta.gid(), &plan);
         println!("would modify {} {:?}: {}", kind.label(), path, desc);
         return Ok(inc_changed(prog, kind));
     }
-    apply_plan(path, &plan)
+    apply_plan(handle, &plan)
         .await
         .map_err(|err| Error::new(err, Default::default()))?;
     Ok(inc_changed(prog, kind))
 }
 
-/// Strip trailing path separators from a root operand. A trailing slash forces the
-/// OS to resolve the final component as a directory, which would dereference a symlink
-/// root like `link/` (following it to its target) -- violating the non-dereference
-/// behavior. Stripping makes `link/` behave like `link` (the symlink itself).
-/// (This non-dereference behavior is not robust against concurrent path replacement
-/// under elevated privilege; see `docs/tocttou.md`.)
-fn without_trailing_separators(path: &std::path::Path) -> std::path::PathBuf {
-    use std::os::unix::ffi::OsStrExt;
-    let bytes = path.as_os_str().as_bytes();
-    let mut end = bytes.len();
-    while end > 1 && bytes[end - 1] == b'/' {
-        end -= 1;
-    }
-    std::path::PathBuf::from(std::ffi::OsStr::from_bytes(&bytes[..end]))
-}
-
 /// Public entry point. Applies metadata changes to `path` and, recursively, its
 /// contents. Mirrors [`crate::rm::rm`] for the root-filter check.
+///
+/// The walk is fd-based (see [`crate::safedir`]): the root operand is opened
+/// relative to its parent directory and every entry is classified and mutated
+/// through file-descriptor-relative syscalls. A privileged `rchm` therefore cannot
+/// be redirected by a concurrent symlink swap into chmod/chown'ing a target outside
+/// the intended tree — the `O_NOFOLLOW` opens and the inode-pinned `O_PATH` handles
+/// catch the swap and fail closed.
 #[instrument(skip(prog_track, settings))]
 pub async fn chmod(
     prog_track: &'static Progress,
     path: &std::path::Path,
     settings: &Settings,
 ) -> Result<Summary, Error> {
-    let stripped = without_trailing_separators(path);
-    let path = stripped.as_path();
-    if let Some(ref filter) = settings.filter
-        && let Some(name) = path.file_name().map(std::path::Path::new)
-    {
-        let metadata = walk::run_metadata_probed(
-            congestion::Side::Source,
-            congestion::MetadataOp::Stat,
-            tokio::fs::symlink_metadata(path),
-        )
+    // decompose the operand into (parent dir, final component) so the root entry is opened and
+    // classified relative to a directory fd — the same fd-relative shape every nested entry takes.
+    // rchm mutates "the" tree in place, so the parent is opened on the Destination side. `.`/`..`
+    // operands (e.g. `rchm -R … .`) are canonicalized so they still name a directory; `/` is
+    // rejected.
+    let operand = crate::walk::split_root_operand(path)
         .await
-        .with_context(|| format!("failed reading metadata from {path:?}"))
         .map_err(|err| Error::new(err, Default::default()))?;
-        match filter.should_include_root_item(name, metadata.is_dir()) {
+    let parent_path = operand.parent.as_path();
+    let name = operand.name.as_os_str();
+    let path = operand.display.as_path();
+    // the operand's TRUSTED parent prefix is resolved following symlinks normally (the prefix is
+    // trusted up to and including the operand's container — only entries strictly below the named
+    // root are O_NOFOLLOW-hardened). a symlinked parent (e.g. `rchm symlinkdir/foo`) is followed; the
+    // operand itself is still classified via `child(name)` with O_NOFOLLOW (a symlink root is
+    // operated on as the link itself).
+    let parent = Dir::open_parent_dir(parent_path, congestion::Side::Destination)
+        .await
+        .with_context(|| format!("cannot open parent directory {parent_path:?}"))
+        .map_err(|err| Error::new(err, Default::default()))?;
+    // cross from the trusted parent prefix into the hardened tree (O_NOFOLLOW below here).
+    let parent = Arc::new(parent.into_tree());
+    if let Some(ref filter) = settings.filter {
+        // classify the root via its parent fd purely to evaluate the root filter; the driver
+        // re-classifies the root authoritatively in `process_entry`, so this handle is just a probe.
+        let root_handle = parent
+            .child(name)
+            .await
+            .with_context(|| format!("failed reading metadata from {path:?}"))
+            .map_err(|err| Error::new(err, Default::default()))?;
+        let name_path = std::path::Path::new(name);
+        match filter.should_include_root_item(name_path, root_handle.kind() == EntryKind::Dir) {
             crate::filter::FilterResult::Included => {}
             result => {
-                let kind = EntryKind::from_metadata(&metadata);
+                let kind = root_handle.kind();
                 if let Some(mode) = settings.dry_run {
                     crate::dry_run::report_skip(path, &result, mode, kind.label_long());
                 }
@@ -695,16 +733,296 @@ pub async fn chmod(
             }
         }
     }
-    chmod_internal(prog_track, path, path, settings).await
+    run_chmod_root(prog_track, &parent, name, path, settings).await
+}
+
+/// Build the [`ChmodVisitor`] and process the root entry through the generic
+/// [`crate::walk_driver`] driver. The root is processed exactly like a nested child: classified
+/// authoritatively, then dispatched to `visit_leaf` or `dir_pre`/recurse/`dir_post`.
+async fn run_chmod_root(
+    prog_track: &'static Progress,
+    parent: &Arc<Dir>,
+    name: &OsStr,
+    root: &std::path::Path,
+    settings: &Settings,
+) -> Result<Summary, Error> {
+    let visitor = Arc::new(ChmodVisitor {
+        prog_track,
+        settings: settings.clone(),
+    });
+    // the root entry's owned context: rel_path/filter_path empty (the root), real_path = the root
+    // operand. chmod has no filter base (no delegated subtree), so `filter_path == rel_path`.
+    let root_cx = EntryCx {
+        parent: Arc::clone(parent),
+        name: name.to_owned(),
+        rel_path: PathBuf::new(),
+        filter_path: PathBuf::new(),
+        real_path: root.to_path_buf(),
+        dry_run: settings.dry_run.is_some(),
+        prog_track,
+    };
+    process_entry(visitor, root_cx, (), None).await // chmod has no second tree → root context `()`
+}
+
+/// The chmod walk's [`WalkVisitor`]. The driver owns enumeration, the leaf-permit lifecycle,
+/// spawning, the single drop-before-recurse site, and the error fold; this visitor supplies
+/// chmod's per-entry bodies (`apply_entry_change` for leaves, `apply_dir_self` for the directory's
+/// own pre-/post-order change, `open_dir` for descent). chmod has no second tree, so
+/// [`Self::DirContext`] is `()`.
+struct ChmodVisitor {
+    prog_track: &'static Progress,
+    settings: Settings,
+}
+
+/// State threaded from [`WalkVisitor::dir_pre`] to [`WalkVisitor::dir_post`] (same task) — what
+/// `dir_post` needs to apply the directory's own change.
+struct ChmodDirState {
+    /// The directory's owned `O_PATH` handle; the post-order chmod goes through its `/proc/self/fd`
+    /// magic symlink, inode-exact (works even on a `0000`-mode directory).
+    handle: Handle,
+    /// Only traversed to find include-matches (not directly matched), so its own mode/owner is left
+    /// unchanged (mirrors rm.rs).
+    traversed_only: bool,
+    /// The directory's own pre-order contribution, folded into the final summary by `dir_post`.
+    base: Summary,
+    /// A pre-order change error captured in keep-going mode (the descent still proceeded, so
+    /// `dir_post` surfaces it). `None` when the pre-order change succeeded or was deferred —
+    /// mutually exclusive with the post-order change `dir_post` applies under `defer_dir_changes`.
+    pre_order_error: Option<anyhow::Error>,
+}
+
+impl WalkVisitor for ChmodVisitor {
+    type Summary = Summary;
+    type DirContext = ();
+    type DirState = ChmodDirState;
+
+    fn root_dir_context(&self) {}
+
+    fn permit_kind(&self) -> PermitKind {
+        // metadata-only walk: no open fd held across leaf work, so gate on the pending-meta pool.
+        PermitKind::PendingMeta
+    }
+
+    fn want_permit(&self, hint: Option<EntryKind>) -> bool {
+        // known non-directory hint only (a hinted dir recurses; DT_UNKNOWN might be a dir) —
+        // matches the old spawn loop's `known_leaf` pre-acquire policy.
+        hint.is_some_and(|k| k != EntryKind::Dir)
+    }
+
+    fn fail_early(&self) -> bool {
+        self.settings.fail_early
+    }
+
+    fn filter(&self) -> Option<&crate::filter::FilterSettings> {
+        self.settings.filter.as_ref()
+    }
+
+    fn on_skip(
+        &self,
+        cx: &EntryCx,
+        kind: EntryKind,
+        skip_result: &crate::filter::FilterResult,
+    ) -> Summary {
+        // mirror the old spawn loop's inline filter-skip: the dry-run "skip ..." line plus the
+        // matching `*_skipped` counter. the driver already did the shared progress increment.
+        if let Some(mode) = self.settings.dry_run {
+            crate::dry_run::report_skip(&cx.real_path, skip_result, mode, kind.label());
+        }
+        skipped_summary_for(kind)
+    }
+
+    async fn visit_leaf(
+        &self,
+        cx: &EntryCx,
+        _parent_ctx: &(),
+        handle: Handle,
+        kind: EntryKind,
+        permit: Option<LeafPermit>,
+    ) -> Result<Summary, Error> {
+        // the leaf change (time-filter + compute_plan + apply_plan), exactly as the old leaf branch.
+        // the permit is held across this non-recursive work and dropped on return (the driver drops
+        // it for directories, never here).
+        let _permit = permit;
+        apply_entry_change(
+            self.prog_track,
+            &cx.real_path,
+            &handle,
+            kind,
+            &self.settings,
+        )
+        .await
+    }
+
+    async fn dir_pre(&self, cx: &EntryCx, _parent_ctx: &(), handle: &Handle) -> DirPreResult<Self> {
+        let path = &cx.real_path;
+        // a "traversed-only" dir was entered only because it COULD contain include-matches; it does
+        // not directly match an include pattern, so its own mode/owner is left unchanged (mirrors
+        // rm.rs) — only directly-selected entries are modified.
+        let traversed_only = self.settings.filter.as_ref().is_some_and(|f| {
+            f.has_includes() && !f.directly_matches_include(&cx.filter_path, true)
+        });
+        let mut base = Summary::default();
+        let mut pre_order_error: Option<anyhow::Error> = None;
+        // pre-order (default, like `chmod -R`): change the dir BEFORE descending, via the O_PATH
+        // handle's /proc path (works even on a 0000 dir) — so `--mode d:u+rwx` recovers an
+        // unreadable dir before the open reads it, and a later child failure can't prevent it. a
+        // restrictive change (e.g. `d:a-rwx`) makes the open fail and is reported (like `chmod -R`).
+        if !self.settings.defer_dir_changes {
+            match apply_dir_self(
+                self.prog_track,
+                path,
+                handle,
+                traversed_only,
+                &self.settings,
+            )
+            .await
+            {
+                Ok(dir_summary) => base = base + dir_summary,
+                // fail-early: report now, never open or descend. keep-going: stash the error for
+                // `dir_post` to surface after the descent, and still open and recurse (old flow).
+                Err(error) if self.settings.fail_early => {
+                    return Err(Error::new(error.source, base + error.summary));
+                }
+                Err(error) => {
+                    tracing::error!("chmod: {:?} failed with: {:#}", path, &error);
+                    base = base + error.summary;
+                    pre_order_error = Some(error.source);
+                }
+            }
+        }
+        // dup the dir's O_PATH handle (a pure fd dup — no extra openat/fstatat) so `dir_post` can
+        // apply the deferred/post-order change inode-exact: the driver lends `&handle` only for
+        // `dir_pre`, so the post-order step needs its own owned handle to the same inode.
+        let dir_handle = handle
+            .try_clone()
+            .with_context(|| format!("cannot duplicate directory handle for {path:?}"))
+            .map_err(|err| Error::new(err, base))?;
+        // open the directory's real fd for the driver to enumerate. in post-order the dir still has
+        // its original mode, so the open succeeds and the held fd survives a later search-bit strip.
+        // an open failure (restrictive pre-order change, or a pre-existing unreadable dir) is reported.
+        match cx.parent.open_dir(&cx.name).await {
+            Ok(dir) => Ok(DirAction::Descend {
+                dir: Arc::new(dir),
+                child_ctx: (),
+                state: ChmodDirState {
+                    handle: dir_handle,
+                    traversed_only,
+                    base,
+                    pre_order_error,
+                },
+            }),
+            Err(error) => {
+                let error = anyhow::Error::new(error)
+                    .context(format!("cannot open directory {path:?} for reading"));
+                if self.settings.fail_early {
+                    return Err(Error::new(error, base));
+                }
+                // keep-going: no children to walk. fold the pre-order error (if any) + the open
+                // error, apply the deferred change (if any), and surface the combined error — the
+                // net result of the old open-failure path (empty join loop, then deferred change).
+                let errors = crate::error_collector::ErrorCollector::default();
+                if let Some(pre_order_error) = pre_order_error {
+                    errors.push(pre_order_error);
+                }
+                tracing::error!("chmod: {:#}", &error);
+                errors.push(error);
+                if self.settings.defer_dir_changes {
+                    match apply_dir_self(
+                        self.prog_track,
+                        path,
+                        handle,
+                        traversed_only,
+                        &self.settings,
+                    )
+                    .await
+                    {
+                        Ok(dir_summary) => base = base + dir_summary,
+                        Err(error) => {
+                            tracing::error!("chmod: {:?} failed with: {:#}", path, &error);
+                            base = base + error.summary;
+                            errors.push(error.source);
+                        }
+                    }
+                }
+                // `into_error()` is `Some` here: at least the open error was pushed.
+                Err(Error::new(errors.into_error().unwrap(), base))
+            }
+        }
+    }
+
+    async fn dir_post(
+        &self,
+        cx: &EntryCx,
+        state: ChmodDirState,
+        _processed: &ProcessedChildren,
+        child_result: Result<Summary, Error>,
+    ) -> Result<Summary, Error> {
+        let ChmodDirState {
+            handle,
+            traversed_only,
+            base,
+            pre_order_error,
+        } = state;
+        let path = &cx.real_path;
+        // seed with the dir's own pre-order contribution, then fold the children (the driver passes
+        // `Err` here only in keep-going mode — fail-early aborts before post-order).
+        let (child_summary, child_error) = match child_result {
+            Ok(summary) => (summary, None),
+            Err(err) => (err.summary, Some(err.source)),
+        };
+        let mut summary = base + child_summary;
+        // collect the deferred pre-order error and the child error (keep-going only).
+        let errors = crate::error_collector::ErrorCollector::default();
+        if let Some(pre_order_error) = pre_order_error {
+            errors.push(pre_order_error);
+        }
+        if let Some(child_error) = child_error {
+            errors.push(child_error);
+        }
+        // post-order (`--defer-dir-changes`): change the dir AFTER its contents (needed to remove
+        // the owner's own traversal permission). the contents were read through a fd opened before
+        // this change, so stripping the search bit here can't lock us out; the change is inode-exact
+        // through the O_PATH handle. (`pre_order_error` is always `None` here, so the two are
+        // mutually exclusive.)
+        if self.settings.defer_dir_changes {
+            match apply_dir_self(
+                self.prog_track,
+                path,
+                &handle,
+                traversed_only,
+                &self.settings,
+            )
+            .await
+            {
+                Ok(dir_summary) => summary = summary + dir_summary,
+                Err(error) => {
+                    if self.settings.fail_early {
+                        return Err(Error::new(error.source, summary + error.summary));
+                    }
+                    tracing::error!("chmod: {:?} failed with: {:#}", path, &error);
+                    summary = summary + error.summary;
+                    errors.push(error.source);
+                }
+            }
+        }
+        if let Some(error) = errors.into_error() {
+            return Err(Error::new(error, summary));
+        }
+        Ok(summary)
+    }
 }
 
 /// Apply the directory's own change, or skip it when the directory was only traversed to
 /// find include-matches. Factored out so the walk can run it before (pre-order, default)
 /// or after (post-order, `--defer-dir-changes`) descending into the contents.
+///
+/// `handle` is the directory's `O_PATH` handle; the chmod goes through its `/proc/self/fd`
+/// magic symlink, so the change applies inode-exact and works even on a `0000`-mode
+/// directory (a pre-order `d:u+rwx` recovers traversability before we open the dir to read).
 async fn apply_dir_self(
     prog_track: &'static Progress,
     path: &std::path::Path,
-    metadata: &std::fs::Metadata,
+    handle: &Handle,
     traversed_only: bool,
     settings: &Settings,
 ) -> Result<Summary, Error> {
@@ -715,171 +1033,7 @@ async fn apply_dir_self(
         prog_track.directories_skipped.inc();
         return Ok(skipped_summary_for(EntryKind::Dir));
     }
-    process_entry(prog_track, path, metadata, EntryKind::Dir, settings).await
-}
-
-#[instrument(skip(prog_track, settings))]
-#[async_recursion]
-async fn chmod_internal(
-    prog_track: &'static Progress,
-    path: &std::path::Path,
-    source_root: &std::path::Path,
-    settings: &Settings,
-) -> Result<Summary, Error> {
-    let _ops_guard = prog_track.ops.guard();
-    let metadata = walk::run_metadata_probed(
-        congestion::Side::Source,
-        congestion::MetadataOp::Stat,
-        tokio::fs::symlink_metadata(path),
-    )
-    .await
-    .with_context(|| format!("failed reading metadata from {path:?}"))
-    .map_err(|err| Error::new(err, Default::default()))?;
-    let kind = EntryKind::from_metadata(&metadata);
-    if kind != EntryKind::Dir {
-        return process_entry(prog_track, path, &metadata, kind, settings).await;
-    }
-    // a directory may have been entered only because it *could contain* include-matches,
-    // not because it directly matches an include pattern. such "traversed-only" dirs are
-    // not modified themselves (mirrors rm.rs) -- only entries the filter directly selects.
-    let relative_path = walk::relative_to_root(path, source_root);
-    let traversed_only = settings
-        .filter
-        .as_ref()
-        .is_some_and(|f| f.has_includes() && !f.directly_matches_include(relative_path, true));
-    let errors = crate::error_collector::ErrorCollector::default();
-    let mut summary = Summary::default();
-    // pre-order (default, like `chmod -R`): change the directory BEFORE descending, so
-    // `--mode d:u+rwx` can recover an unreadable directory and a child failure can't
-    // prevent the directory's own change.
-    if !settings.defer_dir_changes {
-        match apply_dir_self(prog_track, path, &metadata, traversed_only, settings).await {
-            Ok(dir_summary) => summary = summary + dir_summary,
-            Err(error) => {
-                if settings.fail_early {
-                    return Err(Error::new(error.source, summary + error.summary));
-                }
-                tracing::error!("chmod: {:?} failed with: {:#}", path, &error);
-                summary = summary + error.summary;
-                errors.push(error.source);
-            }
-        }
-    }
-    // descend into the directory's contents
-    match tokio::fs::read_dir(path).await {
-        Ok(mut entries) => {
-            let mut join_set = tokio::task::JoinSet::new();
-            loop {
-                let (entry, entry_file_type) =
-                    match walk::next_entry_probed(&mut entries, congestion::Side::Source, || {
-                        format!("failed traversing directory {path:?}")
-                    })
-                    .await
-                    {
-                        Ok(Some(entry)) => entry,
-                        Ok(None) => break,
-                        Err(error) => {
-                            if settings.fail_early {
-                                return Err(Error::new(error, summary));
-                            }
-                            tracing::error!("chmod: {:#}", &error);
-                            errors.push(error);
-                            break;
-                        }
-                    };
-                let entry_path = entry.path();
-                let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
-                let relative_path = walk::relative_to_root(&entry_path, source_root);
-                if let Some(skip_result) = walk::should_skip_entry(
-                    &settings.filter,
-                    relative_path,
-                    entry_kind == EntryKind::Dir,
-                ) {
-                    if let Some(mode) = settings.dry_run {
-                        crate::dry_run::report_skip(
-                            &entry_path,
-                            &skip_result,
-                            mode,
-                            entry_kind.label(),
-                        );
-                    }
-                    entry_kind.inc_skipped(prog_track);
-                    summary = summary + skipped_summary_for(entry_kind);
-                    continue;
-                }
-                let settings = settings.clone();
-                let source_root = source_root.to_owned();
-                let known_leaf = entry_file_type.as_ref().is_some_and(|ft| !ft.is_dir());
-                let pending_guard = if known_leaf {
-                    Some(throttle::pending_meta_permit().await)
-                } else {
-                    None
-                };
-                join_set.spawn(async move {
-                    let _pending_guard = pending_guard;
-                    chmod_internal(prog_track, &entry_path, &source_root, &settings).await
-                });
-            }
-            drop(entries);
-            while let Some(res) = join_set.join_next().await {
-                match res {
-                    Ok(Ok(child)) => summary = summary + child,
-                    Ok(Err(error)) => {
-                        tracing::error!("chmod: {:?} failed with: {:#}", path, &error);
-                        summary = summary + error.summary;
-                        errors.push(error.source);
-                        if settings.fail_early {
-                            break;
-                        }
-                    }
-                    Err(error) => {
-                        errors.push(error.into());
-                        if settings.fail_early {
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-        Err(read_error) => {
-            // couldn't read the directory -- e.g. owner r/x was just removed (a pre-order
-            // restrictive change) or it was already unreadable with no traversability-
-            // restoring rule. report it; unless --fail-early, keep going with the rest.
-            let error = anyhow::Error::new(read_error)
-                .context(format!("failed reading directory {path:?}"));
-            if settings.fail_early {
-                return Err(Error::new(error, summary));
-            }
-            tracing::error!("chmod: {:#}", &error);
-            errors.push(error);
-        }
-    }
-    // under --fail-early, a child failure broke the join loop above; stop here, before any
-    // deferred parent change -- never apply more changes after the error we were asked to
-    // stop on. (read_dir / next_entry failures already returned directly.)
-    if settings.fail_early && errors.has_errors() {
-        return Err(Error::new(errors.into_error().unwrap(), summary));
-    }
-    // post-order (`--defer-dir-changes`): change the directory AFTER its contents -- needed
-    // when recursively removing the owner's own traversal permission. in keep-going mode it
-    // is applied even after a child failure; fail-early returned just above.
-    if settings.defer_dir_changes {
-        match apply_dir_self(prog_track, path, &metadata, traversed_only, settings).await {
-            Ok(dir_summary) => summary = summary + dir_summary,
-            Err(error) => {
-                if settings.fail_early {
-                    return Err(Error::new(error.source, summary + error.summary));
-                }
-                tracing::error!("chmod: {:?} failed with: {:#}", path, &error);
-                summary = summary + error.summary;
-                errors.push(error.source);
-            }
-        }
-    }
-    if errors.has_errors() {
-        return Err(Error::new(errors.into_error().unwrap(), summary));
-    }
-    Ok(summary)
+    apply_entry_change(prog_track, path, handle, EntryKind::Dir, settings).await
 }
 
 #[cfg(test)]
@@ -1179,5 +1333,213 @@ mod tests {
         let plan = compute_plan(0o2770, 1000, 1000, EntryKind::Dir, &s);
         assert_eq!(plan.chown, Some((None, Some(2000))));
         assert_eq!(plan.chmod, Some(0o2770));
+    }
+
+    static RACE_PROGRESS: std::sync::LazyLock<Progress> = std::sync::LazyLock::new(Progress::new);
+
+    // Repeatedly swap `dir/entry` between a real regular file (mode 0644) and a symlink
+    // pointing at `sentinel`, using rename so each individual state is atomic. Two staging
+    // names live alongside `entry` and are renamed over it in a tight loop until `stop` is
+    // set. Runs on a dedicated OS thread so it makes progress regardless of the tokio
+    // runtime's scheduling. Mirrors copy's `spawn_file_symlink_swapper`.
+    fn spawn_file_symlink_swapper(
+        dir: std::path::PathBuf,
+        entry_name: &'static str,
+        sentinel: std::path::PathBuf,
+        stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) -> std::thread::JoinHandle<()> {
+        use std::os::unix::fs::PermissionsExt;
+        std::thread::spawn(move || {
+            let entry = dir.join(entry_name);
+            let staged_real = dir.join("__staged_real");
+            let staged_link = dir.join("__staged_link");
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                // prepare a real file (mode 0644) at a staging name, then rename it over `entry`.
+                let _ = std::fs::remove_file(&staged_real);
+                if std::fs::write(&staged_real, b"REAL").is_err() {
+                    continue;
+                }
+                let _ =
+                    std::fs::set_permissions(&staged_real, std::fs::Permissions::from_mode(0o644));
+                let _ = std::fs::rename(&staged_real, &entry);
+                // prepare a symlink-to-sentinel at the other staging name, then rename it over.
+                let _ = std::fs::remove_file(&staged_link);
+                let _ = std::os::unix::fs::symlink(&sentinel, &staged_link);
+                let _ = std::fs::rename(&staged_link, &entry);
+            }
+        })
+    }
+
+    // TOCTOU race: while rchm runs `--mode g+w` over a directory, the entry inside it is
+    // rapidly flipped between a real file (0644) and a symlink to a SENTINEL file that lives
+    // OUTSIDE the tree with a distinctive mode (0600). rchm classifies each entry through an
+    // O_PATH/O_NOFOLLOW handle and chmods that exact pinned inode — so it may chmod the real
+    // file (0644 -> 0664), or see a symlink (which it never chmods), or fail closed, but it
+    // must NEVER follow the link and change the sentinel's mode. The sentinel staying 0600 on
+    // every iteration is the safety assertion. Also confirms the run terminates (timeout).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn entry_symlink_swap_never_changes_sentinel_mode() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = crate::testutils::create_temp_dir().await?;
+        let root = tmp.as_path();
+        // sentinel lives OUTSIDE the rchm target tree, with a distinctive mode we must not touch.
+        let sentinel = root.join("sentinel_secret");
+        tokio::fs::write(&sentinel, b"SENTINEL").await?;
+        std::fs::set_permissions(&sentinel, std::fs::Permissions::from_mode(0o600))?;
+        let sentinel_uid_before =
+            std::os::unix::fs::MetadataExt::uid(&std::fs::symlink_metadata(&sentinel)?);
+        // the tree rchm operates on: a directory containing the entry that gets swapped.
+        let target_dir = root.join("tree");
+        tokio::fs::create_dir(&target_dir).await?;
+        let entry_path = target_dir.join("entry");
+        tokio::fs::write(&entry_path, b"REAL").await?;
+        std::fs::set_permissions(&entry_path, std::fs::Permissions::from_mode(0o644))?;
+
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let swapper =
+            spawn_file_symlink_swapper(target_dir.clone(), "entry", sentinel.clone(), stop.clone());
+
+        // g+w on a file would turn the sentinel 0600 -> 0620 if the link were ever followed.
+        let settings = settings_with("g+w", None, None);
+        let mut caught = 0usize;
+        let mut changed_real = 0usize;
+        for i in 0..300 {
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                chmod(&RACE_PROGRESS, &target_dir, &settings),
+            )
+            .await
+            .expect("rchm must not hang under concurrent swapping");
+            match result {
+                Ok(summary) => changed_real += summary.files_changed,
+                Err(_) => caught += 1, // a swap was caught mid-run (failed closed for that entry)
+            }
+            // CORE SAFETY ASSERTION (holds on every iteration regardless of timing): the
+            // out-of-tree sentinel's mode and owner are never modified by rchm.
+            let sentinel_md = std::fs::symlink_metadata(&sentinel)?;
+            assert_eq!(
+                sentinel_md.permissions().mode() & 0o7777,
+                0o600,
+                "iteration {i}: sentinel mode changed — rchm followed the symlink to chmod it"
+            );
+            assert_eq!(
+                std::os::unix::fs::MetadataExt::uid(&sentinel_md),
+                sentinel_uid_before,
+                "iteration {i}: sentinel owner changed — rchm followed the symlink to chown it"
+            );
+        }
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        swapper.join().expect("swapper thread panicked");
+        // sanity (not the safety assertion): the run did observable work across the iterations.
+        tracing::info!("entry swap: caught={caught}, changed_real={changed_real}");
+        assert!(
+            caught + changed_real > 0,
+            "expected at least one observable outcome across the iterations"
+        );
+        Ok(())
+    }
+
+    /// Stress tests exercising `pending_meta` (max-open-files) saturation during rchm. The module
+    /// name carries the `max_open_files` substring so nextest's serial test-group isolates these
+    /// from anything else that mutates the process-wide throttle limit (see `.config/nextest.toml`).
+    mod max_open_files_tests {
+        use super::*;
+        use crate::walk_driver::process_entry;
+
+        static PROGRESS: std::sync::LazyLock<Progress> = std::sync::LazyLock::new(Progress::new);
+
+        /// Regression for the hold-and-wait deadlock when a getdents leaf-hint entry is actually a
+        /// directory (the DT_UNKNOWN edge, or a getdents-vs-`child()` swap). A `pending_meta` permit
+        /// is pre-acquired for hinted leaves only; if such an entry is really a directory, the
+        /// permit must be DROPPED before recursing, or it is held while its children block acquiring
+        /// one and a saturated pool hangs the walk.
+        ///
+        /// Reproduced deterministically by driving a directory entry through the driver's
+        /// [`process_entry`] with the real [`ChmodVisitor`] and the one-and-only permit pre-acquired
+        /// (as the spawn loop does for a hinted leaf): with the bug the held permit strands the
+        /// child's pre-acquire and the timeout fires; with the driver's single drop-before-recurse
+        /// site the child acquires it and the walk completes. (Runs the real `ChmodVisitor` through
+        /// the driver — the chmod-side coverage the old direct `chmod_entry` call gave, now that
+        /// `chmod_entry` no longer exists after the Phase E conversion.)
+        #[tokio::test]
+        async fn hinted_leaf_that_is_dir_drops_permit_before_recursion() -> anyhow::Result<()> {
+            let root = crate::testutils::create_temp_dir().await?;
+            // `d` is a directory (the authoritative type) holding one child file `c`.
+            let dir_path = root.join("d");
+            tokio::fs::create_dir(&dir_path).await?;
+            let child_path = dir_path.join("c");
+            tokio::fs::write(&child_path, b"x").await?;
+            std::fs::set_permissions(&child_path, std::fs::Permissions::from_mode(0o644))?;
+            // size the pending-meta pool to a single permit so a held-across-recursion permit
+            // strands the child's pre-acquire — the saturation the fd-walk must tolerate.
+            throttle::set_max_open_files(1);
+            // open the container of `d` and classify `d` itself: an authoritative directory handle.
+            let parent = Dir::open_parent_dir(&root, congestion::Side::Destination)
+                .await
+                .context("open parent dir")?;
+            let parent = Arc::new(parent.into_tree());
+            let name = std::ffi::OsStr::new("d");
+            let handle = parent.child(name).await.context("classify d")?;
+            assert_eq!(
+                handle.kind(),
+                EntryKind::Dir,
+                "fixture `d` must be a directory"
+            );
+            drop(handle);
+            // build the visitor + root context for `d`, pre-acquire the single permit as the spawn
+            // loop does for a hinted leaf, and hand it to `process_entry` (the fix drops it before
+            // recursing).
+            let visitor = Arc::new(ChmodVisitor {
+                prog_track: &PROGRESS,
+                settings: settings_with("g+w", None, None),
+            });
+            let cx = EntryCx {
+                parent: Arc::clone(&parent),
+                name: name.to_owned(),
+                rel_path: PathBuf::new(),
+                filter_path: PathBuf::new(),
+                real_path: dir_path.clone(),
+                dry_run: false,
+                prog_track: &PROGRESS,
+            };
+            let permit = crate::walk::preacquire_leaf_permit(
+                PermitKind::PendingMeta,
+                Some(EntryKind::File),
+                |_| true,
+            )
+            .await;
+            assert!(permit.is_some(), "the pre-acquire must take the one permit");
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(20),
+                process_entry(visitor, cx, (), permit),
+            )
+            .await;
+            // restore the default (disabled) pool before asserting so a failure here can't strand
+            // the tiny limit for any concurrent test (the serial group already isolates us, but
+            // this keeps the process-global knob clean on the failure path too).
+            throttle::set_max_open_files(0);
+            let summary = result
+                .context(
+                    "process_entry hung — leaf permit held across directory recursion (deadlock)",
+                )?
+                .map_err(|e| e.source)
+                .context("process_entry failed")?;
+            // both the directory and its child get g+w (0644 -> 0664 on the file).
+            assert_eq!(
+                summary.files_changed, 1,
+                "child file should have its mode changed"
+            );
+            assert_eq!(
+                summary.directories_changed, 1,
+                "directory should have its mode changed"
+            );
+            assert_eq!(
+                std::fs::symlink_metadata(&child_path)?.permissions().mode() & 0o777,
+                0o664,
+                "child file mode should be g+w applied"
+            );
+            Ok(())
+        }
     }
 }

--- a/common/src/copy.rs
+++ b/common/src/copy.rs
@@ -1,17 +1,24 @@
-use std::os::unix::fs::MetadataExt;
+use std::ffi::{OsStr, OsString};
+use std::os::fd::AsFd;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
-use async_recursion::async_recursion;
 use throttle::get_file_iops_tokens;
 use tracing::instrument;
 
 use crate::config::DryRunMode;
+use crate::copy_data::copy_file_range_all;
 use crate::filecmp;
 use crate::preserve;
 use crate::progress;
 use crate::rm;
 use crate::rm::{Settings as RmSettings, Summary as RmSummary};
-use crate::walk::{self, EntryKind};
+use crate::safedir::{self, Dir, FileMeta, Handle};
+use crate::walk::{EntryKind, LeafPermit, PermitKind};
+use crate::walk_driver::{
+    DirAction, DirPreResult, EntryCx, ProcessedChildren, WalkVisitor, process_entry,
+};
 
 /// Error type for copy operations. See [`crate::error::OperationError`] for
 /// logging conventions and rationale.
@@ -162,138 +169,6 @@ pub fn is_file_type_same(md1: &std::fs::Metadata, md2: &std::fs::Metadata) -> bo
         && ft1.is_symlink() == ft2.is_symlink()
 }
 
-#[instrument(skip(prog_track, src_metadata, settings, preserve))]
-pub async fn copy_file(
-    prog_track: &'static progress::Progress,
-    src: &std::path::Path,
-    dst: &std::path::Path,
-    src_metadata: &std::fs::Metadata,
-    settings: &Settings,
-    preserve: &preserve::Settings,
-    is_fresh: bool,
-) -> Result<Summary, Error> {
-    // check --ignore-existing before dry-run so dry-run output reflects actual behavior.
-    // use symlink_metadata to detect dangling symlinks too (Path::exists follows symlinks)
-    if !is_fresh
-        && settings.ignore_existing
-        && crate::walk::run_metadata_probed(
-            congestion::Side::Destination,
-            congestion::MetadataOp::Stat,
-            tokio::fs::symlink_metadata(dst),
-        )
-        .await
-        .is_ok()
-    {
-        if let Some(mode) = settings.dry_run {
-            match mode {
-                DryRunMode::Brief => {}
-                DryRunMode::All => println!("skip file {:?}", dst),
-                DryRunMode::Explain => println!("skip file {:?} (destination exists)", dst),
-            }
-        }
-        tracing::debug!("destination exists, skipping (--ignore-existing)");
-        prog_track.files_unchanged.inc();
-        return Ok(Summary {
-            files_unchanged: 1,
-            ..Default::default()
-        });
-    }
-    // handle dry-run mode for files
-    if settings.dry_run.is_some() {
-        crate::dry_run::report_action("copy", src, Some(dst), "file");
-        return Ok(Summary {
-            files_copied: 1,
-            bytes_copied: src_metadata.len(),
-            ..Default::default()
-        });
-    }
-    tracing::debug!("opening 'src' for reading and 'dst' for writing");
-    get_file_iops_tokens(settings.chunk_size, src_metadata.size()).await;
-    let mut rm_summary = RmSummary::default();
-    if !is_fresh && dst.exists() {
-        if settings.overwrite {
-            tracing::debug!("file exists, check if it's identical");
-            let dst_metadata = crate::walk::run_metadata_probed(
-                congestion::Side::Destination,
-                congestion::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(dst),
-            )
-            .await
-            .with_context(|| format!("failed reading metadata from {:?}", &dst))
-            .map_err(|err| Error::new(err, Default::default()))?;
-            if is_file_type_same(src_metadata, &dst_metadata) {
-                if filecmp::metadata_equal(&settings.overwrite_compare, src_metadata, &dst_metadata)
-                {
-                    tracing::debug!("file is identical, skipping");
-                    prog_track.files_unchanged.inc();
-                    return Ok(Summary {
-                        files_unchanged: 1,
-                        ..Default::default()
-                    });
-                }
-                if let Some(OverwriteFilter::Newer) = settings.overwrite_filter
-                    && filecmp::dest_is_newer(src_metadata, &dst_metadata)
-                {
-                    tracing::debug!("dest is newer than source, skipping");
-                    prog_track.files_unchanged.inc();
-                    return Ok(Summary {
-                        files_unchanged: 1,
-                        ..Default::default()
-                    });
-                }
-            }
-            tracing::info!("file is different, removing existing file");
-            // note tokio::fs::overwrite cannot handle this path being e.g. a directory
-            rm_summary = rm::rm(
-                prog_track,
-                dst,
-                &RmSettings {
-                    fail_early: settings.fail_early,
-                    filter: None,
-                    dry_run: None,
-                    time_filter: None,
-                },
-            )
-            .await
-            .map_err(|err| {
-                let rm_summary = err.summary;
-                let copy_summary = Summary {
-                    rm_summary,
-                    ..Default::default()
-                };
-                Error::new(err.source, copy_summary)
-            })?;
-        } else {
-            return Err(Error::new(
-                anyhow!(
-                    "destination {:?} already exists, did you intend to specify --overwrite?",
-                    dst
-                ),
-                Default::default(),
-            ));
-        }
-    }
-    tracing::debug!("copying data");
-    let mut copy_summary = Summary {
-        rm_summary,
-        ..Default::default()
-    };
-    tokio::fs::copy(src, dst)
-        .await
-        .with_context(|| format!("failed copying {:?} to {:?}", &src, &dst))
-        .map_err(|err| Error::new(err, copy_summary))?;
-    prog_track.files_copied.inc();
-    prog_track.bytes_copied.add(src_metadata.len());
-    tracing::debug!("setting permissions");
-    preserve::set_file_metadata(preserve, src_metadata, dst)
-        .await
-        .map_err(|err| Error::new(err, copy_summary))?;
-    // we mark files as "copied" only after all metadata is set as well
-    copy_summary.bytes_copied += src_metadata.len();
-    copy_summary.files_copied += 1;
-    Ok(copy_summary)
-}
-
 #[derive(Copy, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub struct Summary {
     pub bytes_copied: u64,
@@ -368,7 +243,7 @@ impl std::fmt::Display for Summary {
 }
 
 /// Public entry point for copy operations.
-/// Internally delegates to copy_internal with source_root tracking for proper filter matching.
+/// Internally delegates to [`copy_with_filter_base`] with an empty filter base.
 #[instrument(skip(prog_track, settings, preserve))]
 pub async fn copy(
     prog_track: &'static progress::Progress,
@@ -394,6 +269,12 @@ pub async fn copy(
 /// root. Used when `rlink` delegates an update-only entry to `copy`: `--delete` pruning inside
 /// the delegated subtree then matches the include/exclude filter at the entry's true relative
 /// path (e.g. `cache/*.log`) instead of relative to the delegated root.
+///
+/// The local copy walk is fd-based: the source and destination roots are opened relative to
+/// their parent directories and every per-entry operation is performed through
+/// file-descriptor-relative syscalls (see [`crate::safedir`]). This closes the TOCTOU window the
+/// old path-based walk had between classifying an entry and acting on it. `--dereference` is the
+/// one exception — it still resolves symlinks by path (`canonicalize`) and is not hardened.
 #[instrument(skip(prog_track, settings, preserve))]
 #[allow(clippy::too_many_arguments)]
 pub async fn copy_with_filter_base(
@@ -405,167 +286,1129 @@ pub async fn copy_with_filter_base(
     is_fresh: bool,
     filter_base: &std::path::Path,
 ) -> Result<Summary, Error> {
+    // Source: decompose via the shared helper so `.`/`..` operands (e.g. `rcp . dst`, `rcp src/..
+    // dst`) are canonicalized to a real directory + basename instead of being rejected; `/` is still
+    // rejected. (The helper also maps a single-component relative path's empty parent to ".".)
+    let src_operand = crate::walk::split_root_operand(src)
+        .await
+        .map_err(|err| Error::new(err, Default::default()))?;
+    let src_parent_path = src_operand.parent.as_path();
+    let src_name = src_operand.name.as_os_str();
+    let src = src_operand.display.as_path();
     // check filter for top-level source (files, directories, and symlinks)
     if let Some(ref filter) = settings.filter {
-        let src_name = src.file_name().map(std::path::Path::new);
-        if let Some(name) = src_name {
-            let src_metadata = crate::walk::run_metadata_probed(
-                congestion::Side::Source,
-                congestion::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(src),
-            )
-            .await
-            .with_context(|| format!("failed reading metadata from src: {:?}", &src))
-            .map_err(|err| Error::new(err, Default::default()))?;
-            let is_dir = src_metadata.is_dir();
-            // for a delegated subtree (non-empty filter_base) the source is not the true filter
-            // root, so match it at its logical path with nested semantics; for a normal copy use
-            // root-item semantics (anchored patterns don't apply to the root itself).
-            let result = if filter_base.as_os_str().is_empty() {
-                filter.should_include_root_item(name, is_dir)
-            } else {
-                filter.should_include(filter_base, is_dir)
-            };
-            match result {
-                crate::filter::FilterResult::Included => {}
-                result => {
-                    let kind = EntryKind::from_metadata(&src_metadata);
-                    if let Some(mode) = settings.dry_run {
-                        crate::dry_run::report_skip(src, &result, mode, kind.label_long());
-                    }
-                    kind.inc_skipped(prog_track);
-                    return Ok(skipped_summary_for(kind));
+        let src_metadata = crate::walk::run_metadata_probed(
+            congestion::Side::Source,
+            congestion::MetadataOp::Stat,
+            tokio::fs::symlink_metadata(src),
+        )
+        .await
+        .with_context(|| format!("failed reading metadata from src: {:?}", &src))
+        .map_err(|err| Error::new(err, Default::default()))?;
+        let is_dir = src_metadata.is_dir();
+        // for a delegated subtree (non-empty filter_base) the source is not the true filter
+        // root, so match it at its logical path with nested semantics; for a normal copy use
+        // root-item semantics (anchored patterns don't apply to the root itself).
+        let result = if filter_base.as_os_str().is_empty() {
+            filter.should_include_root_item(std::path::Path::new(src_name), is_dir)
+        } else {
+            filter.should_include(filter_base, is_dir)
+        };
+        match result {
+            crate::filter::FilterResult::Included => {}
+            result => {
+                let kind = EntryKind::from_metadata(&src_metadata);
+                if let Some(mode) = settings.dry_run {
+                    crate::dry_run::report_skip(src, &result, mode, kind.label_long());
                 }
+                kind.inc_skipped(prog_track);
+                return Ok(skipped_summary_for(kind));
             }
         }
     }
-    copy_internal(
+    // Open the parent directories of the source and destination roots so the root entry itself can
+    // be opened and classified relative to a directory fd (the same fd-relative path every nested
+    // entry takes). The root is then handed to the walk driver (via `run_copy_root`) by its
+    // basename, exactly like a child entry. The destination keeps the direct split — a `.`/`..`
+    // destination is not a meaningful copy target, and rejecting it avoids clobbering the cwd.
+    let (Some(dst_parent_path), Some(_dst_name)) = (dst.parent(), dst.file_name()) else {
+        return Err(Error::new(
+            anyhow!(
+                "copy destination {:?} has no parent directory or file name",
+                dst
+            ),
+            Default::default(),
+        ));
+    };
+    // empty parent (relative path with a single component) means the current directory.
+    let dst_parent_path = if dst_parent_path.as_os_str().is_empty() {
+        std::path::Path::new(".")
+    } else {
+        dst_parent_path
+    };
+    // open the operand's TRUSTED parent prefix following symlinks normally (the prefix is trusted
+    // up to and including the operand's container — only entries strictly below the named root are
+    // O_NOFOLLOW-hardened). a symlinked parent (e.g. `rcp src symlinkdir/out`) is followed.
+    let src_parent = Dir::open_parent_dir(src_parent_path, congestion::Side::Source)
+        .await
+        .with_context(|| format!("cannot open source parent directory {:?}", src_parent_path))
+        .map_err(|err| Error::new(err, Default::default()))?;
+    // cross from the trusted parent prefix into the hardened tree (O_NOFOLLOW below here).
+    let src_parent = Arc::new(src_parent.into_tree());
+    // In dry-run we never touch the destination, so we don't open its parent at all (the parent
+    // may not even exist). `dst_parent == None` is the signal throughout the walk that destination
+    // operations must be skipped.
+    let dst_parent = if settings.dry_run.is_some() {
+        None
+    } else {
+        // the destination's TRUSTED parent prefix is resolved following symlinks (see the source
+        // parent above): `rcp file symlink_to_dir/out` must copy into the real directory the
+        // symlinked parent points at, not fail closed on it.
+        let dir = Dir::open_parent_dir(dst_parent_path, congestion::Side::Destination)
+            .await
+            .with_context(|| {
+                format!(
+                    "cannot open destination parent directory {:?}",
+                    dst_parent_path
+                )
+            })
+            .map_err(|err| Error::new(err, Default::default()))?;
+        // cross from the trusted parent prefix into the hardened tree (O_NOFOLLOW below here).
+        Some(Arc::new(dir.into_tree()))
+    };
+    run_copy_root(
         prog_track,
+        &src_parent,
+        dst_parent,
+        src_name,
         src,
         dst,
-        src,
+        filter_base,
         settings,
         preserve,
         is_fresh,
         None,
-        filter_base,
     )
     .await
 }
 
-#[instrument(skip(prog_track, settings, preserve, open_file_guard))]
-#[async_recursion]
+/// Copy a single entry `name` (within `src_parent`) into `dst_parent`, using held directory
+/// handles rather than re-resolving any path. This is the fd-based delegation entry point for
+/// `rlink`: when an entry must be COPIED rather than hard-linked (a file that changed vs the
+/// update tree, a symlink, a type-mismatch, or an update-only entry), `link` hands its already-open
+/// parent `Dir`s plus the entry `name` here, so the copy inherits the same intermediate-component
+/// TOCTOU safety the link walk has — no path is re-walked from a root.
+///
+/// `src_path`/`dst_path` are the entry's reconstructed real paths; they serve as the copy walk's
+/// roots so diagnostics, `--dereference` (`canonicalize`), path-based `rm`, and `--delete` pruning
+/// reconstruct the right paths inside the delegated subtree. `filter_base` is the entry's logical
+/// path relative to the original filter root, so any `--delete` pruning inside the subtree matches
+/// include/exclude patterns at the entry's true relative path (e.g. `cache/*.log`). `dst_parent`
+/// is `None` only in dry-run (no destination mutation).
+#[instrument(skip(
+    prog_track,
+    src_parent,
+    dst_parent,
+    settings,
+    preserve,
+    open_file_guard
+))]
 #[allow(clippy::too_many_arguments)]
-async fn copy_internal(
+pub(crate) async fn copy_child(
     prog_track: &'static progress::Progress,
-    src: &std::path::Path,
-    dst: &std::path::Path,
-    source_root: &std::path::Path,
+    src_parent: &Arc<Dir>,
+    dst_parent: Option<&Arc<Dir>>,
+    name: &OsStr,
+    src_path: &std::path::Path,
+    dst_path: &std::path::Path,
+    filter_base: &std::path::Path,
     settings: &Settings,
     preserve: &preserve::Settings,
-    mut is_fresh: bool,
+    is_fresh: bool,
     open_file_guard: Option<throttle::OpenFileGuard>,
-    filter_base: &std::path::Path,
 ) -> Result<Summary, Error> {
-    let _ops_guard = prog_track.ops.guard();
-    tracing::debug!("reading source metadata");
-    let src_metadata = crate::walk::run_metadata_probed(
-        congestion::Side::Source,
-        congestion::MetadataOp::Stat,
-        tokio::fs::symlink_metadata(src),
+    run_copy_root(
+        prog_track,
+        src_parent,
+        dst_parent.map(Arc::clone),
+        name,
+        src_path,
+        dst_path,
+        filter_base,
+        settings,
+        preserve,
+        is_fresh,
+        open_file_guard.map(LeafPermit::OpenFile),
     )
     .await
-    .with_context(|| format!("failed reading metadata from src: {:?}", &src))
-    .map_err(|err| Error::new(err, Default::default()))?;
-    if settings.dereference && src_metadata.is_symlink() {
-        debug_assert!(
-            open_file_guard.is_none(),
-            "open file guard should not be pre-acquired for symlinks"
-        );
-        let link = crate::walk::run_metadata_probed(
-            congestion::Side::Source,
-            congestion::MetadataOp::Stat,
-            tokio::fs::canonicalize(&src),
-        )
-        .await
-        .with_context(|| format!("failed reading src symlink {:?}", &src))
-        .map_err(|err| Error::new(err, Default::default()))?;
-        return copy(prog_track, &link, dst, settings, preserve, is_fresh).await;
+}
+
+/// The copy walk's [`WalkVisitor`]: holds the run-constant state shared by every entry and maps
+/// each per-entry decision onto the generic [`crate::walk_driver`] driver.
+///
+/// The driver owns enumeration, the leaf-permit lifecycle, spawning, the single
+/// drop-before-recurse site, and the error fold; this visitor supplies copy's per-entry bodies
+/// (`copy_file_fd`, `copy_symlink_fd`, `resolve_dst_dir`, `remove_existing`, the empty-dir cleanup,
+/// `--delete` prune, and directory metadata). The destination tree is threaded as an *inherited
+/// attribute* through [`Self::DirContext`] (each directory's children read their destination parent
+/// from `parent_ctx`), so the single-tree driver carries copy's second tree without modeling it.
+struct CopyVisitor {
+    prog_track: &'static progress::Progress,
+    /// The destination root operand. The root's destination basename comes from here (it may differ
+    /// from the source basename, e.g. copying `foo` → `bar`); nested entries reuse the source name.
+    /// The *source* root needs no field: an entry's source real path is the driver-maintained
+    /// `EntryCx::real_path` (seeded with the source root in [`run_copy_root`]).
+    dst_root: PathBuf,
+    /// The logical filter base: an entry's filter path is `filter_base.join(rel_path)`.
+    filter_base: PathBuf,
+    settings: Settings,
+    preserve: preserve::Settings,
+    /// The opened top-level destination parent directory (`None` in dry-run). Seeds the
+    /// [`Self::DirContext`] chain via [`WalkVisitor::root_dir_context`].
+    dst_parent: Option<Arc<Dir>>,
+    /// The initial freshness for the root entry's containing directory.
+    root_is_fresh: bool,
+}
+
+/// Inherited per-directory context: the destination parent directory for one level plus its
+/// freshness. `dst_dir == None` is the dry-run signal threaded throughout the walk (no destination
+/// mutation). This is how the single-tree driver carries copy's destination tree — each child reads
+/// its destination parent from here rather than the driver knowing a second tree exists.
+#[derive(Clone)]
+struct CopyDirContext {
+    dst_dir: Option<Arc<Dir>>,
+    is_fresh: bool,
+}
+
+/// State threaded from [`WalkVisitor::dir_pre`] to [`WalkVisitor::dir_post`] in the same task:
+/// everything `dir_post` needs to run empty-dir cleanup, `--delete` prune, and apply directory
+/// metadata.
+struct CopyDirState {
+    /// The destination directory just created/reused (`None` in dry-run).
+    dst_dir: Option<Arc<Dir>>,
+    /// The destination parent directory and this directory's destination name within it — used to
+    /// remove an empty directory fd-relative (`dst_parent.rmdir_at(dst_name)`). `None` in dry-run.
+    dst_parent: Option<Arc<Dir>>,
+    dst_name: OsString,
+    /// Whether we created the destination directory (vs. reused an existing one).
+    we_created: bool,
+    /// The source directory's metadata, applied to the destination post-order.
+    src_meta: FileMeta,
+    /// Whether this is the user-specified root directory (never empty-dir-cleaned up).
+    is_root: bool,
+    /// The `directories_created`/`directories_unchanged` contribution from resolving this
+    /// directory's destination, folded into the final summary.
+    base: Summary,
+}
+
+impl CopyVisitor {
+    /// The destination real path for the entry described by `cx` (`dst_root.join(rel_path)`, or the
+    /// root verbatim when `rel_path` is empty — joining an empty `rel_path` would append a trailing
+    /// separator that `canonicalize`/ENOTDIR-sensitive paths reject). Mirrors `copy_internal`.
+    fn dst_path_for(&self, cx: &EntryCx) -> PathBuf {
+        if cx.rel_path.as_os_str().is_empty() {
+            self.dst_root.clone()
+        } else {
+            self.dst_root.join(&cx.rel_path)
+        }
     }
-    if src_metadata.is_file() {
-        // acquire permit if not pre-acquired by the caller
-        let _guard = match open_file_guard {
-            Some(g) => g,
-            None => throttle::open_file_permit().await,
+
+    /// The destination entry's name within its parent. For nested entries this equals the source
+    /// `cx.name`, but for the root the source and destination basenames may differ (e.g. copying
+    /// `foo` → `bar`), so the root's destination name comes from `dst_root`. Mirrors `copy_internal`.
+    // copy's `Error` carries a `Summary` (intrinsically large); a fallible helper returning it trips
+    // `result_large_err` only because the `Ok` variant here is a small `OsString`. The error arm is
+    // unreachable in practice (`copy_with_filter_base` pre-validates the root's file name and a
+    // delegated `copy_child` root path always has one) — keep it as defense-in-depth.
+    #[allow(clippy::result_large_err)]
+    fn dst_name_for(&self, cx: &EntryCx) -> Result<OsString, Error> {
+        if cx.rel_path.as_os_str().is_empty() {
+            self.dst_root
+                .file_name()
+                .map(OsStr::to_owned)
+                .ok_or_else(|| {
+                    Error::new(
+                        anyhow!("copy destination {:?} has no file name", &self.dst_root),
+                        Default::default(),
+                    )
+                })
+        } else {
+            Ok(cx.name.clone())
+        }
+    }
+
+    /// rsync-style `--delete` prune for one finished directory: remove destination entries with no
+    /// source counterpart. Runs only when `--delete` was requested AND every child of this directory
+    /// succeeded — skipping the prune on any error (deleting based on a run that did not fully
+    /// succeed could remove data unexpectedly). Prune enumerates and removes through the
+    /// destination's own pinned directory fd, so a concurrent symlink swap cannot redirect it outside
+    /// the destination.
+    ///
+    /// Folds the prune's `RmSummary` into `copy_summary`. On a non-fail-early prune error it records
+    /// the error in `child_error` (surfaced later by [`Self::finalize_dir`]); it returns `Err` only
+    /// in fail-early mode or when the dry-run delete-scan open fails outright.
+    async fn prune_finished_dir(
+        &self,
+        copy_summary: &mut Summary,
+        child_error: &mut Option<anyhow::Error>,
+        processed: &ProcessedChildren,
+        dst_dir: &Option<Arc<Dir>>,
+        dst_path: &std::path::Path,
+        rel_path: &std::path::Path,
+    ) -> Result<(), Error> {
+        if child_error.is_some() && self.settings.delete.is_some() {
+            tracing::warn!(
+                "skipping --delete pruning of {:?} because the copy reported errors",
+                dst_path
+            );
+        }
+        let Some(delete_settings) = &self.settings.delete else {
+            return Ok(());
         };
-        return copy_file(
-            prog_track,
-            src,
-            dst,
-            &src_metadata,
-            settings,
-            preserve,
-            is_fresh,
-        )
-        .await;
-    }
-    debug_assert!(
-        open_file_guard.is_none(),
-        "open file guard should not be pre-acquired for directories or symlinks"
-    );
-    if src_metadata.is_symlink() {
-        // check --ignore-existing before dry-run so dry-run output reflects actual behavior.
-        // use symlink_metadata to detect dangling symlinks too (Path::exists follows symlinks)
-        if !is_fresh
-            && settings.ignore_existing
-            && crate::walk::run_metadata_probed(
-                congestion::Side::Destination,
-                congestion::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(dst),
-            )
-            .await
-            .is_ok()
-        {
-            if let Some(mode) = settings.dry_run {
-                match mode {
-                    DryRunMode::Brief => {}
-                    DryRunMode::All => println!("skip symlink {:?}", dst),
-                    DryRunMode::Explain => println!("skip symlink {:?} (destination exists)", dst),
+        if child_error.is_some() {
+            return Ok(());
+        }
+        // the keep-set: every source child the driver spawned for this directory (filter-IN, special
+        // files included — they have a source counterpart so must not be pruned). this is exactly the
+        // set `copy_dir_contents` built inline before the skip-specials check.
+        let keep_set: std::collections::HashSet<OsString> =
+            processed.names().iter().cloned().collect();
+        let relative_dir = self.filter_base.join(rel_path);
+        // obtain the destination directory as an open `Dir`. in a real copy we already hold it
+        // (`dst_dir`). in --dry-run the create-or-overwrite step was skipped, so there is no held
+        // handle and the path could still be a symlink-to-directory or a non-directory; open it
+        // O_NOFOLLOW|O_DIRECTORY (dereference=false) so a symlink or non-directory fails closed here
+        // and prune is simply skipped — never following the symlink to preview deletions OUTSIDE the
+        // destination. a missing dir likewise skips.
+        let prune_dir: Option<Arc<Dir>> = match dst_dir {
+            Some(dir) => Some(Arc::clone(dir)),
+            None => {
+                match Dir::open_root_dir(dst_path, false, congestion::Side::Destination).await {
+                    Ok(dir) => Some(Arc::new(dir)),
+                    Err(err)
+                        if matches!(
+                            err.kind(),
+                            std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+                        ) || err.raw_os_error() == Some(libc::ELOOP)
+                            || err.raw_os_error() == Some(libc::ENOTDIR) =>
+                    {
+                        tracing::debug!(
+                            "skipping --delete pruning of {:?}: not a real directory in dry-run",
+                            dst_path
+                        );
+                        None
+                    }
+                    Err(err) => {
+                        let err = anyhow::Error::new(err).context(format!(
+                            "cannot open destination {dst_path:?} for delete scan"
+                        ));
+                        // a scan-open failure is surfaced as this directory's own error (this runs only
+                        // when children all succeeded, so there is no prior error to combine with —
+                        // matching the old fail-early/collect handling).
+                        return Err(Error::new(err, *copy_summary));
+                    }
                 }
             }
-            tracing::debug!("destination exists, skipping symlink (--ignore-existing)");
-            prog_track.symlinks_unchanged.inc();
-            return Ok(Summary {
-                symlinks_unchanged: 1,
-                ..Default::default()
-            });
-        }
-        // handle dry-run mode for symlinks
-        if settings.dry_run.is_some() {
-            crate::dry_run::report_action("copy", src, Some(dst), "symlink");
-            return Ok(Summary {
-                symlinks_created: 1,
-                ..Default::default()
-            });
-        }
-        let mut rm_summary = RmSummary::default();
-        let link = crate::walk::run_metadata_probed(
-            congestion::Side::Source,
-            congestion::MetadataOp::ReadLink,
-            tokio::fs::read_link(src),
-        )
-        .await
-        .with_context(|| format!("failed reading symlink {:?}", &src))
-        .map_err(|err| Error::new(err, Default::default()))?;
-        // try creating a symlink, if dst path exists and overwrite is set - remove and try again
-        if let Err(error) = crate::walk::run_metadata_probed(
-            congestion::Side::Destination,
-            congestion::MetadataOp::Symlink,
-            tokio::fs::symlink(&link, dst),
+        };
+        let Some(prune_dir) = prune_dir else {
+            return Ok(());
+        };
+        match crate::delete::prune_extraneous(
+            self.prog_track,
+            &prune_dir,
+            &relative_dir,
+            &keep_set,
+            self.settings.filter.as_ref(),
+            delete_settings,
+            self.settings.fail_early,
+            self.settings.dry_run,
         )
         .await
         {
-            if settings.ignore_existing && error.kind() == std::io::ErrorKind::AlreadyExists {
+            Ok(rm_summary) => {
+                copy_summary.rm_summary = copy_summary.rm_summary + rm_summary;
+            }
+            Err(err) => {
+                copy_summary.rm_summary = copy_summary.rm_summary + err.summary;
+                if self.settings.fail_early {
+                    return Err(Error::new(err.source, *copy_summary));
+                }
+                // non-fail-early: remember the prune error but still apply this fully-copied
+                // directory's own metadata below (matching main's collect-then-finalize), surfacing
+                // the prune error from the tail.
+                *child_error = Some(err.source);
+            }
+        }
+        Ok(())
+    }
+
+    /// Finish a directory after its children and `--delete` prune have run: when filtering left it
+    /// empty, clean it up (or, in dry-run, suppress its would-be-created count); otherwise apply the
+    /// source directory's metadata to the destination through its own held fd. A collected
+    /// `child_error` always takes precedence and is surfaced here (even when the empty directory was
+    /// pruned), so a failed child copy can never be reported as overall success.
+    async fn finalize_dir(&self, fin: FinalizeDir, cx: &EntryCx) -> Result<Summary, Error> {
+        let FinalizeDir {
+            mut copy_summary,
+            child_error,
+            dst_dir,
+            dst_parent,
+            dst_name,
+            src_meta,
+            we_created,
+            is_root,
+        } = fin;
+        let src_path = &cx.real_path;
+        let dst_path = self.dst_path_for(cx);
+        let rel_path = &cx.rel_path;
+        // when filtering is active and we created this directory, check whether anything was
+        // actually copied into it. if not, we may need to clean up the empty directory.
+        let this_dir_count = usize::from(we_created);
+        let child_dirs_created = copy_summary
+            .directories_created
+            .saturating_sub(this_dir_count);
+        let anything_copied = copy_summary.files_copied > 0
+            || copy_summary.symlinks_created > 0
+            || child_dirs_created > 0;
+        let relative_path = self.filter_base.join(rel_path);
+        match check_empty_dir_cleanup(
+            self.settings.filter.as_ref(),
+            we_created,
+            anything_copied,
+            &relative_path,
+            is_root,
+            self.settings.dry_run.is_some(),
+        ) {
+            EmptyDirAction::Keep => { /* proceed with metadata application */ }
+            EmptyDirAction::DryRunSkip => {
+                tracing::debug!(
+                    "dry-run: directory {:?} would not be created (nothing to copy inside)",
+                    dst_path
+                );
+                copy_summary.directories_created = 0;
+                // the directory itself is not created, but a child error collected during the walk
+                // must still surface — otherwise a traversal-only directory whose only child FAILED
+                // becomes "empty", gets skipped here, and the failed copy is reported as success.
+                return match child_error {
+                    Some(child_error) => Err(Error::new(child_error, copy_summary)),
+                    None => Ok(copy_summary),
+                };
+            }
+            EmptyDirAction::Remove => {
+                tracing::debug!(
+                    "directory {:?} has nothing to copy inside, removing empty directory",
+                    dst_path
+                );
+                // remove the empty directory fd-relative, through its parent dir handle:
+                // `rmdir_at` operates on `dst_name` within the held `dst_parent` fd (never by path)
+                // and only succeeds on an empty directory, so it is contained to `dst_parent` and
+                // cannot be redirected. our still-open fd to the directory itself simply detaches.
+                // `dst_parent` is always Some here: it is None only in dry-run, where this arm is
+                // unreachable (`check_empty_dir_cleanup` returns `DryRunSkip`, not `Remove`).
+                let rmdir_result = match &dst_parent {
+                    Some(dst_parent) => dst_parent.rmdir_at(&dst_name).await,
+                    None => {
+                        crate::walk::run_metadata_probed(
+                            congestion::Side::Destination,
+                            congestion::MetadataOp::RmDir,
+                            tokio::fs::remove_dir(&dst_path),
+                        )
+                        .await
+                    }
+                };
+                match rmdir_result {
+                    Ok(()) => {
+                        copy_summary.directories_created = 0;
+                        // the empty directory is removed, but a child error collected during the
+                        // walk must still surface — otherwise a traversal-only directory whose only
+                        // child FAILED becomes "empty", is removed here, and the failed copy is
+                        // reported as success.
+                        return match child_error {
+                            Some(child_error) => Err(Error::new(child_error, copy_summary)),
+                            None => Ok(copy_summary),
+                        };
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            "failed to remove empty directory {:?}: {:#}, keeping",
+                            dst_path,
+                            &err
+                        );
+                        // fall through to apply metadata.
+                    }
+                }
+            }
+        }
+        // apply directory metadata regardless of whether all children copied successfully (the
+        // directory itself was created/opened in dir_pre). skipped in dry-run (no directory
+        // exists). a child error takes precedence over a metadata error (matching the old tail:
+        // log the metadata error, return the child error).
+        tracing::debug!("set 'dst' directory metadata");
+        let metadata_result = match &dst_dir {
+            Some(dst_dir) => safedir::set_dir_metadata_fd(&self.preserve, &src_meta, dst_dir).await,
+            None => Ok(()),
+        };
+        if let Some(child_error) = child_error {
+            if let Err(metadata_err) = metadata_result {
+                tracing::error!(
+                    "copy: {:?} -> {:?} failed to set directory metadata: {:#}",
+                    src_path,
+                    dst_path,
+                    &metadata_err
+                );
+            }
+            return Err(Error::new(child_error, copy_summary));
+        }
+        // no child failures, so the metadata error is the primary error.
+        metadata_result
+            .with_context(|| format!("failed setting directory metadata on {:?}", dst_path))
+            .map_err(|err| Error::new(err, copy_summary))?;
+        Ok(copy_summary)
+    }
+}
+
+/// The owned per-directory state [`CopyVisitor::dir_post`] hands to [`CopyVisitor::finalize_dir`]
+/// after the child summaries are folded and `--delete` pruning has run: the accumulated summary, any
+/// collected child error to surface, and this directory's destination handles / classification.
+struct FinalizeDir {
+    copy_summary: Summary,
+    child_error: Option<anyhow::Error>,
+    dst_dir: Option<Arc<Dir>>,
+    dst_parent: Option<Arc<Dir>>,
+    dst_name: OsString,
+    src_meta: FileMeta,
+    we_created: bool,
+    is_root: bool,
+}
+
+/// Build the [`CopyVisitor`] for one copy operation and process the root entry through the generic
+/// driver. Shared by [`copy_with_filter_base`] (root entry, no pre-acquired permit) and
+/// [`copy_child`] (rlink's fd-based delegation entry point, which may pass an already-held
+/// open-files permit). The root is processed exactly like a nested child via
+/// [`crate::walk_driver::process_entry`]: it is classified authoritatively, then dispatched to
+/// `visit_leaf` (file/symlink/special) or `dir_pre`/recurse/`dir_post` (directory).
+#[allow(clippy::too_many_arguments)]
+async fn run_copy_root(
+    prog_track: &'static progress::Progress,
+    src_parent: &Arc<Dir>,
+    dst_parent: Option<Arc<Dir>>,
+    name: &OsStr,
+    src_root: &std::path::Path,
+    dst_root: &std::path::Path,
+    filter_base: &std::path::Path,
+    settings: &Settings,
+    preserve: &preserve::Settings,
+    is_fresh: bool,
+    permit: Option<LeafPermit>,
+) -> Result<Summary, Error> {
+    let visitor = Arc::new(CopyVisitor {
+        prog_track,
+        dst_root: dst_root.to_path_buf(),
+        filter_base: filter_base.to_path_buf(),
+        settings: settings.clone(),
+        preserve: *preserve,
+        dst_parent,
+        root_is_fresh: is_fresh,
+    });
+    // the root entry's owned context: parent = the hardened source parent, name = the source root
+    // basename, rel_path = "" (the root), real_path = the source root. `filter_path` is seeded with
+    // `filter_base` so that inside a delegated subtree (rlink handing an update-only/type-changed
+    // subtree to `copy_child`, rooted BELOW the original filter root) every descendant's filter
+    // decision is evaluated at its true logical path (e.g. `cache/keep.txt`, not the bare basename
+    // relative to the delegated root). For a normal `copy()` (`filter_base` empty) this is "", so
+    // `filter_path == rel_path` throughout. dry_run is the destination's None signal carried on the
+    // context for the driver's bookkeeping.
+    let root_cx = EntryCx {
+        parent: Arc::clone(src_parent),
+        name: name.to_owned(),
+        rel_path: PathBuf::new(),
+        filter_path: filter_base.to_path_buf(),
+        real_path: src_root.to_path_buf(),
+        dry_run: settings.dry_run.is_some(),
+        prog_track,
+    };
+    let root_ctx = visitor.root_dir_context();
+    process_entry(visitor, root_cx, root_ctx, permit).await
+}
+
+impl WalkVisitor for CopyVisitor {
+    type Summary = Summary;
+    type DirContext = CopyDirContext;
+    type DirState = CopyDirState;
+
+    fn root_dir_context(&self) -> CopyDirContext {
+        CopyDirContext {
+            dst_dir: self.dst_parent.clone(),
+            is_fresh: self.root_is_fresh,
+        }
+    }
+
+    fn permit_kind(&self) -> PermitKind {
+        // copy holds an open file descriptor across a regular-file copy.
+        PermitKind::OpenFile
+    }
+
+    fn want_permit(&self, hint: Option<EntryKind>) -> bool {
+        // pre-acquire the open-files permit only for a known regular-file hint. symlinks are
+        // excluded (with --dereference they may resolve to directories — deadlock risk) and so is
+        // DT_UNKNOWN (it might be a directory). this matches `copy_dir_contents`'s old policy.
+        hint == Some(EntryKind::File)
+    }
+
+    fn fail_early(&self) -> bool {
+        self.settings.fail_early
+    }
+
+    fn filter(&self) -> Option<&crate::filter::FilterSettings> {
+        self.settings.filter.as_ref()
+    }
+
+    fn on_skip(
+        &self,
+        cx: &EntryCx,
+        kind: EntryKind,
+        skip_result: &crate::filter::FilterResult,
+    ) -> Summary {
+        // mirror `copy_dir_contents`'s inline filter-skip: the dry-run "skip ..." line plus the
+        // matching `*_skipped` counter. the driver already did the shared progress increment.
+        if let Some(mode) = self.settings.dry_run {
+            crate::dry_run::report_skip(&cx.real_path, skip_result, mode, kind.label());
+        }
+        skipped_summary_for(kind)
+    }
+
+    async fn visit_leaf(
+        &self,
+        cx: &EntryCx,
+        parent_ctx: &CopyDirContext,
+        handle: Handle,
+        kind: EntryKind,
+        permit: Option<LeafPermit>,
+    ) -> Result<Summary, Error> {
+        let src_parent = &cx.parent;
+        let dst_parent = parent_ctx.dst_dir.as_ref();
+        let name = cx.name.as_os_str();
+        let src_path = &cx.real_path;
+        let dst_path = self.dst_path_for(cx);
+        let dst_name = self.dst_name_for(cx)?;
+        let is_fresh = parent_ctx.is_fresh;
+        // --dereference: resolve a symlink to its target by path and copy that instead. this is the
+        // one path-based branch we intentionally keep (hardening -L is out of scope). drop the
+        // (regular-file-only) pre-acquired permit first: it is meaningless for a symlink that may
+        // resolve to a directory and could deadlock the recursive `copy()` under a saturated pool.
+        if self.settings.dereference && kind == EntryKind::Symlink {
+            drop(permit);
+            // invariant: only the explicit `--dereference` path may re-resolve an entry by path
+            // (`canonicalize`). the non-dereference walk is fully fd-based and must never reach
+            // here. a future refactor that wires `dereference == false` into this branch trips in
+            // debug/tests.
+            debug_assert!(
+                self.settings.dereference,
+                "canonicalize reached with dereference == false; the non-dereference copy path \
+                 must never re-resolve a path"
+            );
+            let link = crate::walk::run_metadata_probed(
+                congestion::Side::Source,
+                congestion::MetadataOp::Stat,
+                tokio::fs::canonicalize(src_path),
+            )
+            .await
+            .with_context(|| format!("failed reading src symlink {:?}", src_path))
+            .map_err(|err| Error::new(err, Default::default()))?;
+            return copy(
+                self.prog_track,
+                &link,
+                &dst_path,
+                &self.settings,
+                &self.preserve,
+                is_fresh,
+            )
+            .await;
+        }
+        match kind {
+            EntryKind::File => {
+                // hold the open-files permit across the file copy. the driver pre-acquired it for a
+                // regular-file hint; if it didn't (an unknown hint that turned out to be a file),
+                // acquire it now.
+                let _guard = match permit {
+                    Some(p) => p,
+                    None => LeafPermit::OpenFile(throttle::open_file_permit().await),
+                };
+                copy_file_fd(
+                    self.prog_track,
+                    src_parent,
+                    dst_parent,
+                    name,
+                    &dst_name,
+                    &dst_path,
+                    src_path,
+                    &handle,
+                    &self.settings,
+                    &self.preserve,
+                    is_fresh,
+                )
+                .await
+            }
+            EntryKind::Symlink => {
+                drop(permit);
+                copy_symlink_fd(
+                    self.prog_track,
+                    src_parent,
+                    dst_parent,
+                    &dst_name,
+                    src_path,
+                    &dst_path,
+                    &handle,
+                    &self.settings,
+                    &self.preserve,
+                    is_fresh,
+                )
+                .await
+            }
+            EntryKind::Special => {
+                drop(permit);
+                if self.settings.skip_specials {
+                    tracing::debug!("skipping special file {:?}", src_path);
+                    if let Some(mode) = self.settings.dry_run {
+                        match mode {
+                            DryRunMode::Brief => {}
+                            DryRunMode::All => println!("skip special {:?}", src_path),
+                            DryRunMode::Explain => {
+                                println!("skip special {:?} (unsupported file type)", src_path);
+                            }
+                        }
+                    }
+                    self.prog_track.specials_skipped.inc();
+                    return Ok(Summary {
+                        specials_skipped: 1,
+                        ..Default::default()
+                    });
+                }
+                Err(Error::new(
+                    anyhow!(
+                        "copy: {:?} -> {:?} failed, unsupported src file type",
+                        src_path,
+                        dst_path
+                    ),
+                    Default::default(),
+                ))
+            }
+            // a directory never reaches `visit_leaf`: the driver dispatches it to dir_pre/dir_post.
+            EntryKind::Dir => unreachable!("directory entries are handled by dir_pre/dir_post"),
+        }
+    }
+
+    async fn dir_pre(
+        &self,
+        cx: &EntryCx,
+        parent_ctx: &CopyDirContext,
+        _handle: &Handle,
+    ) -> DirPreResult<Self> {
+        let src_parent = &cx.parent;
+        let name = cx.name.as_os_str();
+        let src_path = &cx.real_path;
+        let dst_path = self.dst_path_for(cx);
+        let dst_name = self.dst_name_for(cx)?;
+        let is_root = cx.rel_path.as_os_str().is_empty();
+        let is_fresh = parent_ctx.is_fresh;
+        // open the source directory's contents (O_NOFOLLOW) — this is the `dir` the driver walks.
+        let src_dir = src_parent
+            .open_dir(name)
+            .await
+            .with_context(|| format!("cannot open directory {:?} for reading", src_path))
+            .map_err(|err| Error::new(err, Default::default()))?;
+        let src_dir = Arc::new(src_dir);
+        // the directory metadata applied to the destination comes from the SAME fd whose contents we
+        // enumerate (read-side fidelity, docs/tocttou.md), not the classify `Handle`: a swap of the
+        // dir entry between classify and `open_dir` is caught by O_NOFOLLOW (fail-closed), and on a
+        // same-name dir swap the applied metadata pairs with the contents actually copied.
+        let src_meta = src_dir
+            .meta()
+            .await
+            .with_context(|| format!("cannot read directory metadata from {:?}", src_path))
+            .map_err(|err| Error::new(err, Default::default()))?;
+        if self.settings.dry_run.is_some() {
+            // dry-run: if --ignore-existing and a non-directory already exists at the destination,
+            // the whole subtree would be skipped. otherwise report the directory and traverse its
+            // contents (with no destination directory).
+            if self.settings.ignore_existing
+                && !is_fresh
+                && crate::walk::run_metadata_probed(
+                    congestion::Side::Destination,
+                    congestion::MetadataOp::Stat,
+                    tokio::fs::symlink_metadata(&dst_path),
+                )
+                .await
+                .is_ok()
+                && !dst_path.is_dir()
+            {
+                match self.settings.dry_run {
+                    Some(DryRunMode::Brief) | None => {}
+                    Some(DryRunMode::All) => println!("skip dir {:?}", dst_path),
+                    Some(DryRunMode::Explain) => {
+                        println!(
+                            "skip dir {:?} (destination exists, not a directory)",
+                            dst_path
+                        );
+                    }
+                }
+                return Ok(DirAction::Skip(Summary {
+                    directories_unchanged: 1,
+                    ..Default::default()
+                }));
+            }
+            crate::dry_run::report_action("copy", src_path, Some(&dst_path), "dir");
+            let base = Summary {
+                directories_created: 1, // report as would-be-created
+                ..Default::default()
+            };
+            return Ok(DirAction::Descend {
+                dir: src_dir,
+                child_ctx: CopyDirContext {
+                    dst_dir: None, // dry-run: no destination parent (no destination mutation)
+                    is_fresh,
+                },
+                state: CopyDirState {
+                    dst_dir: None,
+                    dst_parent: None,
+                    dst_name,
+                    // treat as "created" so empty-dir cleanup can suppress the dry-run count.
+                    we_created: true,
+                    src_meta,
+                    is_root,
+                    base,
+                },
+            });
+        }
+        // real copy: the destination parent is Some (None only in dry-run, handled above).
+        let dst_parent = parent_ctx
+            .dst_dir
+            .as_ref()
+            .expect("destination parent must be open for a real copy");
+        let DirSlot {
+            dir: dst_dir,
+            summary: base,
+            is_fresh: child_is_fresh,
+            we_created,
+        } = match resolve_dst_dir(
+            self.prog_track,
+            dst_parent,
+            &dst_name,
+            &dst_path,
+            &self.settings,
+            is_fresh,
+        )
+        .await?
+        {
+            DirResolution::Skip(summary) => return Ok(DirAction::Skip(summary)),
+            DirResolution::Proceed(slot) => slot,
+        };
+        Ok(DirAction::Descend {
+            dir: src_dir,
+            child_ctx: CopyDirContext {
+                dst_dir: Some(Arc::clone(&dst_dir)),
+                is_fresh: child_is_fresh,
+            },
+            state: CopyDirState {
+                dst_dir: Some(dst_dir),
+                dst_parent: Some(Arc::clone(dst_parent)),
+                dst_name,
+                we_created,
+                src_meta,
+                is_root,
+                base,
+            },
+        })
+    }
+
+    async fn dir_post(
+        &self,
+        cx: &EntryCx,
+        state: CopyDirState,
+        processed: &ProcessedChildren,
+        child_result: Result<Summary, Error>,
+    ) -> Result<Summary, Error> {
+        let CopyDirState {
+            dst_dir,
+            dst_parent,
+            dst_name,
+            we_created,
+            src_meta,
+            is_root,
+            base,
+        } = state;
+        // whether any child failed (non-fail-early: the driver still calls dir_post on error so we
+        // can apply post-order directory metadata, but we must skip the destructive `--delete`
+        // prune and surface the child error). the partial child summary is folded either way,
+        // seeded with `base` (this directory's own create/unchanged contribution) — exactly as
+        // `copy_dir_contents` seeded `copy_summary = base` before joining the children.
+        let (child_summary, mut child_error) = match child_result {
+            Ok(summary) => (summary, None),
+            Err(err) => (err.summary, Some(err.source)),
+        };
+        let mut copy_summary = base + child_summary;
+        let dst_path = self.dst_path_for(cx);
+        // rsync-style --delete prune (folds the RmSummary; may record a non-fail-early child error
+        // or fail-early). A no-op unless --delete was requested AND every child succeeded.
+        self.prune_finished_dir(
+            &mut copy_summary,
+            &mut child_error,
+            processed,
+            &dst_dir,
+            &dst_path,
+            &cx.rel_path,
+        )
+        .await?;
+        // empty-dir cleanup + post-order directory metadata; also surfaces any collected child error.
+        self.finalize_dir(
+            FinalizeDir {
+                copy_summary,
+                child_error,
+                dst_dir,
+                dst_parent,
+                dst_name,
+                src_meta,
+                we_created,
+                is_root,
+            },
+            cx,
+        )
+        .await
+    }
+}
+
+/// Copy a regular file fd-relative: create (or overwrite) the destination via `dst_parent`,
+/// copy the bytes with `copy_file_range_all`, then apply metadata through the destination's own
+/// fd — the open is held from creation through metadata, closing the path-based re-open TOCTOU
+/// window. `--overwrite`/`--ignore-existing`/`is_fresh`/dry-run semantics mirror the path-based
+/// [`copy_file`].
+#[allow(clippy::too_many_arguments)]
+async fn copy_file_fd(
+    prog_track: &'static progress::Progress,
+    src_parent: &Arc<Dir>,
+    dst_parent: Option<&Arc<Dir>>,
+    name: &OsStr,
+    dst_name: &OsStr,
+    dst_path: &std::path::Path,
+    src_path: &std::path::Path,
+    src_handle: &Handle,
+    settings: &Settings,
+    preserve: &preserve::Settings,
+    is_fresh: bool,
+) -> Result<Summary, Error> {
+    // bring `FileMeta::size()` into scope locally; importing the trait at module level would
+    // collide with `std::os::unix::fs::MetadataExt` on `std::fs::Metadata` elsewhere in this file.
+    use crate::preserve::Metadata as _;
+    let src_meta = src_handle.meta();
+    // --ignore-existing: skip if the destination already exists (any type, including a dangling
+    // symlink). probe via the held dst fd in a real copy; in dry-run there is no held fd
+    // (`dst_parent` is None), so probe by path — dry-run is already deliberately path-based — so the
+    // preview output and counters reflect the real skip decision.
+    let dst_exists = match dst_parent {
+        Some(dst_parent) => dst_parent.child(dst_name).await.is_ok(),
+        None => tokio::fs::symlink_metadata(dst_path).await.is_ok(),
+    };
+    if !is_fresh && settings.ignore_existing && dst_exists {
+        if let Some(mode) = settings.dry_run {
+            match mode {
+                DryRunMode::Brief => {}
+                DryRunMode::All => println!("skip file {:?}", dst_path),
+                DryRunMode::Explain => println!("skip file {:?} (destination exists)", dst_path),
+            }
+        }
+        tracing::debug!("destination exists, skipping (--ignore-existing)");
+        prog_track.files_unchanged.inc();
+        return Ok(Summary {
+            files_unchanged: 1,
+            ..Default::default()
+        });
+    }
+    // dry-run: report and return what would happen without touching the destination.
+    if settings.dry_run.is_some() {
+        crate::dry_run::report_action("copy", src_path, Some(dst_path), "file");
+        return Ok(Summary {
+            files_copied: 1,
+            bytes_copied: src_meta.size(),
+            ..Default::default()
+        });
+    }
+    // dst_parent is guaranteed Some here: it is None only in dry-run, which returned above.
+    let dst_parent = dst_parent.expect("destination parent must be open for a real copy");
+    get_file_iops_tokens(settings.chunk_size, src_meta.size()).await;
+    let mut rm_summary = RmSummary::default();
+    // when the destination tree is not known-fresh, an entry may already exist. classify it and
+    // decide whether to skip (identical / newer), error (no --overwrite), or remove it first.
+    if !is_fresh && let Ok(dst_handle) = dst_parent.child(dst_name).await {
+        if !settings.overwrite {
+            return Err(Error::new(
+                anyhow!(
+                    "destination {:?} already exists, did you intend to specify --overwrite?",
+                    dst_path
+                ),
+                Default::default(),
+            ));
+        }
+        tracing::debug!("file exists, check if it's identical");
+        if dst_handle.kind() == EntryKind::File {
+            if filecmp::metadata_equal(&settings.overwrite_compare, src_meta, dst_handle.meta()) {
+                tracing::debug!("file is identical, skipping");
+                prog_track.files_unchanged.inc();
+                return Ok(Summary {
+                    files_unchanged: 1,
+                    ..Default::default()
+                });
+            }
+            if let Some(OverwriteFilter::Newer) = settings.overwrite_filter
+                && filecmp::dest_is_newer(src_meta, dst_handle.meta())
+            {
+                tracing::debug!("dest is newer than source, skipping");
+                prog_track.files_unchanged.inc();
+                return Ok(Summary {
+                    files_unchanged: 1,
+                    ..Default::default()
+                });
+            }
+        }
+        tracing::info!("destination differs, removing existing entry");
+        rm_summary = remove_existing(
+            prog_track,
+            dst_parent,
+            dst_name,
+            dst_path,
+            &dst_handle,
+            settings,
+        )
+        .await?;
+    }
+    // open the source for reading (fstat confirms it is still a regular file) and create the
+    // destination fresh. the creation mode matches what the metadata applier will chmod to, so the
+    // file has correct permissions even before metadata is fully applied. our write fd is writable
+    // regardless of those bits (it was opened O_WRONLY at creation).
+    let copy_summary = Summary {
+        rm_summary,
+        ..Default::default()
+    };
+    let (src_file, open_meta) = src_parent
+        .open_file_read(name)
+        .await
+        .with_context(|| format!("failed opening src file {:?} for reading", src_path))
+        .map_err(|err| Error::new(err, copy_summary))?;
+    let create_mode = preserve::masked_file_mode(&preserve.file, &open_meta);
+    let dst_file = dst_parent
+        .create_file(dst_name, create_mode)
+        .await
+        .with_context(|| format!("failed creating {:?}", dst_path))
+        .map_err(|err| Error::new(err, copy_summary))?;
+    tracing::debug!("copying data");
+    let len = open_meta.size();
+    // the data copy is the data path, not a metadata syscall — it is deliberately NOT wrapped in a
+    // congestion probe (matching the old `tokio::fs::copy`), so the large/variable copy latency
+    // never pollutes the per-metadata-op controller baseline. backpressure comes from the
+    // open-files permit the caller holds. the dst file is returned so its still-open fd can carry
+    // the metadata application that follows, closing the path-based re-open TOCTOU window.
+    let (copied, dst_file) = tokio::task::spawn_blocking(move || {
+        copy_file_range_all(&src_file, &dst_file, len).map(|copied| (copied, dst_file))
+    })
+    .await
+    .map_err(std::io::Error::other)
+    .and_then(|res| res)
+    .with_context(|| format!("failed copying data to {:?}", dst_path))
+    .map_err(|err| Error::new(err, copy_summary))?;
+    // account for the bytes ACTUALLY copied, not `len` (the size snapshotted at open): if the source
+    // is concurrently truncated, `copy_file_range_all` returns the shorter real count, so using `len`
+    // would over-report. `len` still drives the copy loop and the iops-token reservation above.
+    prog_track.files_copied.inc();
+    prog_track.bytes_copied.add(copied);
+    tracing::debug!("setting permissions");
+    safedir::set_file_metadata_fd(
+        preserve,
+        &open_meta,
+        dst_file.as_fd(),
+        congestion::Side::Destination,
+    )
+    .await
+    .with_context(|| format!("failed setting metadata on {:?}", dst_path))
+    .map_err(|err| Error::new(err, copy_summary))?;
+    let mut copy_summary = copy_summary;
+    // count the file as copied only after all metadata has been applied (actual bytes, see above).
+    copy_summary.bytes_copied += copied;
+    copy_summary.files_copied += 1;
+    Ok(copy_summary)
+}
+
+/// Create a symlink fd-relative and apply its metadata through the created link's own handle.
+/// `--overwrite`/`--ignore-existing`/dry-run semantics mirror the path-based symlink handling.
+#[allow(clippy::too_many_arguments)]
+async fn copy_symlink_fd(
+    prog_track: &'static progress::Progress,
+    src_parent: &Arc<Dir>,
+    dst_parent: Option<&Arc<Dir>>,
+    dst_name: &OsStr,
+    src_path: &std::path::Path,
+    dst_path: &std::path::Path,
+    src_handle: &Handle,
+    settings: &Settings,
+    preserve: &preserve::Settings,
+    is_fresh: bool,
+) -> Result<Summary, Error> {
+    // --ignore-existing: skip if the destination already exists (any type). probe via the held dst
+    // fd in a real copy; in dry-run there is no held fd (`dst_parent` is None), so probe by path, so
+    // the preview output and counters reflect the real skip decision.
+    let dst_exists = match dst_parent {
+        Some(dst_parent) => dst_parent.child(dst_name).await.is_ok(),
+        None => tokio::fs::symlink_metadata(dst_path).await.is_ok(),
+    };
+    if !is_fresh && settings.ignore_existing && dst_exists {
+        if let Some(mode) = settings.dry_run {
+            match mode {
+                DryRunMode::Brief => {}
+                DryRunMode::All => println!("skip symlink {:?}", dst_path),
+                DryRunMode::Explain => println!("skip symlink {:?} (destination exists)", dst_path),
+            }
+        }
+        tracing::debug!("destination exists, skipping symlink (--ignore-existing)");
+        prog_track.symlinks_unchanged.inc();
+        return Ok(Summary {
+            symlinks_unchanged: 1,
+            ..Default::default()
+        });
+    }
+    if settings.dry_run.is_some() {
+        crate::dry_run::report_action("copy", src_path, Some(dst_path), "symlink");
+        return Ok(Summary {
+            symlinks_created: 1,
+            ..Default::default()
+        });
+    }
+    let dst_parent = dst_parent.expect("destination parent must be open for a real copy");
+    // read the target AND metadata from the SAME pinned handle (one paired call), so a concurrent
+    // same-name symlink swap can't pair one link's target with another link's owner/timestamps
+    // (target/metadata fidelity, matching the regular-file path which takes both from one fd).
+    let (target, src_meta) = src_handle
+        .read_symlink(src_parent.side())
+        .await
+        .with_context(|| format!("failed reading symlink {:?}", src_path))
+        .map_err(|err| Error::new(err, Default::default()))?;
+    // fast path: the destination slot is empty, create the link directly.
+    match dst_parent.symlink_at(dst_name, &target).await {
+        Ok(link_handle) => {
+            safedir::set_symlink_metadata_fd(
+                preserve,
+                &src_meta,
+                &link_handle,
+                congestion::Side::Destination,
+            )
+            .await
+            .with_context(|| format!("failed setting symlink metadata on {:?}", dst_path))
+            .map_err(|err| Error::new(err, Default::default()))?;
+            prog_track.symlinks_created.inc();
+            Ok(Summary {
+                symlinks_created: 1,
+                ..Default::default()
+            })
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            if settings.ignore_existing {
                 tracing::debug!("destination exists, skipping symlink (--ignore-existing)");
                 prog_track.symlinks_unchanged.inc();
                 return Ok(Summary {
@@ -573,556 +1416,369 @@ async fn copy_internal(
                     ..Default::default()
                 });
             }
-            if settings.overwrite && error.kind() == std::io::ErrorKind::AlreadyExists {
-                let dst_metadata = crate::walk::run_metadata_probed(
-                    congestion::Side::Destination,
-                    congestion::MetadataOp::Stat,
-                    tokio::fs::symlink_metadata(dst),
-                )
-                .await
-                .with_context(|| format!("failed reading metadata from dst: {:?}", &dst))
-                .map_err(|err| Error::new(err, Default::default()))?;
-                if is_file_type_same(&src_metadata, &dst_metadata) {
-                    let dst_link = crate::walk::run_metadata_probed(
-                        congestion::Side::Destination,
-                        congestion::MetadataOp::ReadLink,
-                        tokio::fs::read_link(dst),
-                    )
-                    .await
-                    .with_context(|| format!("failed reading dst symlink: {:?}", &dst))
-                    .map_err(|err| Error::new(err, Default::default()))?;
-                    if link == dst_link {
-                        tracing::debug!(
-                            "'dst' is a symlink and points to the same location as 'src'"
-                        );
-                        if preserve.symlink.any() {
-                            // do we need to update the metadata for this symlink?
-                            let dst_metadata = crate::walk::run_metadata_probed(
-                                congestion::Side::Destination,
-                                congestion::MetadataOp::Stat,
-                                tokio::fs::symlink_metadata(dst),
-                            )
-                            .await
-                            .with_context(|| {
-                                format!("failed reading metadata from dst: {:?}", &dst)
-                            })
-                            .map_err(|err| Error::new(err, Default::default()))?;
-                            if !filecmp::metadata_equal(
-                                &settings.overwrite_compare,
-                                &src_metadata,
-                                &dst_metadata,
-                            ) {
-                                tracing::debug!("'dst' metadata is different, updating");
-                                preserve::set_symlink_metadata(preserve, &src_metadata, dst)
-                                    .await
-                                    .map_err(|err| Error::new(err, Default::default()))?;
-                                prog_track.symlinks_removed.inc();
-                                prog_track.symlinks_created.inc();
-                                return Ok(Summary {
-                                    rm_summary: RmSummary {
-                                        symlinks_removed: 1,
-                                        ..Default::default()
-                                    },
-                                    symlinks_created: 1,
-                                    ..Default::default()
-                                });
-                            }
-                        }
-                        tracing::debug!("symlink already exists, skipping");
-                        prog_track.symlinks_unchanged.inc();
-                        return Ok(Summary {
-                            symlinks_unchanged: 1,
-                            ..Default::default()
-                        });
-                    }
-                    tracing::debug!("'dst' is a symlink but points to a different path, updating");
-                } else {
-                    tracing::info!("'dst' is not a symlink, updating");
-                }
-                rm_summary = rm::rm(
-                    prog_track,
-                    dst,
-                    &RmSettings {
-                        fail_early: settings.fail_early,
-                        filter: None,
-                        dry_run: None,
-                        time_filter: None,
-                    },
-                )
-                .await
-                .map_err(|err| {
-                    let rm_summary = err.summary;
-                    let copy_summary = Summary {
-                        rm_summary,
-                        ..Default::default()
-                    };
-                    Error::new(err.source, copy_summary)
-                })?;
-                crate::walk::run_metadata_probed(
-                    congestion::Side::Destination,
-                    congestion::MetadataOp::Symlink,
-                    tokio::fs::symlink(&link, dst),
-                )
-                .await
-                .with_context(|| format!("failed creating symlink {:?}", &dst))
-                .map_err(|err| {
-                    let copy_summary = Summary {
-                        rm_summary,
-                        ..Default::default()
-                    };
-                    Error::new(err, copy_summary)
-                })?;
-            } else {
+            if !settings.overwrite {
                 return Err(Error::new(
-                    anyhow!("failed creating symlink {:?}", &dst),
+                    anyhow!("failed creating symlink {:?}", dst_path),
                     Default::default(),
                 ));
             }
-        }
-        preserve::set_symlink_metadata(preserve, &src_metadata, dst)
-            .await
-            .map_err(|err| {
-                let copy_summary = Summary {
-                    rm_summary,
-                    ..Default::default()
-                };
-                Error::new(err, copy_summary)
-            })?;
-        prog_track.symlinks_created.inc();
-        return Ok(Summary {
-            rm_summary,
-            symlinks_created: 1,
-            ..Default::default()
-        });
-    }
-    if !src_metadata.is_dir() {
-        if settings.skip_specials {
-            tracing::debug!(
-                "skipping special file {:?} (type: {:?})",
-                src,
-                src_metadata.file_type()
-            );
-            if let Some(mode) = settings.dry_run {
-                match mode {
-                    DryRunMode::Brief => {}
-                    DryRunMode::All => println!("skip special {:?}", src),
-                    DryRunMode::Explain => {
-                        println!(
-                            "skip special {:?} (unsupported file type: {:?})",
-                            src,
-                            src_metadata.file_type()
-                        );
+            let dst_handle = dst_parent
+                .child(dst_name)
+                .await
+                .with_context(|| format!("failed reading metadata from dst: {:?}", dst_path))
+                .map_err(|err| Error::new(err, Default::default()))?;
+            if dst_handle.kind() == EntryKind::Symlink {
+                let dst_link = dst_parent
+                    .read_link_at(dst_name) // rcp-toctou-allow: destination symlink (overwrite compare), not a source payload
+                    .await
+                    .with_context(|| format!("failed reading dst symlink: {:?}", dst_path))
+                    .map_err(|err| Error::new(err, Default::default()))?;
+                if dst_link == target {
+                    tracing::debug!("'dst' is a symlink and points to the same location as 'src'");
+                    if preserve.symlink.any()
+                        && !filecmp::metadata_equal(
+                            &settings.overwrite_compare,
+                            &src_meta,
+                            dst_handle.meta(),
+                        )
+                    {
+                        tracing::debug!("'dst' metadata is different, updating");
+                        safedir::set_symlink_metadata_fd(
+                            preserve,
+                            &src_meta,
+                            &dst_handle,
+                            congestion::Side::Destination,
+                        )
+                        .await
+                        .with_context(|| {
+                            format!("failed setting symlink metadata on {:?}", dst_path)
+                        })
+                        .map_err(|err| Error::new(err, Default::default()))?;
+                        prog_track.symlinks_removed.inc();
+                        prog_track.symlinks_created.inc();
+                        return Ok(Summary {
+                            rm_summary: RmSummary {
+                                symlinks_removed: 1,
+                                ..Default::default()
+                            },
+                            symlinks_created: 1,
+                            ..Default::default()
+                        });
                     }
+                    tracing::debug!("symlink already exists, skipping");
+                    prog_track.symlinks_unchanged.inc();
+                    return Ok(Summary {
+                        symlinks_unchanged: 1,
+                        ..Default::default()
+                    });
                 }
+                tracing::debug!("'dst' is a symlink but points to a different path, updating");
+            } else {
+                tracing::info!("'dst' is not a symlink, updating");
             }
-            prog_track.specials_skipped.inc();
-            return Ok(Summary {
-                specials_skipped: 1,
+            // remove the conflicting destination entry, then create the link fresh.
+            let rm_summary = remove_existing(
+                prog_track,
+                dst_parent,
+                dst_name,
+                dst_path,
+                &dst_handle,
+                settings,
+            )
+            .await?;
+            let copy_summary = Summary {
+                rm_summary,
                 ..Default::default()
-            });
+            };
+            let link_handle = dst_parent
+                .symlink_at(dst_name, &target)
+                .await
+                .with_context(|| format!("failed creating symlink {:?}", dst_path))
+                .map_err(|err| Error::new(err, copy_summary))?;
+            safedir::set_symlink_metadata_fd(
+                preserve,
+                &src_meta,
+                &link_handle,
+                congestion::Side::Destination,
+            )
+            .await
+            .with_context(|| format!("failed setting symlink metadata on {:?}", dst_path))
+            .map_err(|err| Error::new(err, copy_summary))?;
+            prog_track.symlinks_created.inc();
+            Ok(Summary {
+                rm_summary,
+                symlinks_created: 1,
+                ..Default::default()
+            })
         }
-        return Err(Error::new(
-            anyhow!(
-                "copy: {:?} -> {:?} failed, unsupported src file type: {:?}",
-                src,
-                dst,
-                src_metadata.file_type()
-            ),
+        Err(error) => Err(Error::new(
+            anyhow::Error::new(error).context(format!("failed creating symlink {:?}", dst_path)),
             Default::default(),
-        ));
+        )),
     }
-    // handle dry-run mode for directories at the top level
-    if settings.dry_run.is_some() {
-        if settings.ignore_existing
-            && !is_fresh
-            && crate::walk::run_metadata_probed(
-                congestion::Side::Destination,
-                congestion::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(dst),
-            )
-            .await
-            .is_ok()
-            && !dst.is_dir()
-        {
-            // destination is not a directory - would skip entire subtree
-            if let Some(mode) = settings.dry_run {
-                match mode {
-                    DryRunMode::Brief => {}
-                    DryRunMode::All => println!("skip dir {:?}", dst),
-                    DryRunMode::Explain => {
-                        println!("skip dir {:?} (destination exists, not a directory)", dst);
-                    }
-                }
-            }
-            return Ok(Summary {
-                directories_unchanged: 1,
-                ..Default::default()
-            });
-        }
-        crate::dry_run::report_action("copy", src, Some(dst), "dir");
-        // still need to recurse to show contents
-    }
-    tracing::debug!("process contents of 'src' directory");
-    let mut entries = tokio::fs::read_dir(src)
-        .await
-        .with_context(|| format!("cannot open directory {src:?} for reading"))
-        .map_err(|err| Error::new(err, Default::default()))?;
-    // in dry-run mode, skip directory creation but still traverse contents
-    let mut copy_summary = if settings.dry_run.is_some() {
-        Summary {
-            directories_created: 1, // report as would be created
-            ..Default::default()
-        }
-    } else if let Err(error) = crate::walk::run_metadata_probed(
-        congestion::Side::Destination,
-        congestion::MetadataOp::MkDir,
-        tokio::fs::create_dir(dst),
-    )
-    .await
-    {
-        assert!(
-            !is_fresh,
-            "unexpected error creating directory: {dst:?}: {error}"
-        );
-        if (settings.overwrite || settings.ignore_existing)
-            && error.kind() == std::io::ErrorKind::AlreadyExists
-        {
-            // check if the destination is a directory - if so, leave it
-            //
-            // N.B. the permissions may prevent us from writing to it but the alternative is to open up the directory
-            // while we're writing to it which isn't safe
-            let dst_metadata = crate::walk::run_metadata_probed(
-                congestion::Side::Destination,
-                congestion::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(dst),
-            )
-            .await
-            .with_context(|| format!("failed reading metadata from dst: {:?}", &dst))
-            .map_err(|err| Error::new(err, Default::default()))?;
-            if dst_metadata.is_dir() {
-                tracing::debug!("'dst' is a directory, leaving it as is");
-                prog_track.directories_unchanged.inc();
-                Summary {
-                    directories_unchanged: 1,
+}
+
+/// An opened destination directory plus the bookkeeping the caller needs.
+pub(crate) struct DirSlot {
+    pub(crate) dir: Arc<Dir>,
+    pub(crate) summary: Summary,
+    pub(crate) is_fresh: bool,
+    pub(crate) we_created: bool,
+}
+
+/// Outcome of resolving a destination directory.
+pub(crate) enum DirResolution {
+    /// Proceed into the directory.
+    Proceed(DirSlot),
+    /// Skip the whole subtree (e.g. `--ignore-existing` and a non-directory already exists).
+    Skip(Summary),
+}
+
+/// Create the destination directory `name` under `dst_parent`, or reuse / replace an existing
+/// entry per `--overwrite`/`--ignore-existing`. Returns an open [`Dir`] handle to it.
+///
+/// New directories are created mode `0o700` (writable so children can be populated) — the real
+/// source mode is applied later by [`CopyVisitor::dir_post`] after all children are copied, matching
+/// the path-based behavior of creating a writable directory and restricting it last.
+pub(crate) async fn resolve_dst_dir(
+    prog_track: &'static progress::Progress,
+    dst_parent: &Arc<Dir>,
+    name: &OsStr,
+    dst_path: &std::path::Path,
+    settings: &Settings,
+    is_fresh: bool,
+) -> Result<DirResolution, Error> {
+    match dst_parent.make_dir(name, 0o700).await {
+        Ok(dir) => {
+            // freshly created: children may assume the destination is empty (no conflict checks).
+            prog_track.directories_created.inc();
+            Ok(DirResolution::Proceed(DirSlot {
+                dir: Arc::new(dir),
+                summary: Summary {
+                    directories_created: 1,
                     ..Default::default()
-                }
+                },
+                is_fresh: true,
+                we_created: true,
+            }))
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            assert!(
+                !is_fresh,
+                "unexpected pre-existing directory in a fresh destination: {dst_path:?}"
+            );
+            let dst_handle = dst_parent
+                .child(name)
+                .await
+                .with_context(|| format!("failed reading metadata from dst: {:?}", dst_path))
+                .map_err(|err| Error::new(err, Default::default()))?;
+            if dst_handle.kind() == EntryKind::Dir {
+                // an existing directory: leave it as is and reuse it.
+                //
+                // N.B. its permissions may stop us writing into it, but the alternative (opening
+                // it up while we copy) isn't safe.
+                tracing::debug!("'dst' is a directory, leaving it as is");
+                let dir = dst_parent
+                    .open_dir(name)
+                    .await
+                    .with_context(|| format!("cannot open existing directory {:?}", dst_path))
+                    .map_err(|err| Error::new(err, Default::default()))?;
+                prog_track.directories_unchanged.inc();
+                Ok(DirResolution::Proceed(DirSlot {
+                    dir: Arc::new(dir),
+                    summary: Summary {
+                        directories_unchanged: 1,
+                        ..Default::default()
+                    },
+                    is_fresh,
+                    we_created: false,
+                }))
             } else if settings.ignore_existing {
-                // destination is not a directory but something exists at this path;
-                // with --ignore-existing we skip the entire subtree
+                // a non-directory exists and --ignore-existing was set: skip the whole subtree.
                 tracing::debug!(
                     "destination exists but is not a directory, skipping subtree (--ignore-existing)"
                 );
                 prog_track.directories_unchanged.inc();
-                return Ok(Summary {
+                Ok(DirResolution::Skip(Summary {
                     directories_unchanged: 1,
                     ..Default::default()
-                });
-            } else {
+                }))
+            } else if settings.overwrite {
+                // a non-directory exists and --overwrite was set: remove it and create the dir.
                 tracing::info!("'dst' is not a directory, removing and creating a new one");
-                let rm_summary = rm::rm(
+                let rm_summary = remove_existing(
                     prog_track,
-                    dst,
-                    &RmSettings {
-                        fail_early: settings.fail_early,
-                        filter: None,
-                        dry_run: None,
-                        time_filter: None,
-                    },
+                    dst_parent,
+                    name,
+                    dst_path,
+                    &dst_handle,
+                    settings,
                 )
-                .await
-                .map_err(|err| {
-                    let rm_summary = err.summary;
-                    let copy_summary = Summary {
-                        rm_summary,
-                        ..Default::default()
-                    };
-                    Error::new(err.source, copy_summary)
-                })?;
-                crate::walk::run_metadata_probed(
-                    congestion::Side::Destination,
-                    congestion::MetadataOp::MkDir,
-                    tokio::fs::create_dir(dst),
-                )
-                .await
-                .with_context(|| format!("cannot create directory {dst:?}"))
-                .map_err(|err| {
-                    let copy_summary = Summary {
-                        rm_summary,
-                        ..Default::default()
-                    };
-                    Error::new(err, copy_summary)
-                })?;
-                // anything copied into dst may assume they don't need to check for conflicts
-                is_fresh = true;
+                .await?;
+                let dir = dst_parent
+                    .make_dir(name, 0o700)
+                    .await
+                    .with_context(|| format!("cannot create directory {:?}", dst_path))
+                    .map_err(|err| {
+                        Error::new(
+                            err,
+                            Summary {
+                                rm_summary,
+                                ..Default::default()
+                            },
+                        )
+                    })?;
                 prog_track.directories_created.inc();
-                Summary {
-                    rm_summary,
-                    directories_created: 1,
-                    ..Default::default()
-                }
+                Ok(DirResolution::Proceed(DirSlot {
+                    dir: Arc::new(dir),
+                    summary: Summary {
+                        rm_summary,
+                        directories_created: 1,
+                        ..Default::default()
+                    },
+                    is_fresh: true,
+                    we_created: true,
+                }))
+            } else {
+                Err(Error::new(
+                    anyhow!(
+                        "destination {:?} already exists, did you intend to specify --overwrite?",
+                        dst_path
+                    ),
+                    Default::default(),
+                ))
             }
-        } else {
-            let error = Err::<(), std::io::Error>(error)
-                .with_context(|| format!("cannot create directory {:?}", dst))
-                .unwrap_err();
+        }
+        Err(error) => {
+            let error = anyhow::Error::new(error)
+                .context(format!("cannot create directory {:?}", dst_path));
             tracing::error!("{:#}", &error);
-            return Err(Error::new(error, Default::default()));
+            Err(Error::new(error, Default::default()))
         }
-    } else {
-        // new directory created, anything copied into dst may assume they don't need to check for conflicts
-        is_fresh = true;
-        prog_track.directories_created.inc();
-        Summary {
-            directories_created: 1,
-            ..Default::default()
-        }
-    };
-    // track whether we created this directory (vs it already existing)
-    // this is used later to decide if we should clean up an empty directory
-    let we_created_this_dir = copy_summary.directories_created == 1;
-    let mut join_set = tokio::task::JoinSet::new();
-    // names of source entries that pass the filter; used by --delete to decide
-    // which destination entries are extraneous. only populated when --delete is
-    // active; an empty HashSet has zero heap cost until the first insert, so the
-    // default path pays only a stack word.
-    let mut keep_set: std::collections::HashSet<std::ffi::OsString> =
-        std::collections::HashSet::new();
-    let errors = crate::error_collector::ErrorCollector::default();
-    loop {
-        let Some((entry, entry_file_type)) =
-            crate::walk::next_entry_probed(&mut entries, congestion::Side::Source, || {
-                format!("failed traversing src directory {:?}", &src)
+    }
+}
+
+/// Remove an existing destination entry (file, symlink, directory, or special) so a fresh copy can
+/// take its place. The returned summary is folded into the caller's copy summary.
+///
+/// # Removal contract
+///
+/// The entry was already classified into `dst_handle` (via [`Dir::child`]) by the caller. Removal
+/// here is **fd-relative and recheck-guarded**:
+///
+/// 1. [`Dir::recheck`] re-opens `dst_name` and confirms it is STILL the same inode that was
+///    classified (same `dev`/`ino`). If the directory entry was swapped to a different inode
+///    between classification and now — an intermediate-dir-to-symlink swap is the canonical
+///    attack — `recheck` returns `ESTALE` and we fail closed, removing nothing.
+/// 2. The entry is then removed through the held `dst_parent` fd by its kind:
+///    - File / Symlink / Special → [`Dir::unlink_at`] (single entry, never follows a symlink).
+///    - Empty directory → [`Dir::rmdir_at`].
+///    - Non-empty directory → fd-relative recursive [`rm::rm_child`] on the held `dst_parent`
+///      (`O_NOFOLLOW|O_DIRECTORY` descent), the same mechanism the remote destination uses.
+///
+/// Because every removal is fd-relative, it is CONTAINED to the held `dst_parent` directory: even in
+/// the residual window between `recheck` and the removal, a final-component swap could at worst
+/// remove a different inode that currently occupies `dst_name` WITHIN this directory — it can never
+/// escape `dst_parent` into a privileged delete elsewhere (design invariant 6, best-effort). The
+/// non-empty-directory subtree is descended through the parent fd with `O_NOFOLLOW`, so a
+/// directory→symlink swap mid-walk fails closed (ELOOP/ENOTDIR) rather than following the link.
+pub(crate) async fn remove_existing(
+    prog_track: &'static progress::Progress,
+    dst_parent: &Arc<Dir>,
+    dst_name: &OsStr,
+    dst_path: &std::path::Path,
+    dst_handle: &Handle,
+    settings: &Settings,
+) -> Result<RmSummary, Error> {
+    // recheck: confirm the entry is still the same inode we classified. fail closed on a swap.
+    dst_parent
+        .recheck(dst_name, dst_handle)
+        .await
+        .with_context(|| {
+            format!(
+                "destination {:?} changed identity before removal (possible TOCTOU swap)",
+                dst_path
+            )
+        })
+        .map_err(|err| Error::new(err, Default::default()))?;
+    match dst_handle.kind() {
+        EntryKind::File | EntryKind::Symlink | EntryKind::Special => {
+            // capture the removed entry's size before unlinking, to account its bytes (matching the
+            // remote destination's overwrite accounting — see rcp::destination::remove_existing_dst).
+            let removed_size = {
+                use crate::preserve::Metadata as _;
+                dst_handle.meta().size()
+            };
+            // single-entry, fd-relative removal contained to dst_parent; never follows a symlink.
+            dst_parent
+                .unlink_at(dst_name)
+                .await
+                .with_context(|| format!("failed removing existing destination {:?}", dst_path))
+                .map_err(|err| Error::new(err, Default::default()))?;
+            let is_symlink = dst_handle.kind() == EntryKind::Symlink;
+            if is_symlink {
+                prog_track.symlinks_removed.inc();
+            } else {
+                prog_track.files_removed.inc();
+                prog_track.bytes_removed.add(removed_size);
+            }
+            Ok(RmSummary {
+                files_removed: usize::from(!is_symlink),
+                symlinks_removed: usize::from(is_symlink),
+                ..Default::default()
             })
-            .await
-            .map_err(|err| Error::new(err, copy_summary))?
-        else {
-            break;
-        };
-        let entry_path = entry.path();
-        let entry_name = entry_path.file_name().unwrap();
-        let dst_path = dst.join(entry_name);
-        let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
-        let entry_is_dir = entry_kind == EntryKind::Dir;
-        // compute the path relative to the original filter root: `filter_base` is empty for a
-        // normal copy and non-empty for an rlink-delegated update subtree, so copy-side filtering
-        // matches the same logical path that delete pruning uses (e.g. `cache/keep.txt`).
-        let relative_path = filter_base.join(walk::relative_to_root(&entry_path, source_root));
-        // apply filter if configured
-        if let Some(skip_result) =
-            walk::should_skip_entry(&settings.filter, &relative_path, entry_is_dir)
-        {
-            if let Some(mode) = settings.dry_run {
-                crate::dry_run::report_skip(&entry_path, &skip_result, mode, entry_kind.label());
-            }
-            tracing::debug!("skipping {:?} due to filter", &entry_path);
-            copy_summary = copy_summary + skipped_summary_for(entry_kind);
-            entry_kind.inc_skipped(prog_track);
-            continue;
         }
-        // record this name as authoritative for --delete: it has a source counterpart, so its
-        // destination counterpart must not be pruned — even when --skip-specials skips copying
-        // it (computed before the skip-specials check below for exactly that reason).
-        if settings.delete.is_some() {
-            keep_set.insert(entry_name.to_owned());
-        }
-        // skip special files (sockets, FIFOs, devices) when --skip-specials is set
-        if settings.skip_specials && entry_kind == EntryKind::Special {
-            tracing::debug!("skipping special file {:?}", &entry_path);
-            if let Some(mode) = settings.dry_run {
-                match mode {
-                    DryRunMode::Brief => {}
-                    DryRunMode::All => println!("skip special {:?}", &entry_path),
-                    DryRunMode::Explain => {
-                        println!(
-                            "skip special {:?} (unsupported file type: {:?})",
-                            &entry_path,
-                            entry_file_type.unwrap()
-                        );
-                    }
-                }
-            }
-            copy_summary.specials_skipped += 1;
-            prog_track.specials_skipped.inc();
-            continue;
-        }
-        // for regular files (not dirs, not symlinks), acquire the open file permit before
-        // spawning the task. this provides backpressure so we don't create unbounded tasks.
-        // it's safe because files are leaf nodes that never recurse, so no deadlock is possible.
-        // we don't acquire for symlinks because with --dereference they could resolve to
-        // directories, which would risk deadlock. when file_type() fails we also skip
-        // pre-acquisition since we can't be sure it's a file — copy_internal will acquire
-        // the permit if needed after reading the actual metadata.
-        let entry_is_regular_file = entry_file_type.as_ref().is_some_and(|ft| ft.is_file());
-        let open_file_guard = if entry_is_regular_file {
-            Some(throttle::open_file_permit().await)
-        } else {
-            None
-        };
-        // spawn recursive call - dry-run reporting is handled by copy_internal
-        // (copy_file, symlink handling, and directory handling all have their own dry-run reporting)
-        let settings = settings.clone();
-        let preserve = *preserve;
-        let source_root = source_root.to_owned();
-        let filter_base = filter_base.to_owned();
-        let do_copy = || async move {
-            copy_internal(
-                prog_track,
-                &entry_path,
-                &dst_path,
-                &source_root,
-                &settings,
-                &preserve,
-                is_fresh,
-                open_file_guard,
-                &filter_base,
-            )
-            .await
-        };
-        join_set.spawn(do_copy());
-    }
-    // unfortunately ReadDir is opening file-descriptors and there's not a good way to limit this,
-    // one thing we CAN do however is to drop it as soon as we're done with it
-    drop(entries);
-    while let Some(res) = join_set.join_next().await {
-        match res {
-            Ok(result) => match result {
-                Ok(summary) => copy_summary = copy_summary + summary,
-                Err(error) => {
-                    tracing::error!("copy: {:?} -> {:?} failed with: {:#}", src, dst, &error);
-                    copy_summary = copy_summary + error.summary;
-                    if settings.fail_early {
-                        return Err(Error::new(error.source, copy_summary));
-                    }
-                    errors.push(error.source);
-                }
-            },
-            Err(error) => {
-                if settings.fail_early {
-                    return Err(Error::new(error.into(), copy_summary));
-                }
-                errors.push(error.into());
-            }
-        }
-    }
-    // rsync-style --delete: remove destination entries with no source counterpart.
-    // runs only when --delete was requested; reaching here means the full set of
-    // source children for this directory is known (all spawned tasks have joined).
-    if let Some(delete_settings) = &settings.delete {
-        if errors.has_errors() {
-            // rsync-style safety: skip pruning when this subtree's copy reported errors —
-            // deleting based on a run that did not fully succeed could remove data
-            // unexpectedly. (rsync likewise skips --delete on I/O errors.)
-            tracing::warn!(
-                "skipping --delete pruning of {:?} because the copy reported errors",
-                dst
-            );
-        } else {
-            let relative_dir = filter_base.join(walk::relative_to_root(src, source_root));
-            match crate::delete::prune_extraneous(
-                prog_track,
-                dst,
-                &relative_dir,
-                &keep_set,
-                settings.filter.as_ref(),
-                delete_settings,
-                settings.fail_early,
-                settings.dry_run,
-            )
-            .await
-            {
-                Ok(rm_summary) => copy_summary.rm_summary = copy_summary.rm_summary + rm_summary,
-                Err(err) => {
-                    copy_summary.rm_summary = copy_summary.rm_summary + err.summary;
-                    if settings.fail_early {
-                        return Err(Error::new(err.source, copy_summary));
-                    }
-                    errors.push(err.source);
-                }
-            }
-        }
-    }
-    // when filtering is active and we created this directory, check if anything was actually
-    // copied into it. if nothing was copied, we may need to clean up the empty directory.
-    let this_dir_count = usize::from(we_created_this_dir);
-    let child_dirs_created = copy_summary
-        .directories_created
-        .saturating_sub(this_dir_count);
-    let anything_copied = copy_summary.files_copied > 0
-        || copy_summary.symlinks_created > 0
-        || child_dirs_created > 0;
-    let relative_path = filter_base.join(walk::relative_to_root(src, source_root));
-    let is_root = src == source_root;
-    match check_empty_dir_cleanup(
-        settings.filter.as_ref(),
-        we_created_this_dir,
-        anything_copied,
-        &relative_path,
-        is_root,
-        settings.dry_run.is_some(),
-    ) {
-        EmptyDirAction::Keep => { /* proceed with metadata application */ }
-        EmptyDirAction::DryRunSkip => {
-            tracing::debug!(
-                "dry-run: directory {:?} would not be created (nothing to copy inside)",
-                &dst
-            );
-            copy_summary.directories_created = 0;
-            return Ok(copy_summary);
-        }
-        EmptyDirAction::Remove => {
-            tracing::debug!(
-                "directory {:?} has nothing to copy inside, removing empty directory",
-                &dst
-            );
-            match crate::walk::run_metadata_probed(
-                congestion::Side::Destination,
-                congestion::MetadataOp::RmDir,
-                tokio::fs::remove_dir(dst),
-            )
-            .await
-            {
+        EntryKind::Dir => {
+            // try the fd-relative fast path first: an empty directory removes cleanly via rmdir_at.
+            match dst_parent.rmdir_at(dst_name).await {
                 Ok(()) => {
-                    copy_summary.directories_created = 0;
-                    return Ok(copy_summary);
+                    prog_track.directories_removed.inc();
+                    Ok(RmSummary {
+                        directories_removed: 1,
+                        ..Default::default()
+                    })
                 }
-                Err(err) => {
-                    // removal failed (not empty, permission error, etc.) — keep directory
-                    tracing::debug!(
-                        "failed to remove empty directory {:?}: {:#}, keeping",
-                        &dst,
-                        &err
-                    );
-                    // fall through to apply metadata
+                // POSIX permits either ENOTEMPTY or EEXIST for a non-empty directory.
+                Err(error)
+                    if matches!(
+                        error.raw_os_error(),
+                        Some(libc::ENOTEMPTY) | Some(libc::EEXIST)
+                    ) =>
+                {
+                    // fd-relative recursive removal of the subtree on the held parent (guarded by
+                    // recheck above): descent uses O_NOFOLLOW, so it cannot be redirected out of
+                    // dst_parent by a concurrent symlink swap. Mirrors the remote destination path.
+                    rm::rm_child(
+                        prog_track,
+                        dst_parent,
+                        dst_name,
+                        dst_path,
+                        &RmSettings {
+                            fail_early: settings.fail_early,
+                            filter: None,
+                            dry_run: None,
+                            time_filter: None,
+                        },
+                    )
+                    .await
+                    .map_err(|err| {
+                        Error::new(
+                            err.source,
+                            Summary {
+                                rm_summary: err.summary,
+                                ..Default::default()
+                            },
+                        )
+                    })
                 }
+                Err(error) => Err(Error::new(
+                    anyhow::Error::new(error)
+                        .context(format!("failed removing existing directory {:?}", dst_path)),
+                    Default::default(),
+                )),
             }
         }
     }
-    // apply directory metadata regardless of whether all children copied successfully.
-    // the directory itself was created earlier in this function (we would have returned
-    // early if create_dir failed), so we should preserve the source metadata.
-    // skip metadata setting in dry-run mode since directory wasn't actually created
-    tracing::debug!("set 'dst' directory metadata");
-    let metadata_result = if settings.dry_run.is_some() {
-        Ok(()) // skip metadata setting in dry-run mode
-    } else {
-        preserve::set_dir_metadata(preserve, &src_metadata, dst).await
-    };
-    if errors.has_errors() {
-        // child failures take precedence - log metadata error if it also failed
-        if let Err(metadata_err) = metadata_result {
-            tracing::error!(
-                "copy: {:?} -> {:?} failed to set directory metadata: {:#}",
-                src,
-                dst,
-                &metadata_err
-            );
-        }
-        // unwrap is safe: has_errors() guarantees into_error() returns Some
-        return Err(Error::new(errors.into_error().unwrap(), copy_summary));
-    }
-    // no child failures, so metadata error is the primary error
-    metadata_result.map_err(|err| Error::new(err, copy_summary))?;
-    Ok(copy_summary)
 }
 
 #[cfg(test)]
@@ -1169,6 +1825,39 @@ mod copy_tests {
         })
     }
 
+    // Regression: a source operand whose final component is `.`/`..` (e.g. `rcp tree/sub/.. dst`,
+    // `rcp . dst`) must be copied, not rejected — `split_root_operand` canonicalizes it. Uses
+    // `tree/sub/..` (== `tree`) rather than `.` to avoid touching the process-wide cwd.
+    #[tokio::test]
+    async fn copies_dot_dot_source_operand() -> Result<(), anyhow::Error> {
+        let tmp = testutils::create_temp_dir().await?;
+        let tree = tmp.join("tree");
+        tokio::fs::create_dir(&tree).await?;
+        tokio::fs::write(tree.join("a.txt"), "hello").await?;
+        tokio::fs::create_dir(tree.join("sub")).await?;
+        let src = tree.join("sub").join(".."); // == tree
+        let dst = tmp.join("dst");
+        let summary = copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(None),
+            &NO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        assert_eq!(
+            summary.files_copied, 1,
+            "the dot-dot source's file must be copied"
+        );
+        assert_eq!(tokio::fs::read_to_string(dst.join("a.txt")).await?, "hello");
+        assert!(
+            dst.join("sub").is_dir(),
+            "the dot-dot source's subdir must be copied"
+        );
+        Ok(())
+    }
+
     #[tokio::test]
     #[traced_test]
     async fn delete_protects_skipped_special_name() -> Result<(), anyhow::Error> {
@@ -1207,6 +1896,70 @@ mod copy_tests {
             "a destination entry matching a skipped special must not be pruned (it has a source counterpart)"
         );
         assert!(!dst.join("stale.txt").exists()); // genuine extra removed
+        Ok(())
+    }
+
+    // FIX A (PR #247 review): the operand's TRUSTED parent prefix must be resolved following
+    // symlinks. `rcp file symlink_to_dir/out` copies into the REAL directory the symlinked parent
+    // points at (the parent prefix is trusted up to and including the operand's container); it must
+    // NOT fail closed with ELOOP/ENOTDIR. The hardening only applies strictly below the named root.
+    #[tokio::test]
+    #[traced_test]
+    async fn copies_into_symlinked_destination_parent() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::setup_test_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("src.txt");
+        tokio::fs::write(&src, b"payload").await?;
+        // a real destination directory and a symlink-to-dir parent prefix pointing at it.
+        let real_dir = test_path.join("real_dst_dir");
+        tokio::fs::create_dir(&real_dir).await?;
+        let link_dir = test_path.join("link_dst_dir");
+        tokio::fs::symlink(&real_dir, &link_dir).await?;
+        // destination operand sits UNDER the symlinked (trusted) parent prefix.
+        let dst = link_dir.join("out.txt");
+        let summary = copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(None),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        assert_eq!(summary.files_copied, 1);
+        // the file landed in the REAL directory (the symlinked parent was followed).
+        let written = tokio::fs::read(real_dir.join("out.txt")).await?;
+        assert_eq!(written, b"payload");
+        Ok(())
+    }
+
+    // FIX A (PR #247 review): a symlinked SOURCE parent prefix is likewise followed —
+    // `rcp symlinkdir/src dst` reads the file through the real directory.
+    #[tokio::test]
+    #[traced_test]
+    async fn copies_from_symlinked_source_parent() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::setup_test_dir().await?;
+        let test_path = tmp_dir.as_path();
+        // a real source directory containing the file, reached via a symlinked parent prefix.
+        let real_src_dir = test_path.join("real_src_dir");
+        tokio::fs::create_dir(&real_src_dir).await?;
+        tokio::fs::write(real_src_dir.join("src.txt"), b"payload").await?;
+        let link_src_dir = test_path.join("link_src_dir");
+        tokio::fs::symlink(&real_src_dir, &link_src_dir).await?;
+        let src = link_src_dir.join("src.txt");
+        let dst = test_path.join("out.txt");
+        let summary = copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &settings_with_delete(None),
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        assert_eq!(summary.files_copied, 1);
+        let written = tokio::fs::read(&dst).await?;
+        assert_eq!(written, b"payload");
         Ok(())
     }
 
@@ -2320,318 +3073,6 @@ mod copy_tests {
 
     #[tokio::test]
     #[traced_test]
-    async fn overwrite_filter_newer_skips_when_dest_is_newer() -> Result<(), anyhow::Error> {
-        let tmp_dir = testutils::create_temp_dir().await?;
-        let test_path = tmp_dir.as_path();
-        let src_file = test_path.join("src.txt");
-        let dst_file = test_path.join("dst.txt");
-        // create dest first with older content, then source
-        tokio::fs::write(&dst_file, "newer content").await?;
-        // set dest mtime to the future so it's strictly newer than source
-        let future_time = filetime::FileTime::from_unix_time(2_000_000_000, 0);
-        filetime::set_file_mtime(&dst_file, future_time)?;
-        tokio::fs::write(&src_file, "older content").await?;
-        let past_time = filetime::FileTime::from_unix_time(1_000_000_000, 0);
-        filetime::set_file_mtime(&src_file, past_time)?;
-        let summary = copy_file(
-            &PROGRESS,
-            &src_file,
-            &dst_file,
-            &tokio::fs::metadata(&src_file).await?,
-            &Settings {
-                dereference: false,
-                fail_early: false,
-                overwrite: true,
-                overwrite_compare: filecmp::MetadataCmpSettings {
-                    size: true,
-                    mtime: true,
-                    ..Default::default()
-                },
-                overwrite_filter: Some(OverwriteFilter::Newer),
-                ignore_existing: false,
-                chunk_size: 0,
-                skip_specials: false,
-                remote_copy_buffer_size: 0,
-                filter: None,
-                dry_run: None,
-                delete: None,
-            },
-            &NO_PRESERVE_SETTINGS,
-            false,
-        )
-        .await?;
-        assert_eq!(summary.files_unchanged, 1);
-        assert_eq!(summary.files_copied, 0);
-        // dest should still have original content
-        let content = tokio::fs::read_to_string(&dst_file).await?;
-        assert_eq!(content, "newer content");
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn overwrite_filter_newer_copies_when_dest_is_older() -> Result<(), anyhow::Error> {
-        let tmp_dir = testutils::create_temp_dir().await?;
-        let test_path = tmp_dir.as_path();
-        let src_file = test_path.join("src.txt");
-        let dst_file = test_path.join("dst.txt");
-        // create dest with old mtime, source with newer mtime
-        tokio::fs::write(&dst_file, "old content").await?;
-        let past_time = filetime::FileTime::from_unix_time(1_000_000_000, 0);
-        filetime::set_file_mtime(&dst_file, past_time)?;
-        tokio::fs::write(&src_file, "new content").await?;
-        let future_time = filetime::FileTime::from_unix_time(2_000_000_000, 0);
-        filetime::set_file_mtime(&src_file, future_time)?;
-        let summary = copy_file(
-            &PROGRESS,
-            &src_file,
-            &dst_file,
-            &tokio::fs::metadata(&src_file).await?,
-            &Settings {
-                dereference: false,
-                fail_early: false,
-                overwrite: true,
-                overwrite_compare: filecmp::MetadataCmpSettings {
-                    size: true,
-                    mtime: true,
-                    ..Default::default()
-                },
-                overwrite_filter: Some(OverwriteFilter::Newer),
-                ignore_existing: false,
-                chunk_size: 0,
-                skip_specials: false,
-                remote_copy_buffer_size: 0,
-                filter: None,
-                dry_run: None,
-                delete: None,
-            },
-            &NO_PRESERVE_SETTINGS,
-            false,
-        )
-        .await?;
-        assert_eq!(summary.files_copied, 1);
-        assert_eq!(summary.files_unchanged, 0);
-        // dest should now have source content
-        let content = tokio::fs::read_to_string(&dst_file).await?;
-        assert_eq!(content, "new content");
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn overwrite_filter_newer_copies_when_same_mtime() -> Result<(), anyhow::Error> {
-        let tmp_dir = testutils::create_temp_dir().await?;
-        let test_path = tmp_dir.as_path();
-        let src_file = test_path.join("src.txt");
-        let dst_file = test_path.join("dst.txt");
-        // create both files with the same mtime but different size
-        tokio::fs::write(&dst_file, "old").await?;
-        tokio::fs::write(&src_file, "new content").await?;
-        let same_time = filetime::FileTime::from_unix_time(1_500_000_000, 0);
-        filetime::set_file_mtime(&dst_file, same_time)?;
-        filetime::set_file_mtime(&src_file, same_time)?;
-        let summary = copy_file(
-            &PROGRESS,
-            &src_file,
-            &dst_file,
-            &tokio::fs::metadata(&src_file).await?,
-            &Settings {
-                dereference: false,
-                fail_early: false,
-                overwrite: true,
-                overwrite_compare: filecmp::MetadataCmpSettings {
-                    size: true,
-                    mtime: true,
-                    ..Default::default()
-                },
-                overwrite_filter: Some(OverwriteFilter::Newer),
-                ignore_existing: false,
-                chunk_size: 0,
-                skip_specials: false,
-                remote_copy_buffer_size: 0,
-                filter: None,
-                dry_run: None,
-                delete: None,
-            },
-            &NO_PRESERVE_SETTINGS,
-            false,
-        )
-        .await?;
-        // same mtime means NOT newer, so the file should be overwritten
-        assert_eq!(summary.files_copied, 1);
-        assert_eq!(summary.files_unchanged, 0);
-        let content = tokio::fs::read_to_string(&dst_file).await?;
-        assert_eq!(content, "new content");
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn overwrite_without_filter_copies_when_dest_is_newer() -> Result<(), anyhow::Error> {
-        let tmp_dir = testutils::create_temp_dir().await?;
-        let test_path = tmp_dir.as_path();
-        let src_file = test_path.join("src.txt");
-        let dst_file = test_path.join("dst.txt");
-        // dest is newer, but no filter set so it should still overwrite
-        tokio::fs::write(&dst_file, "newer content").await?;
-        let future_time = filetime::FileTime::from_unix_time(2_000_000_000, 0);
-        filetime::set_file_mtime(&dst_file, future_time)?;
-        tokio::fs::write(&src_file, "older content").await?;
-        let past_time = filetime::FileTime::from_unix_time(1_000_000_000, 0);
-        filetime::set_file_mtime(&src_file, past_time)?;
-        let summary = copy_file(
-            &PROGRESS,
-            &src_file,
-            &dst_file,
-            &tokio::fs::metadata(&src_file).await?,
-            &Settings {
-                dereference: false,
-                fail_early: false,
-                overwrite: true,
-                overwrite_compare: filecmp::MetadataCmpSettings {
-                    size: true,
-                    mtime: true,
-                    ..Default::default()
-                },
-                overwrite_filter: None,
-                ignore_existing: false,
-                chunk_size: 0,
-                skip_specials: false,
-                remote_copy_buffer_size: 0,
-                filter: None,
-                dry_run: None,
-                delete: None,
-            },
-            &NO_PRESERVE_SETTINGS,
-            false,
-        )
-        .await?;
-        // without filter, file should be overwritten regardless
-        assert_eq!(summary.files_copied, 1);
-        let content = tokio::fs::read_to_string(&dst_file).await?;
-        assert_eq!(content, "older content");
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn ignore_existing_skips_when_dest_exists() -> Result<(), anyhow::Error> {
-        let tmp_dir = testutils::create_temp_dir().await?;
-        let test_path = tmp_dir.as_path();
-        let src_file = test_path.join("src.txt");
-        let dst_file = test_path.join("dst.txt");
-        tokio::fs::write(&src_file, "source content").await?;
-        tokio::fs::write(&dst_file, "dest content").await?;
-        let summary = copy_file(
-            &PROGRESS,
-            &src_file,
-            &dst_file,
-            &tokio::fs::metadata(&src_file).await?,
-            &Settings {
-                dereference: false,
-                fail_early: false,
-                overwrite: false,
-                overwrite_compare: Default::default(),
-                overwrite_filter: None,
-                ignore_existing: true,
-                chunk_size: 0,
-                skip_specials: false,
-                remote_copy_buffer_size: 0,
-                filter: None,
-                dry_run: None,
-                delete: None,
-            },
-            &NO_PRESERVE_SETTINGS,
-            false,
-        )
-        .await?;
-        assert_eq!(summary.files_unchanged, 1);
-        assert_eq!(summary.files_copied, 0);
-        // dest should still have original content
-        let content = tokio::fs::read_to_string(&dst_file).await?;
-        assert_eq!(content, "dest content");
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn ignore_existing_skips_when_dest_is_different_type() -> Result<(), anyhow::Error> {
-        let tmp_dir = testutils::create_temp_dir().await?;
-        let test_path = tmp_dir.as_path();
-        let src_file = test_path.join("src.txt");
-        let dst_dir = test_path.join("dst.txt");
-        tokio::fs::write(&src_file, "source content").await?;
-        // destination is a directory, not a file
-        tokio::fs::create_dir(&dst_dir).await?;
-        let summary = copy_file(
-            &PROGRESS,
-            &src_file,
-            &dst_dir,
-            &tokio::fs::metadata(&src_file).await?,
-            &Settings {
-                dereference: false,
-                fail_early: false,
-                overwrite: false,
-                overwrite_compare: Default::default(),
-                overwrite_filter: None,
-                ignore_existing: true,
-                chunk_size: 0,
-                skip_specials: false,
-                remote_copy_buffer_size: 0,
-                filter: None,
-                dry_run: None,
-                delete: None,
-            },
-            &NO_PRESERVE_SETTINGS,
-            false,
-        )
-        .await?;
-        assert_eq!(summary.files_unchanged, 1);
-        assert_eq!(summary.files_copied, 0);
-        // dest directory should still exist
-        assert!(dst_dir.is_dir());
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[traced_test]
-    async fn ignore_existing_copies_when_dest_missing() -> Result<(), anyhow::Error> {
-        let tmp_dir = testutils::create_temp_dir().await?;
-        let test_path = tmp_dir.as_path();
-        let src_file = test_path.join("src.txt");
-        let dst_file = test_path.join("dst.txt");
-        tokio::fs::write(&src_file, "source content").await?;
-        let summary = copy_file(
-            &PROGRESS,
-            &src_file,
-            &dst_file,
-            &tokio::fs::metadata(&src_file).await?,
-            &Settings {
-                dereference: false,
-                fail_early: false,
-                overwrite: false,
-                overwrite_compare: Default::default(),
-                overwrite_filter: None,
-                ignore_existing: true,
-                chunk_size: 0,
-                skip_specials: false,
-                remote_copy_buffer_size: 0,
-                filter: None,
-                dry_run: None,
-                delete: None,
-            },
-            &NO_PRESERVE_SETTINGS,
-            false,
-        )
-        .await?;
-        assert_eq!(summary.files_copied, 1);
-        let content = tokio::fs::read_to_string(&dst_file).await?;
-        assert_eq!(content, "source content");
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[traced_test]
     async fn test_cp_dereference_symlink_chain() -> Result<(), anyhow::Error> {
         // Create a fresh temporary directory to avoid conflicts
         let tmp_dir = testutils::create_temp_dir().await?;
@@ -2919,54 +3360,6 @@ mod copy_tests {
         /// Helper to extract full error message with chain
         fn get_full_error_message(error: &Error) -> String {
             format!("{:#}", error.source)
-        }
-
-        #[tokio::test]
-        #[traced_test]
-        async fn test_permission_error_includes_root_cause() -> Result<(), anyhow::Error> {
-            let tmp_dir = testutils::create_temp_dir().await?;
-            let unreadable = tmp_dir.join("unreadable.txt");
-            tokio::fs::write(&unreadable, "test").await?;
-            tokio::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).await?;
-
-            // symlink_metadata succeeds even without read permission
-            let src_metadata = tokio::fs::symlink_metadata(&unreadable).await?;
-            let result = copy_file(
-                &PROGRESS,
-                &unreadable,
-                &tmp_dir.join("dest.txt"),
-                &src_metadata,
-                &Settings {
-                    dereference: false,
-                    fail_early: false,
-                    overwrite: false,
-                    overwrite_compare: Default::default(),
-                    overwrite_filter: None,
-                    ignore_existing: false,
-                    chunk_size: 0,
-                    skip_specials: false,
-                    remote_copy_buffer_size: 0,
-                    filter: None,
-                    dry_run: None,
-                    delete: None,
-                },
-                &NO_PRESERVE_SETTINGS,
-                false,
-            )
-            .await;
-
-            assert!(result.is_err(), "Should fail with permission error");
-            let err_msg = get_full_error_message(&result.unwrap_err());
-
-            // The error message MUST include the root cause
-            assert!(
-                err_msg.to_lowercase().contains("permission")
-                    || err_msg.contains("EACCES")
-                    || err_msg.contains("denied"),
-                "Error message must include permission-related text. Got: {}",
-                err_msg
-            );
-            Ok(())
         }
 
         #[tokio::test]
@@ -3267,6 +3660,61 @@ mod copy_tests {
             actual_mode, 0o750,
             "directory should have preserved source permissions (0o750), got {:o}",
             actual_mode
+        );
+        Ok(())
+    }
+
+    /// A child copy failure inside a filter-traversal-only directory must surface as an overall
+    /// error even though the now-empty directory is pruned (regression: the empty-dir cleanup path
+    /// returned Ok and swallowed the collected child error, so a failed copy looked successful).
+    #[tokio::test]
+    #[traced_test]
+    async fn pruned_empty_traversal_dir_still_surfaces_child_error() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::create_temp_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src_dir = test_path.join("src");
+        let sub = src_dir.join("sub");
+        tokio::fs::create_dir_all(&sub).await?;
+        // the only entry under `sub` is unreadable, so its copy fails and nothing lands in `sub`,
+        // leaving it an empty traversal-only directory that the filter cleanup prunes.
+        let unreadable = sub.join("file.txt");
+        tokio::fs::write(&unreadable, "secret").await?;
+        tokio::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o000)).await?;
+        let dst_dir = test_path.join("dst");
+        let mut filter = crate::filter::FilterSettings::new();
+        filter.add_include("*.txt").unwrap();
+        let result = copy(
+            &PROGRESS,
+            &src_dir,
+            &dst_dir,
+            &Settings {
+                dereference: false,
+                fail_early: false,
+                overwrite: false,
+                overwrite_compare: Default::default(),
+                overwrite_filter: None,
+                ignore_existing: false,
+                chunk_size: 0,
+                skip_specials: false,
+                remote_copy_buffer_size: 0,
+                filter: Some(filter),
+                dry_run: None,
+                delete: None,
+            },
+            &DO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await;
+        // restore permissions so the temp dir can be cleaned up
+        tokio::fs::set_permissions(&unreadable, std::fs::Permissions::from_mode(0o644)).await?;
+        assert!(
+            result.is_err(),
+            "the failed child copy must surface even though the empty traversal dir was pruned"
+        );
+        // the empty traversal directory itself was still cleaned up (count adjustment preserved).
+        assert!(
+            !dst_dir.join("sub").exists(),
+            "empty traversal directory should have been removed"
         );
         Ok(())
     }
@@ -4065,6 +4513,94 @@ mod copy_tests {
             );
             Ok(())
         }
+        /// Regression: in dry-run, `--ignore-existing` must report an existing destination file as
+        /// skipped (files_unchanged), not as a would-be copy. The dry-run signal is `dst_parent ==
+        /// None`, so the skip must probe existence by path rather than via a held dst fd.
+        #[tokio::test]
+        async fn dry_run_ignore_existing_reports_file_as_skipped() -> Result<(), anyhow::Error> {
+            let tmp = testutils::create_temp_dir().await?;
+            let src = tmp.join("src.txt");
+            let dst = tmp.join("dst.txt");
+            tokio::fs::write(&src, "new").await?;
+            tokio::fs::write(&dst, "old").await?; // destination already exists and differs
+            let summary = copy(
+                &PROGRESS,
+                &src,
+                &dst,
+                &Settings {
+                    dereference: false,
+                    fail_early: false,
+                    overwrite: false,
+                    overwrite_compare: Default::default(),
+                    overwrite_filter: None,
+                    ignore_existing: true,
+                    chunk_size: 0,
+                    skip_specials: false,
+                    remote_copy_buffer_size: 0,
+                    filter: None,
+                    dry_run: Some(crate::config::DryRunMode::Brief),
+                    delete: None,
+                },
+                &NO_PRESERVE_SETTINGS,
+                false,
+            )
+            .await?;
+            assert_eq!(
+                summary.files_unchanged, 1,
+                "existing file must be reported skipped in dry-run under --ignore-existing"
+            );
+            assert_eq!(
+                summary.files_copied, 0,
+                "must not report a would-be copy when --ignore-existing skips"
+            );
+            assert_eq!(
+                tokio::fs::read_to_string(&dst).await?,
+                "old",
+                "dry-run must not mutate the destination"
+            );
+            Ok(())
+        }
+        /// Regression: the symlink counterpart of `dry_run_ignore_existing_reports_file_as_skipped`
+        /// — an existing destination must be reported as `symlinks_unchanged`, not `symlinks_created`.
+        #[tokio::test]
+        async fn dry_run_ignore_existing_reports_symlink_as_skipped() -> Result<(), anyhow::Error> {
+            let tmp = testutils::create_temp_dir().await?;
+            let src = tmp.join("src_link");
+            let dst = tmp.join("dst_link");
+            tokio::fs::symlink("some/target", &src).await?;
+            tokio::fs::write(&dst, "existing").await?; // destination already exists (any type)
+            let summary = copy(
+                &PROGRESS,
+                &src,
+                &dst,
+                &Settings {
+                    dereference: false,
+                    fail_early: false,
+                    overwrite: false,
+                    overwrite_compare: Default::default(),
+                    overwrite_filter: None,
+                    ignore_existing: true,
+                    chunk_size: 0,
+                    skip_specials: false,
+                    remote_copy_buffer_size: 0,
+                    filter: None,
+                    dry_run: Some(crate::config::DryRunMode::Brief),
+                    delete: None,
+                },
+                &NO_PRESERVE_SETTINGS,
+                false,
+            )
+            .await?;
+            assert_eq!(
+                summary.symlinks_unchanged, 1,
+                "existing symlink dst must be reported skipped in dry-run under --ignore-existing"
+            );
+            assert_eq!(
+                summary.symlinks_created, 0,
+                "must not report a would-be symlink creation when --ignore-existing skips"
+            );
+            Ok(())
+        }
         /// Test that root directory is always created even when nothing matches
         /// the include pattern. The root is the user-specified source — it should
         /// never be removed/skipped due to empty-dir cleanup.
@@ -4664,6 +5200,708 @@ mod copy_tests {
             dst.join("stale.txt").exists(),
             "destination must not be pruned when source enumeration fails"
         );
+        Ok(())
+    }
+
+    // Overwriting an existing regular file goes through the fd-relative + recheck-guarded removal
+    // path: the destination file is removed (counted as a single `files_removed`) and recreated
+    // with the source content. This exercises `remove_existing`'s `unlink_at` branch via the real
+    // fd-based `copy` walk (not the legacy path-based `copy_file`).
+    #[tokio::test]
+    #[traced_test]
+    async fn overwrite_regular_file_removes_and_recreates_via_fd() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::create_temp_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src_file = test_path.join("src.txt");
+        let dst_file = test_path.join("dst.txt");
+        // distinct sizes so the metadata comparison treats them as different and overwrite proceeds.
+        tokio::fs::write(&src_file, "fresh source content").await?;
+        tokio::fs::write(&dst_file, "old").await?;
+        let summary = copy(
+            &PROGRESS,
+            &src_file,
+            &dst_file,
+            &Settings {
+                dereference: false,
+                fail_early: false,
+                overwrite: true, // <- exercises the overwrite removal path
+                overwrite_compare: filecmp::MetadataCmpSettings {
+                    size: true,
+                    mtime: true,
+                    ..Default::default()
+                },
+                overwrite_filter: None,
+                ignore_existing: false,
+                chunk_size: 0,
+                skip_specials: false,
+                remote_copy_buffer_size: 0,
+                filter: None,
+                dry_run: None,
+                delete: None,
+            },
+            &NO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        // the existing regular file was removed (fd-relative unlink_at) and the source recreated.
+        assert_eq!(summary.files_copied, 1);
+        assert_eq!(summary.rm_summary.files_removed, 1);
+        assert_eq!(summary.rm_summary.symlinks_removed, 0);
+        assert_eq!(summary.rm_summary.directories_removed, 0);
+        let content = tokio::fs::read_to_string(&dst_file).await?;
+        assert_eq!(content, "fresh source content");
+        Ok(())
+    }
+
+    // ── TOCTOU hardening: -L separability, swap-loop races, fd-budget ────────────────
+
+    /// Default non-dereference copy settings used by the TOCTOU/fd-budget tests below.
+    /// `overwrite` is on so a fresh destination per iteration is never required to be empty.
+    fn toctou_settings() -> Settings {
+        Settings {
+            dereference: false,
+            fail_early: false,
+            overwrite: true,
+            overwrite_compare: filecmp::MetadataCmpSettings {
+                size: true,
+                mtime: true,
+                ..Default::default()
+            },
+            overwrite_filter: None,
+            ignore_existing: false,
+            chunk_size: 0,
+            skip_specials: false,
+            remote_copy_buffer_size: 0,
+            filter: None,
+            dry_run: None,
+            delete: None,
+        }
+    }
+
+    // Task 1.4: with `dereference == false`, a symlink in the source is copied as a symlink — the
+    // non-dereference (fd-based) path is taken and `canonicalize` is never invoked. The
+    // `debug_assert!(settings.dereference, ...)` guarding the canonicalize call is the actual
+    // invariant guard (it would fire in debug/tests if a refactor reached it); this test exercises
+    // that non-dereference symlink path end-to-end and proves the link is preserved as a link.
+    #[tokio::test]
+    #[traced_test]
+    async fn non_dereference_copy_never_canonicalizes() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::create_temp_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("src");
+        let dst = test_path.join("dst");
+        tokio::fs::create_dir(&src).await?;
+        // a real file plus a symlink to it living inside the source tree.
+        tokio::fs::write(src.join("real.txt"), "REAL_CONTENT").await?;
+        tokio::fs::symlink("real.txt", src.join("link")).await?;
+        let summary = copy(
+            &PROGRESS,
+            &src,
+            &dst,
+            &toctou_settings(),
+            &NO_PRESERVE_SETTINGS,
+            false,
+        )
+        .await?;
+        assert_eq!(summary.files_copied, 1);
+        assert_eq!(
+            summary.symlinks_created, 1,
+            "symlink must be copied as a symlink"
+        );
+        // the destination entry must itself be a symlink (non-deref path), not a dereferenced file.
+        let link_md = tokio::fs::symlink_metadata(dst.join("link")).await?;
+        assert!(
+            link_md.file_type().is_symlink(),
+            "with dereference == false the source symlink must remain a symlink in the destination"
+        );
+        // and its target text is preserved verbatim (it was never resolved/canonicalized).
+        let target = tokio::fs::read_link(dst.join("link")).await?;
+        assert_eq!(target, std::path::Path::new("real.txt"));
+        Ok(())
+    }
+
+    // Task 1.5 helper: repeatedly swap `path` between a real regular file (content `REAL_CONTENT`)
+    // and a symlink pointing at `sentinel`, using rename so each individual state is atomic. Two
+    // staging names (a prepared symlink and the real file) live alongside `path` and are renamed
+    // over it in a tight loop until `stop` is set. Runs on a dedicated OS thread (std::thread), so
+    // it makes progress regardless of the tokio runtime's scheduling.
+    fn spawn_file_symlink_swapper(
+        dir: std::path::PathBuf,
+        entry_name: &'static str,
+        sentinel: std::path::PathBuf,
+        stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            let entry = dir.join(entry_name);
+            let staged_real = dir.join("__staged_real");
+            let staged_link = dir.join("__staged_link");
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                // prepare the real file at a staging name, then rename it over `entry`.
+                let _ = std::fs::remove_file(&staged_real);
+                if std::fs::write(&staged_real, b"REAL_CONTENT").is_err() {
+                    continue;
+                }
+                let _ = std::fs::rename(&staged_real, &entry);
+                // prepare a symlink-to-sentinel at the other staging name, then rename it over.
+                let _ = std::fs::remove_file(&staged_link);
+                let _ = std::os::unix::fs::symlink(&sentinel, &staged_link);
+                let _ = std::fs::rename(&staged_link, &entry);
+            }
+        })
+    }
+
+    // Task 1.5 (a): final-component file<->symlink swap. While the copy runs, `src/sub/entry` is
+    // rapidly flipped between a real regular file and a symlink to a sentinel outside the tree. The
+    // copy may grab the real file, or O_NOFOLLOW/fstat may catch the symlink (error or skip), but
+    // the sentinel's secret content must NEVER end up in the destination as data.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn file_symlink_swap_never_leaks_sentinel() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::create_temp_dir().await?;
+        let test_path = tmp_dir.as_path();
+        // sentinel lives OUTSIDE the source tree with distinctive content.
+        let sentinel = test_path.join("sentinel_secret");
+        tokio::fs::write(&sentinel, "SENTINEL_SECRET_CONTENT").await?;
+        let src = test_path.join("src");
+        let sub = src.join("sub");
+        tokio::fs::create_dir(&src).await?;
+        tokio::fs::create_dir(&sub).await?;
+        tokio::fs::write(sub.join("entry"), "REAL_CONTENT").await?;
+
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let swapper =
+            spawn_file_symlink_swapper(sub.clone(), "entry", sentinel.clone(), stop.clone());
+
+        let settings = toctou_settings();
+        let mut caught_swaps = 0usize;
+        let mut copied_real = 0usize;
+        for i in 0..200 {
+            let dst = test_path.join(format!("dst_{i}"));
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                copy(
+                    &PROGRESS,
+                    &src,
+                    &dst,
+                    &settings,
+                    &NO_PRESERVE_SETTINGS,
+                    false,
+                ),
+            )
+            .await
+            .expect("copy must not hang under concurrent swapping");
+            match result {
+                Ok(_) => {}
+                Err(_) => caught_swaps += 1, // a swap was caught mid-copy (failed closed)
+            }
+            // CORE ASSERTION: if a regular file landed at the destination, it is the real content —
+            // never the sentinel's secret. The entry may instead be absent or a symlink.
+            let entry_dst = dst.join("sub").join("entry");
+            if let Ok(md) = tokio::fs::symlink_metadata(&entry_dst).await
+                && md.file_type().is_file()
+            {
+                let content = tokio::fs::read_to_string(&entry_dst).await?;
+                assert_ne!(
+                    content, "SENTINEL_SECRET_CONTENT",
+                    "iteration {i}: sentinel content leaked into the destination as a regular file"
+                );
+                assert_eq!(
+                    content, "REAL_CONTENT",
+                    "iteration {i}: a regular destination file must hold the real content"
+                );
+                copied_real += 1;
+            }
+            let _ = tokio::fs::remove_dir_all(&dst).await;
+        }
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        swapper.join().expect("swapper thread panicked");
+        // sanity: the run did meaningful work (caught some swaps or copied the real file at least
+        // once). This is not the safety assertion — the safety assertion is "sentinel never leaks"
+        // above and holds on every iteration regardless of timing.
+        tracing::info!("file/symlink swap: caught_swaps={caught_swaps}, copied_real={copied_real}");
+        assert!(
+            caught_swaps + copied_real > 0,
+            "expected at least one observable outcome across 200 iterations"
+        );
+        Ok(())
+    }
+
+    // Task 1.5 (b): intermediate-directory swap. While the copy runs, `src/sub` is flipped between a
+    // real directory (containing a real file) and a symlink to a directory outside the tree holding
+    // a sentinel. open_dir uses O_NOFOLLOW, so the walk either descends the real directory or fails
+    // closed — it must never follow the symlink and copy the outside sentinel.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn intermediate_dir_swap_never_follows_symlink() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::create_temp_dir().await?;
+        let test_path = tmp_dir.as_path();
+        // an "outside" directory tree holding a sentinel file, reachable only via a symlink.
+        let outside = test_path.join("outside_dir");
+        tokio::fs::create_dir(&outside).await?;
+        tokio::fs::write(outside.join("sentinel.txt"), "SENTINEL_SECRET_CONTENT").await?;
+        let src = test_path.join("src");
+        tokio::fs::create_dir(&src).await?;
+        // the real `sub` directory with a real file inside.
+        let real_sub = src.join("sub");
+        tokio::fs::create_dir(&real_sub).await?;
+        tokio::fs::write(real_sub.join("real.txt"), "REAL_CONTENT").await?;
+
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let swapper = {
+            let src = src.clone();
+            let outside = outside.clone();
+            let stop = stop.clone();
+            std::thread::spawn(move || {
+                let sub = src.join("sub");
+                let staged_dir = src.join("__staged_sub_dir");
+                let staged_link = src.join("__staged_sub_link");
+                while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    // stage a real directory (with the real file) then rename it over `sub`.
+                    let _ = std::fs::remove_dir_all(&staged_dir);
+                    if std::fs::create_dir(&staged_dir).is_ok() {
+                        let _ = std::fs::write(staged_dir.join("real.txt"), b"REAL_CONTENT");
+                        // RENAME_EXCHANGE isn't available portably here; remove-then-rename. The
+                        // window where `sub` is briefly absent is fine — the copy may error, which
+                        // is an accepted failed-closed outcome.
+                        let _ = std::fs::remove_dir_all(&sub);
+                        let _ = std::fs::remove_file(&sub);
+                        let _ = std::fs::rename(&staged_dir, &sub);
+                    }
+                    // stage a symlink to the outside dir, then swap it in over `sub`.
+                    let _ = std::fs::remove_file(&staged_link);
+                    if std::os::unix::fs::symlink(&outside, &staged_link).is_ok() {
+                        let _ = std::fs::remove_dir_all(&sub);
+                        let _ = std::fs::remove_file(&sub);
+                        let _ = std::fs::rename(&staged_link, &sub);
+                    }
+                }
+            })
+        };
+
+        let settings = toctou_settings();
+        for i in 0..200 {
+            let dst = test_path.join(format!("dst_{i}"));
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                copy(
+                    &PROGRESS,
+                    &src,
+                    &dst,
+                    &settings,
+                    &NO_PRESERVE_SETTINGS,
+                    false,
+                ),
+            )
+            .await
+            .expect("copy must not hang under concurrent dir swapping");
+            // CORE ASSERTION: the walk must never DESCEND through the symlink and copy the outside
+            // tree's contents as data. Classify `dst/sub` WITHOUT following symlinks: if it is a
+            // symlink, the link was copied verbatim (safe — `outside` was never read); if it is a
+            // real directory, the copy descended a real `sub`, and the sentinel — which only ever
+            // lived in `outside`, reachable solely via the symlink — must NOT have been reproduced
+            // inside it. (`Path::exists` follows symlinks, so it would falsely "see" the sentinel
+            // through a verbatim-copied symlink; `symlink_metadata` is the correct probe here.)
+            // when `dst/sub` is a symlink it was copied verbatim (accepted failed-closed outcome,
+            // `outside` was never read); only a REAL destination directory means the walk descended,
+            // and then it must have descended the real `sub` — never the symlink into `outside`.
+            let sub_dst = dst.join("sub");
+            if let Ok(sub_md) = tokio::fs::symlink_metadata(&sub_dst).await
+                && sub_md.file_type().is_dir()
+            {
+                let leaked = sub_dst.join("sentinel.txt");
+                let leaked_is_real_file = tokio::fs::symlink_metadata(&leaked)
+                    .await
+                    .map(|m| m.file_type().is_file())
+                    .unwrap_or(false);
+                assert!(
+                    !leaked_is_real_file,
+                    "iteration {i}: intermediate-dir symlink was followed; the outside \
+                     sentinel was copied into a real destination directory"
+                );
+                // a real `sub` directory copied from the real source holds the real file.
+                let real_dst = sub_dst.join("real.txt");
+                if let Ok(content) = tokio::fs::read_to_string(&real_dst).await {
+                    assert_eq!(
+                        content, "REAL_CONTENT",
+                        "iteration {i}: copied file must hold real content"
+                    );
+                }
+            }
+            let _ = tokio::fs::remove_dir_all(&dst).await;
+        }
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        swapper.join().expect("dir swapper thread panicked");
+        Ok(())
+    }
+
+    // Task 1.5 (d): destination NON-EMPTY-directory overwrite removal under an intermediate-component
+    // swap — the racy mirror of `test_remote_dest_overwrite_replaces_intermediate_symlink_in_tree`,
+    // targeting the removal path B1 hardened. The source has regular files at `src/mid/deeper/subK`,
+    // while the destination has NON-EMPTY directories at `dst/mid/deeper/subK`. A `--overwrite` copy
+    // must therefore REMOVE those non-empty directories (`remove_existing` → ENOTEMPTY →
+    // `rm::rm_child`) before creating the files. Concurrently, a swapper flips the INTERMEDIATE
+    // component `dst/mid` between a real directory (holding `deeper/subK`) and a symlink to an
+    // out-of-tree directory mirroring `deeper/subK/`, whose `subK/` each hold a sentinel.
+    //
+    // This is a fail-closed STRESS test: under the fd code the copy either descends a real `dst/mid`
+    // and removes through the pinned `deeper` fd, or fails closed at the intermediate `make_dir`
+    // O_NOFOLLOW when it observes the symlink — never escaping. CORE ASSERTION: no out-of-tree
+    // sentinel is ever deleted, and the copy never hangs. (Because the walk fails closed at the
+    // intermediate `make_dir` whenever it sees the symlink, this racy form rarely even reaches the
+    // removal branch and does NOT reliably reproduce the path-based escape; the deterministic
+    // `nonempty_dir_overwrite_removal_uses_pinned_fd_not_path` below is the regression-catcher that
+    // FAILS when the branch is reverted to `rm::rm`.)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dest_nonempty_dir_overwrite_removal_contained_under_intermediate_swap()
+    -> Result<(), anyhow::Error> {
+        const N: usize = 8;
+        let tmp_dir = testutils::create_temp_dir().await?;
+        let test_path = tmp_dir.as_path();
+        // an out-of-tree tree mirroring `deeper/`, holding several non-empty `subK/` each guarding a
+        // sentinel. A path-based rm(dst/mid/deeper/subK) through a `mid`->out_of_tree symlink would
+        // delete out_of_tree/deeper/subK. Several targets widen the window: once `mid` flips
+        // to a symlink mid-copy (after `deeper` was opened), every remaining path-based rm escapes.
+        let out_of_tree = test_path.join("out_of_tree");
+        let oot_deeper = out_of_tree.join("deeper");
+        for k in 0..N {
+            let oot_sub = oot_deeper.join(format!("sub{k}"));
+            tokio::fs::create_dir_all(&oot_sub).await?;
+            tokio::fs::write(oot_sub.join("sentinel.txt"), "SENTINEL").await?;
+        }
+
+        // source: src/mid/deeper/subK are regular FILES (so the copy must replace the dst dirs).
+        let src = test_path.join("src");
+        let src_deeper = src.join("mid").join("deeper");
+        tokio::fs::create_dir_all(&src_deeper).await?;
+        for k in 0..N {
+            tokio::fs::write(src_deeper.join(format!("sub{k}")), "REAL_FILE_CONTENT").await?;
+        }
+
+        // destination root persists; the swapper owns the intermediate `dst/mid`.
+        let dst = test_path.join("dst");
+        tokio::fs::create_dir(&dst).await?;
+
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let swapper = {
+            let dst = dst.clone();
+            let out_of_tree = out_of_tree.clone();
+            let stop = stop.clone();
+            std::thread::spawn(move || {
+                let mid = dst.join("mid");
+                let staged_dir = dst.join("__staged_mid_dir");
+                let staged_link = dst.join("__staged_mid_link");
+                while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    // stage a real `mid` directory holding `deeper/subK` as NON-EMPTY directories,
+                    // then rename it over `mid`. This is the state in which the overwrite-removal
+                    // branch fires (src has FILES at mid/deeper/subK, dst has non-empty dirs).
+                    let _ = std::fs::remove_dir_all(&staged_dir);
+                    let staged_deeper = staged_dir.join("deeper");
+                    if std::fs::create_dir_all(&staged_deeper).is_ok() {
+                        for k in 0..N {
+                            let s = staged_deeper.join(format!("sub{k}"));
+                            if std::fs::create_dir(&s).is_ok() {
+                                let _ = std::fs::write(s.join("inner.txt"), b"INNER_CONTENT");
+                            }
+                        }
+                        let _ = std::fs::remove_dir_all(&mid);
+                        let _ = std::fs::remove_file(&mid);
+                        let _ = std::fs::rename(&staged_dir, &mid);
+                    }
+                    // stage a symlink to the out-of-tree directory, then swap it in over `mid`.
+                    let _ = std::fs::remove_file(&staged_link);
+                    if std::os::unix::fs::symlink(&out_of_tree, &staged_link).is_ok() {
+                        let _ = std::fs::remove_dir_all(&mid);
+                        let _ = std::fs::remove_file(&mid);
+                        let _ = std::fs::rename(&staged_link, &mid);
+                    }
+                }
+            })
+        };
+
+        let settings = toctou_settings();
+        for i in 0..200 {
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                copy(
+                    &PROGRESS,
+                    &src,
+                    &dst,
+                    &settings,
+                    &NO_PRESERVE_SETTINGS,
+                    false,
+                ),
+            )
+            .await
+            .expect("copy must not hang under concurrent intermediate-component swapping");
+            // CORE ASSERTION (every iteration, regardless of timing): no out-of-tree sentinel is
+            // ever deleted. The fd-relative removal is contained to the pinned `dst/mid/deeper` fd
+            // and its O_NOFOLLOW descent fails closed on a swapped-in symlink — it can never
+            // re-resolve `dst/mid/deeper/subK` through a `mid`->out_of_tree symlink and delete
+            // `out_of_tree/deeper/subK`.
+            for k in 0..N {
+                assert!(
+                    oot_deeper
+                        .join(format!("sub{k}"))
+                        .join("sentinel.txt")
+                        .exists(),
+                    "iteration {i}: out-of-tree sentinel sub{k} was deleted — the non-empty-\
+                     directory overwrite removal escaped the destination tree through a swapped \
+                     intermediate symlink (path-based rm regression)"
+                );
+            }
+        }
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        swapper
+            .join()
+            .expect("intermediate-swap swapper thread panicked");
+        // sanity: the out-of-tree subtree itself also survived intact.
+        assert!(
+            oot_deeper.join("sub0").is_dir(),
+            "out-of-tree sub directory must survive"
+        );
+        Ok(())
+    }
+
+    // Deterministic companion to the racy test above, proving the B1 fix at the contract level: the
+    // non-empty-directory overwrite removal acts through the PINNED parent fd, never by re-resolving
+    // the display path. We open the REAL parent directory as `dst_parent`, classify the real
+    // non-empty child, but pass a `dst_path` whose INTERMEDIATE component is an out-of-tree symlink
+    // (the post-classification redirect a racy attacker would plant). The fd-relative `rm_child`
+    // removes the real child through the held fd and leaves the out-of-tree tree untouched. The old
+    // path-based `rm::rm(dst_path)` would instead re-resolve `dst_path` through the symlink and
+    // delete the out-of-tree subtree — so this test FAILS if the branch is reverted to `rm::rm`
+    // (verified by hand). `recheck` passes because the real child's identity is unchanged.
+    #[tokio::test]
+    #[traced_test]
+    async fn nonempty_dir_overwrite_removal_uses_pinned_fd_not_path() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::create_temp_dir().await?;
+        let test_path = tmp_dir.as_path();
+
+        // the REAL destination tree: base/realdeeper/victim is a NON-EMPTY directory.
+        let real_deeper = test_path.join("base").join("realdeeper");
+        let real_victim = real_deeper.join("victim");
+        tokio::fs::create_dir_all(&real_victim).await?;
+        tokio::fs::write(real_victim.join("inner.txt"), "INNER").await?;
+
+        // an out-of-tree tree the stale display path would resolve into. Its `victim/` holds a
+        // sentinel; a path-based rm of the redirected path would delete it.
+        let out_of_tree = test_path.join("out_of_tree");
+        let oot_victim = out_of_tree.join("realdeeper").join("victim");
+        tokio::fs::create_dir_all(&oot_victim).await?;
+        tokio::fs::write(oot_victim.join("sentinel.txt"), "SENTINEL").await?;
+
+        // the redirected display path: base/mid -> out_of_tree, so `mid/realdeeper/victim`
+        // resolves to out_of_tree/realdeeper/victim by PATH, but the pinned fd points at the real
+        // base/realdeeper.
+        let mid_link = test_path.join("base").join("mid");
+        tokio::fs::symlink(&out_of_tree, &mid_link).await?;
+        let stale_dst_path = mid_link.join("realdeeper").join("victim");
+
+        // open the REAL parent fd and classify the real non-empty child through it.
+        let dst_parent =
+            Arc::new(Dir::open_root_dir(&real_deeper, false, congestion::Side::Destination).await?);
+        let victim_name: &OsStr = OsStr::new("victim");
+        let dst_handle = dst_parent.child(victim_name).await?;
+        assert_eq!(dst_handle.kind(), EntryKind::Dir);
+
+        let settings = toctou_settings();
+        let summary = remove_existing(
+            &PROGRESS,
+            &dst_parent,
+            victim_name,
+            &stale_dst_path,
+            &dst_handle,
+            &settings,
+        )
+        .await?;
+        assert_eq!(
+            summary.directories_removed, 1,
+            "the real non-empty victim directory should have been removed via the pinned fd"
+        );
+
+        // the real child was removed through the held fd...
+        assert!(
+            !real_victim.exists(),
+            "the real non-empty victim should have been removed through the pinned parent fd"
+        );
+        // ...and the out-of-tree subtree (which the stale path resolves into) was NOT touched.
+        assert!(
+            oot_victim.join("sentinel.txt").exists(),
+            "out-of-tree sentinel was deleted — removal re-resolved the display path through the \
+             intermediate symlink instead of using the pinned fd (path-based rm regression)"
+        );
+        Ok(())
+    }
+
+    // Task 1.5 (c): FIFO swap. While the copy runs, `src/sub/entry` is flipped between a real file
+    // and a FIFO (named pipe). open_file_read uses O_NONBLOCK + an fstat S_ISREG check, so a FIFO is
+    // rejected without blocking. The whole copy is wrapped in a generous timeout: the assertion is
+    // that it never hangs, and a FIFO is never copied as file data.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn fifo_swap_never_hangs_or_copies_pipe() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::create_temp_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("src");
+        let sub = src.join("sub");
+        tokio::fs::create_dir(&src).await?;
+        tokio::fs::create_dir(&sub).await?;
+        tokio::fs::write(sub.join("entry"), "REAL_CONTENT").await?;
+
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let swapper = {
+            let sub = sub.clone();
+            let stop = stop.clone();
+            std::thread::spawn(move || {
+                let entry = sub.join("entry");
+                let staged_real = sub.join("__staged_real");
+                let staged_fifo = sub.join("__staged_fifo");
+                while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    // real file staged then renamed over `entry`.
+                    let _ = std::fs::remove_file(&staged_real);
+                    if std::fs::write(&staged_real, b"REAL_CONTENT").is_ok() {
+                        let _ = std::fs::rename(&staged_real, &entry);
+                    }
+                    // FIFO staged then renamed over `entry`. mkfifo can't target an existing name,
+                    // so create it at a staging path and rename it in.
+                    let _ = std::fs::remove_file(&staged_fifo);
+                    let made = nix::unistd::mkfifo(
+                        &staged_fifo,
+                        nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+                    )
+                    .is_ok();
+                    if made {
+                        let _ = std::fs::rename(&staged_fifo, &entry);
+                    }
+                }
+            })
+        };
+
+        let settings = toctou_settings();
+        for i in 0..200 {
+            let dst = test_path.join(format!("dst_{i}"));
+            // the generous timeout is the anti-hang assertion: a FIFO opened without O_NONBLOCK
+            // would block the copy forever waiting for a writer.
+            let _ = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                copy(
+                    &PROGRESS,
+                    &src,
+                    &dst,
+                    &settings,
+                    &NO_PRESERVE_SETTINGS,
+                    false,
+                ),
+            )
+            .await
+            .expect("copy must not hang when an entry is swapped to a FIFO");
+            // CORE ASSERTION: whatever landed at the destination is either absent or a real regular
+            // file with the real content — a FIFO is never copied as data, and never copied as a
+            // special (no specials are expected in the destination).
+            let entry_dst = dst.join("sub").join("entry");
+            if let Ok(md) = tokio::fs::symlink_metadata(&entry_dst).await {
+                use std::os::unix::fs::FileTypeExt as _;
+                let ft = md.file_type();
+                assert!(
+                    !ft.is_fifo(),
+                    "iteration {i}: a FIFO was reproduced at the destination"
+                );
+                if ft.is_file() {
+                    let content = tokio::fs::read_to_string(&entry_dst).await?;
+                    assert_eq!(
+                        content, "REAL_CONTENT",
+                        "iteration {i}: a regular destination file must hold the real content"
+                    );
+                }
+            }
+            let _ = tokio::fs::remove_dir_all(&dst).await;
+        }
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        swapper.join().expect("fifo swapper thread panicked");
+        Ok(())
+    }
+
+    // Task 1.6: a deep, narrow chain `a/a/a/.../file` copies fully without hanging or exhausting
+    // fds. `copy_internal` is `#[async_recursion]`, so depth exercises the recursive chain; 800 is
+    // deep enough to stress the fd budget / hold-and-wait avoidance without risking a stack blowup.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn copy_deep_narrow_tree_completes() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::create_temp_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("src");
+        const DEPTH: usize = 800;
+        // build src/a/a/.../a/leaf.txt by appending one "a" per level.
+        let mut cur = src.clone();
+        for _ in 0..DEPTH {
+            cur = cur.join("a");
+        }
+        tokio::fs::create_dir_all(&cur).await?;
+        tokio::fs::write(cur.join("leaf.txt"), "DEEP_LEAF").await?;
+
+        let dst = test_path.join("dst");
+        let summary = tokio::time::timeout(
+            std::time::Duration::from_secs(120),
+            copy(
+                &PROGRESS,
+                &src,
+                &dst,
+                &toctou_settings(),
+                &NO_PRESERVE_SETTINGS,
+                false,
+            ),
+        )
+        .await
+        .expect("deep-narrow copy must not hang (fd budget / hold-and-wait)")?;
+        assert_eq!(
+            summary.files_copied, 1,
+            "the single leaf file must be copied"
+        );
+        // the destination root directory plus the DEPTH-level `a` chain copied into it.
+        assert_eq!(summary.directories_created, DEPTH + 1);
+        // verify the leaf actually landed at the bottom of the destination chain.
+        let mut leaf = dst.clone();
+        for _ in 0..DEPTH {
+            leaf = leaf.join("a");
+        }
+        let content = tokio::fs::read_to_string(leaf.join("leaf.txt")).await?;
+        assert_eq!(content, "DEEP_LEAF");
+        Ok(())
+    }
+
+    // Task 1.6: a single very wide directory (many sibling files) copies fully within a timeout. The
+    // per-entry open-files permit bounds concurrency; this confirms the wide fan-out drains without
+    // fd exhaustion or a hang.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn copy_wide_tree_completes() -> Result<(), anyhow::Error> {
+        let tmp_dir = testutils::create_temp_dir().await?;
+        let test_path = tmp_dir.as_path();
+        let src = test_path.join("src");
+        tokio::fs::create_dir(&src).await?;
+        const WIDTH: usize = 2000;
+        for i in 0..WIDTH {
+            tokio::fs::write(src.join(format!("f{i}.txt")), format!("content {i}")).await?;
+        }
+        let dst = test_path.join("dst");
+        let summary = tokio::time::timeout(
+            std::time::Duration::from_secs(120),
+            copy(
+                &PROGRESS,
+                &src,
+                &dst,
+                &toctou_settings(),
+                &NO_PRESERVE_SETTINGS,
+                false,
+            ),
+        )
+        .await
+        .expect("wide copy must not hang (fd exhaustion / permit deadlock)")?;
+        assert_eq!(summary.files_copied, WIDTH, "every file must be copied");
+        // spot-check a few files actually landed with the right content.
+        for i in [0usize, WIDTH / 2, WIDTH - 1] {
+            let content = tokio::fs::read_to_string(dst.join(format!("f{i}.txt"))).await?;
+            assert_eq!(content, format!("content {i}"));
+        }
         Ok(())
     }
 }

--- a/common/src/copy_data.rs
+++ b/common/src/copy_data.rs
@@ -1,0 +1,715 @@
+//! Low-level data-copy primitive used by the copy path.
+//!
+//! This replaces `std::fs::copy` so the copy path can keep the destination fd
+//! open across the data copy and the subsequent metadata operations (closing
+//! the TOCTOU window between writing bytes and setting times/owner/mode).
+//!
+//! The copy uses a three-tier fallback chain, fastest first:
+//! 1. the in-kernel `copy_file_range` syscall, which is reflink- and
+//!    server-side-copy capable (e.g. on Btrfs/XFS/NFSv4.2);
+//! 2. when the kernel or filesystem cannot satisfy that, a sparse-aware
+//!    userspace copy that walks the source with `SEEK_DATA`/`SEEK_HOLE` and
+//!    preserves holes;
+//! 3. when the filesystem does not even support `SEEK_DATA`/`SEEK_HOLE` (some
+//!    FUSE/older/unusual filesystems return `EINVAL`/`ENOTSUP` for those
+//!    `lseek` whences), a plain dense read/write copy loop, which always works
+//!    on any regular file (this mirrors what `std::fs::copy` would have done
+//!    and exists purely for robustness — it does not preserve holes).
+//!
+//! # Snapshot-size semantics
+//!
+//! Callers pass `len`, the size captured when the source was classified. Both
+//! the primary and fallback paths copy *up to* `len` and agree on the result:
+//! - a source that *grew* after classification is intentionally **not**
+//!   over-copied — we copy at most `len` bytes and `dst` ends at `len`;
+//! - a source that *shrank* below `len` (e.g. a concurrent truncate — holding
+//!   the fd does not prevent it) copies and returns only what the source
+//!   provides and sizes `dst` to that actual end, **not** to `len` (no
+//!   spurious trailing padding);
+//! - a *legitimate* sparse trailing hole (the source's logical size still
+//!   equals `len`) keeps `dst` sized to `len`. Whether the trailing region is
+//!   left *unallocated* depends on the path: the sparse-aware fallback (tier 2)
+//!   preserves the hole, and the primary `copy_file_range` (tier 1) does so only
+//!   on reflink/sparse-capable filesystems (e.g. Btrfs/XFS) — on others (e.g.
+//!   ext4) the size is still `len` but the region may be fully allocated.
+//!
+//! # Durability
+//!
+//! These are synchronous syscalls, so once they return the writes are in the
+//! kernel. This function deliberately does **not** `fsync`/`flush` — durability
+//! is out of scope here. mtime correctness is the caller's responsibility (it
+//! sets times after this returns).
+use std::fs::File;
+use std::os::fd::AsFd;
+use std::os::unix::fs::FileExt;
+
+/// sparse-aware userspace fallback copy buffer size (1 MiB).
+const FALLBACK_BUF_SIZE: usize = 1024 * 1024;
+
+/// dense read/write fallback copy buffer size (128 KiB). Smaller than the
+/// sparse buffer because this path is the last-resort robustness fallback for
+/// filesystems that can't do `SEEK_DATA`/`SEEK_HOLE`, not a throughput path.
+const DENSE_BUF_SIZE: usize = 128 * 1024;
+
+/// Copy up to `len` bytes from `src` to `dst` using the in-kernel
+/// `copy_file_range` (reflink/server-side capable), falling back to a
+/// sparse-aware userspace copy when the kernel/filesystem can't. Both files are
+/// already open; offsets start at `0`. Returns the number of bytes copied.
+///
+/// See the module docs for snapshot-size and durability semantics.
+pub fn copy_file_range_all(src: &File, dst: &File, len: u64) -> std::io::Result<u64> {
+    // establish the documented offset-0 start on both fds. The caller may hand
+    // us descriptors whose offsets were advanced by an earlier read/stat, and
+    // copy_file_range with `None` offsets uses each fd's current position.
+    nix::unistd::lseek(src.as_fd(), 0, nix::unistd::Whence::SeekSet)
+        .map_err(std::io::Error::from)?;
+    nix::unistd::lseek(dst.as_fd(), 0, nix::unistd::Whence::SeekSet)
+        .map_err(std::io::Error::from)?;
+    let mut copied: u64 = 0;
+    while copied < len {
+        let remaining = usize::try_from(len - copied).unwrap_or(usize::MAX);
+        // None offsets => the kernel uses and advances each fd's own offset,
+        // so successive calls naturally continue where the last left off.
+        match nix::fcntl::copy_file_range(src.as_fd(), None, dst.as_fd(), None, remaining) {
+            Ok(0) => {
+                // EOF: the source is shorter than `len` (a shrink). Stop here
+                // rather than spinning forever on a zero-byte copy.
+                return Ok(copied);
+            }
+            Ok(n) => copied += n as u64,
+            Err(errno) => {
+                // these errnos mean copy_file_range is unsupported for this
+                // pair (no kernel support, cross-filesystem, bad arguments,
+                // or the fs rejects it) -> fall back for the remaining range.
+                // note: ENOTSUP == EOPNOTSUPP numerically on Linux.
+                if matches!(
+                    errno,
+                    nix::errno::Errno::ENOSYS
+                        | nix::errno::Errno::EXDEV
+                        | nix::errno::Errno::EINVAL
+                        | nix::errno::Errno::EOPNOTSUPP
+                ) {
+                    // the fallback returns only the bytes IT moved ([copied, final]);
+                    // add the prefix the primary path already copied so the total is
+                    // reported correctly.
+                    return copy_sparse_fallback(src, dst, copied, len)
+                        .map(|fallback| copied + fallback);
+                }
+                return Err(std::io::Error::from(errno));
+            }
+        }
+    }
+    Ok(copied)
+}
+
+/// Classification of an initial `SEEK_DATA` probe, used to decide whether the
+/// sparse fallback can run or must degrade to a dense read/write copy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SparseProbe {
+    /// `SEEK_DATA` found a data region starting at this offset.
+    Data(u64),
+    /// `SEEK_DATA` returned `ENXIO`: no data at or after the probe offset, i.e.
+    /// the rest of the file up to its logical end is a hole.
+    TrailingHole,
+    /// the filesystem does not support `SEEK_DATA`/`SEEK_HOLE` (`EINVAL` or
+    /// `ENOTSUP`/`EOPNOTSUPP`): the caller must fall back to a dense copy.
+    Unsupported,
+}
+
+/// Classify the result of an `lseek(.., SEEK_DATA)` probe (the testable seam for
+/// the sparse-vs-dense routing decision).
+///
+/// - `Ok(off)` -> [`SparseProbe::Data`] at `off`;
+/// - `ENXIO` -> [`SparseProbe::TrailingHole`] (a legitimate trailing hole, not
+///   an error: the file simply has no more data);
+/// - `EINVAL` / `EOPNOTSUPP` (== `ENOTSUP` on Linux) -> [`SparseProbe::Unsupported`],
+///   meaning the filesystem rejects the `SEEK_DATA`/`SEEK_HOLE` whences and the
+///   sparse walk can't run on it;
+/// - any other errno (e.g. `EIO`, `EBADF`) is a genuine failure and is
+///   propagated — we deliberately do **not** mask real I/O errors as
+///   "unsupported".
+fn classify_seek_data(result: nix::Result<libc::off_t>) -> std::io::Result<SparseProbe> {
+    match result {
+        Ok(off) => Ok(SparseProbe::Data(off as u64)),
+        Err(nix::errno::Errno::ENXIO) => Ok(SparseProbe::TrailingHole),
+        // note: ENOTSUP == EOPNOTSUPP numerically on Linux, so this arm also
+        // covers ENOTSUP.
+        Err(nix::errno::Errno::EINVAL | nix::errno::Errno::EOPNOTSUPP) => {
+            Ok(SparseProbe::Unsupported)
+        }
+        Err(errno) => Err(std::io::Error::from(errno)),
+    }
+}
+
+/// Sparse-aware userspace copy of the range `[start, len)` from `src` to `dst`,
+/// with a dense read/write copy as a final fallback.
+///
+/// Used as the fallback when `copy_file_range` is unsupported. It first probes
+/// the source with `SEEK_DATA`; if the filesystem supports it, it walks the
+/// source's data regions with `SEEK_DATA`/`SEEK_HOLE` and copies only the data
+/// extents, so holes (e.g. in a sparse VM or Lustre image) are preserved
+/// instead of being expanded to fully-allocated zeros. If the filesystem does
+/// not support those whences (some FUSE/older/unusual filesystems return
+/// `EINVAL`/`ENOTSUP`), it degrades to [`dense_copy`], a plain read/write loop
+/// that always works on a regular file (this matches what `std::fs::copy` would
+/// have done — see the module docs). A genuine I/O error during the probe (e.g.
+/// `EIO`) is propagated rather than masked as "unsupported".
+///
+/// The final size is reconciled with the source's *actual* end so this path
+/// agrees with the primary one on a shrunk source: after the data loop it
+/// computes `final = min(len, actual_eof)` and `ftruncate`s `dst` to `final`.
+/// A legitimate trailing hole (source logical size still == `len`) leaves
+/// `actual_eof == len`, so `dst` ends at `len` with the trailing region
+/// unallocated; a source that shrank below `len` (`actual_eof < len`) sizes
+/// `dst` to `actual_eof` rather than padding a spurious hole up to `len`.
+///
+/// Returns `final - start`, i.e. the number of bytes of the logical copy that
+/// the source actually provided — matching the primary path's return.
+pub(crate) fn copy_sparse_fallback(
+    src: &File,
+    dst: &File,
+    start: u64,
+    len: u64,
+) -> std::io::Result<u64> {
+    if start >= len {
+        // only reachable with `start == len`: the primary path copied the whole
+        // logical range before erroring, so the source was at least `len` and
+        // there is nothing left to copy. `min(len, actual_eof) == len` here, so
+        // sizing `dst` to `len` is correct and can't drop already-copied bytes.
+        nix::unistd::ftruncate(dst.as_fd(), to_off_t(len)?).map_err(std::io::Error::from)?;
+        return Ok(0);
+    }
+    // probe the source for sparse support before committing to the sparse walk.
+    // if the filesystem can't do SEEK_DATA/SEEK_HOLE, fall back to a dense copy
+    // of the whole range; a genuine I/O error propagates from classify_seek_data.
+    let probe = classify_seek_data(nix::unistd::lseek(
+        src.as_fd(),
+        to_off_t(start)?,
+        nix::unistd::Whence::SeekData,
+    ))?;
+    let first_data = match probe {
+        SparseProbe::Unsupported => return dense_copy(src, dst, start, len),
+        // no data at all before EOF: nothing to copy, the trailing ftruncate
+        // below sizes dst (a fully-hole range).
+        SparseProbe::TrailingHole => len,
+        SparseProbe::Data(d) => d,
+    };
+    // the data loop reads/writes at explicit offsets via read_at/write_at, so we
+    // don't pre-seek the fds here; the scan starts from the probed first data
+    // offset and re-runs SEEK_DATA for subsequent regions.
+    let mut buf = vec![0u8; FALLBACK_BUF_SIZE];
+    let mut off = start;
+    let mut next_data = first_data;
+    while off < len {
+        // `next_data` holds the next data region at or after `off` (seeded by the
+        // initial probe, then refreshed by SEEK_DATA at the bottom of the loop).
+        let data = next_data;
+        if data >= len {
+            break;
+        }
+        // find the hole that ends this data region; clamp to `len`.
+        let hole =
+            match nix::unistd::lseek(src.as_fd(), to_off_t(data)?, nix::unistd::Whence::SeekHole) {
+                Ok(h) => (h as u64).min(len),
+                // a data region with no following hole means data extends to EOF;
+                // clamp to `len`.
+                Err(nix::errno::Errno::ENXIO) => len,
+                Err(errno) => return Err(std::io::Error::from(errno)),
+            };
+        copy_data_extent(src, dst, data, hole, &mut buf)?;
+        off = hole;
+        if off >= len {
+            break;
+        }
+        // find the next data region for the following iteration. the filesystem
+        // already proved it supports SEEK_DATA on the initial probe, so an
+        // Unsupported result here would be anomalous; handle it defensively by
+        // dense-copying the remaining range (dense_copy reconciles dst's final
+        // size for the whole file, so the already-copied prefix is preserved).
+        next_data = match classify_seek_data(nix::unistd::lseek(
+            src.as_fd(),
+            to_off_t(off)?,
+            nix::unistd::Whence::SeekData,
+        ))? {
+            SparseProbe::Data(d) => d,
+            SparseProbe::TrailingHole => break, // no more data -> trailing hole
+            SparseProbe::Unsupported => return dense_copy(src, dst, off, len),
+        };
+    }
+    // reconcile the final size with the source's actual end so we agree with the
+    // primary path on a shrunk source. `min(len, actual_eof)`: a legitimate
+    // trailing hole keeps `actual_eof == len` (dst ends at `len`, trailing region
+    // unallocated); a source that shrank below `len` sizes dst to `actual_eof`
+    // rather than padding a spurious hole up to `len`.
+    let actual_eof = nix::unistd::lseek(src.as_fd(), 0, nix::unistd::Whence::SeekEnd)
+        .map_err(std::io::Error::from)? as u64;
+    let final_size = len.min(actual_eof);
+    nix::unistd::ftruncate(dst.as_fd(), to_off_t(final_size)?).map_err(std::io::Error::from)?;
+    // saturating: if the source shrank below `start` between the primary copy
+    // and this check, the fallback added no bytes (final < start).
+    Ok(final_size.saturating_sub(start))
+}
+
+/// Copy the data extent `[from, to)` from `src` to `dst` at the same offsets
+/// using explicit positioned reads/writes, handling short reads and writes.
+fn copy_data_extent(
+    src: &File,
+    dst: &File,
+    from: u64,
+    to: u64,
+    buf: &mut [u8],
+) -> std::io::Result<()> {
+    let mut pos = from;
+    while pos < to {
+        let want = usize::try_from((to - pos).min(buf.len() as u64)).unwrap_or(buf.len());
+        let n = src.read_at(&mut buf[..want], pos)?;
+        if n == 0 {
+            // source ended earlier than SEEK_HOLE implied (e.g. a concurrent
+            // shrink) -> stop; the trailing ftruncate will fix up the size.
+            break;
+        }
+        let mut written = 0;
+        while written < n {
+            let w = dst.write_at(&buf[written..n], pos + written as u64)?;
+            if w == 0 {
+                // a zero-length write on a non-empty buffer would spin forever.
+                return Err(std::io::Error::from(std::io::ErrorKind::WriteZero));
+            }
+            written += w;
+        }
+        pos += n as u64;
+    }
+    Ok(())
+}
+
+/// Dense read/write copy of the range `[start, len)` from `src` to `dst`, the
+/// final robustness fallback for filesystems that don't support
+/// `SEEK_DATA`/`SEEK_HOLE`.
+///
+/// Reads fixed-size buffers from `src` and writes them to `dst` at the same
+/// offsets until the source ends or `len` is reached, retrying on `EINTR` and
+/// handling short reads/writes. Unlike the sparse path it does not preserve
+/// holes — it reads zeros out of a hole and writes them — but it always works
+/// on any regular file (this matches what `std::fs::copy` would have done).
+///
+/// Size reconciliation matches [`copy_sparse_fallback`]: it `ftruncate`s `dst`
+/// to `min(len, actual_eof)` so a source that shrank below `len` sizes `dst` to
+/// its real end (no spurious trailing padding), and a source at least `len`
+/// long sizes `dst` to exactly `len`. Returns `final - start`, the number of
+/// bytes of the logical copy the source actually provided.
+fn dense_copy(src: &File, dst: &File, start: u64, len: u64) -> std::io::Result<u64> {
+    let mut buf = vec![0u8; DENSE_BUF_SIZE];
+    let mut pos = start;
+    while pos < len {
+        let want = usize::try_from((len - pos).min(buf.len() as u64)).unwrap_or(buf.len());
+        let n = match src.read_at(&mut buf[..want], pos) {
+            Ok(0) => break, // EOF: source is shorter than `len` (a shrink).
+            Ok(n) => n,
+            // a signal interrupted the read before any bytes moved: retry.
+            Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(err) => return Err(err),
+        };
+        let mut written = 0;
+        while written < n {
+            match dst.write_at(&buf[written..n], pos + written as u64) {
+                // a zero-length write on a non-empty buffer would spin forever.
+                Ok(0) => return Err(std::io::Error::from(std::io::ErrorKind::WriteZero)),
+                Ok(w) => written += w,
+                Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(err) => return Err(err),
+            }
+        }
+        pos += n as u64;
+    }
+    // reconcile the final size with the source's actual end, matching the sparse
+    // path: `min(len, actual_eof)` sizes dst to the real source end on a shrink
+    // and to exactly `len` otherwise. this also fixes up the size when the loop
+    // stopped early on an EOF that the read loop detected before reaching `len`.
+    let actual_eof = nix::unistd::lseek(src.as_fd(), 0, nix::unistd::Whence::SeekEnd)
+        .map_err(std::io::Error::from)? as u64;
+    let final_size = len.min(actual_eof);
+    nix::unistd::ftruncate(dst.as_fd(), to_off_t(final_size)?).map_err(std::io::Error::from)?;
+    // saturating: if the source shrank below `start`, no bytes were added.
+    Ok(final_size.saturating_sub(start))
+}
+
+/// convert a `u64` byte offset/length to the libc `off_t` expected by nix's
+/// lseek/ftruncate, mapping overflow to an io error rather than panicking.
+fn to_off_t(value: u64) -> std::io::Result<libc::off_t> {
+    libc::off_t::try_from(value).map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "file offset exceeds off_t range",
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+    use std::os::unix::fs::MetadataExt;
+
+    fn make_file(dir: &std::path::Path, name: &str) -> File {
+        std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(dir.join(name))
+            .expect("open temp file")
+    }
+
+    #[test]
+    fn copies_bytes_identically() {
+        let tmp = tempfile::tempdir().unwrap();
+        let contents = b"the quick brown fox jumps over the lazy dog";
+        let mut src = make_file(tmp.path(), "src");
+        src.write_all(contents).unwrap();
+        src.sync_all().unwrap();
+        let dst = make_file(tmp.path(), "dst");
+        let copied = copy_file_range_all(&src, &dst, contents.len() as u64).unwrap();
+        assert_eq!(copied, contents.len() as u64);
+        let got = std::fs::read(tmp.path().join("dst")).unwrap();
+        assert_eq!(got, contents);
+    }
+
+    #[test]
+    fn copies_large_file_fully() {
+        let tmp = tempfile::tempdir().unwrap();
+        let len: usize = 8 * 1024 * 1024;
+        // varied bytes so a truncated/short copy would be detectable.
+        let data: Vec<u8> = (0..len)
+            .map(|i| (i.wrapping_mul(31) ^ (i >> 7)) as u8)
+            .collect();
+        let mut src = make_file(tmp.path(), "src");
+        src.write_all(&data).unwrap();
+        src.sync_all().unwrap();
+        let dst = make_file(tmp.path(), "dst");
+        let copied = copy_file_range_all(&src, &dst, len as u64).unwrap();
+        assert_eq!(copied, len as u64);
+        let got = std::fs::read(tmp.path().join("dst")).unwrap();
+        assert_eq!(got.len(), len);
+        assert!(got == data, "destination bytes differ from source");
+    }
+
+    #[test]
+    fn sparse_fallback_preserves_holes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let logical: u64 = 8 * 1024 * 1024;
+        let head = b"HEAD-region-bytes";
+        let tail = b"TAIL-region-bytes";
+        let tail_off = logical - tail.len() as u64;
+        let src = make_file(tmp.path(), "src");
+        // create a sparse file: size = logical, small data near start and end,
+        // big hole in the middle.
+        nix::unistd::ftruncate(src.as_fd(), to_off_t(logical).unwrap()).unwrap();
+        src.write_at(head, 0).unwrap();
+        src.write_at(tail, tail_off).unwrap();
+        src.sync_all().unwrap();
+        let dst = make_file(tmp.path(), "dst");
+        // call the fallback directly rather than relying on triggering EXDEV.
+        let copied = copy_sparse_fallback(&src, &dst, 0, logical).unwrap();
+        assert_eq!(copied, logical);
+        // (a) content byte-equal to src across the whole logical range.
+        let got = std::fs::read(tmp.path().join("dst")).unwrap();
+        let expected = std::fs::read(tmp.path().join("src")).unwrap();
+        assert_eq!(got.len() as u64, logical);
+        assert_eq!(got, expected, "destination content differs from source");
+        // spot-check the data regions explicitly.
+        assert_eq!(&got[..head.len()], head);
+        assert_eq!(&got[tail_off as usize..], tail);
+        // (b) dst size == logical.
+        let dst_meta = std::fs::metadata(tmp.path().join("dst")).unwrap();
+        assert_eq!(dst_meta.len(), logical);
+        // (c) dst is actually sparse: allocated bytes << logical size.
+        let src_meta = std::fs::metadata(tmp.path().join("src")).unwrap();
+        let dst_allocated = dst_meta.blocks() * 512;
+        let src_allocated = src_meta.blocks() * 512;
+        eprintln!(
+            "sparse blocks: src={} blocks ({} bytes), dst={} blocks ({} bytes), logical={} bytes",
+            src_meta.blocks(),
+            src_allocated,
+            dst_meta.blocks(),
+            dst_allocated,
+            logical
+        );
+        assert!(
+            dst_allocated < logical,
+            "destination is not sparse: allocated {dst_allocated} >= logical {logical}"
+        );
+        // dst should be roughly as sparse as src (within a generous factor to
+        // tolerate filesystem block-allocation differences).
+        assert!(
+            dst_allocated <= src_allocated * 4 + 4096,
+            "destination far less sparse than source: dst={dst_allocated} src={src_allocated}"
+        );
+    }
+
+    #[test]
+    fn terminates_on_short_source() {
+        let tmp = tempfile::tempdir().unwrap();
+        let contents = b"short source contents";
+        let real_len = contents.len() as u64;
+        let mut src = make_file(tmp.path(), "src");
+        src.write_all(contents).unwrap();
+        src.sync_all().unwrap();
+        // create the destination so the worker thread can open it for writing.
+        let _dst = make_file(tmp.path(), "dst");
+        // claim a length larger than the real file: must return promptly having
+        // copied exactly the real bytes (the Ok(0)/EOF guard prevents a hang).
+        let claimed = real_len + 4096;
+        let (tx, rx) = std::sync::mpsc::channel();
+        let src_path = tmp.path().join("src");
+        let dst_path = tmp.path().join("dst");
+        std::thread::spawn(move || {
+            let src = std::fs::File::open(&src_path).unwrap();
+            let dst = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&dst_path)
+                .unwrap();
+            let copied = copy_file_range_all(&src, &dst, claimed).unwrap();
+            tx.send(copied).unwrap();
+        });
+        let copied = rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("copy_file_range_all hung on a short source");
+        assert_eq!(copied, real_len);
+        let got = std::fs::read(tmp.path().join("dst")).unwrap();
+        assert_eq!(got, contents);
+    }
+
+    #[test]
+    fn copies_partial_len_on_both_paths() {
+        // caller asks for fewer bytes than the source has: both paths must copy
+        // exactly `len` bytes, leave dst at `len`, and return `len`.
+        let tmp = tempfile::tempdir().unwrap();
+        let full: Vec<u8> = (0u32..4096).map(|i| (i % 251) as u8).collect();
+        let len: u64 = 1000;
+        let mut src = make_file(tmp.path(), "src");
+        src.write_all(&full).unwrap();
+        src.sync_all().unwrap();
+        // primary path.
+        let dst_cfr = make_file(tmp.path(), "dst_cfr");
+        let copied_cfr = copy_file_range_all(&src, &dst_cfr, len).unwrap();
+        assert_eq!(copied_cfr, len);
+        let got_cfr = std::fs::read(tmp.path().join("dst_cfr")).unwrap();
+        assert_eq!(got_cfr.len() as u64, len);
+        assert_eq!(got_cfr, &full[..len as usize]);
+        // fallback path called directly.
+        let dst_fb = make_file(tmp.path(), "dst_fb");
+        let copied_fb = copy_sparse_fallback(&src, &dst_fb, 0, len).unwrap();
+        assert_eq!(copied_fb, len);
+        let got_fb = std::fs::read(tmp.path().join("dst_fb")).unwrap();
+        assert_eq!(got_fb.len() as u64, len);
+        assert_eq!(got_fb, &full[..len as usize]);
+    }
+
+    #[test]
+    fn fallback_shrunk_source_not_padded() {
+        // locks the primary/fallback reconciliation: when `len` exceeds the
+        // source size, the fallback must size dst to the actual source end (not
+        // pad a spurious trailing hole up to `len`) and return the actual bytes.
+        let tmp = tempfile::tempdir().unwrap();
+        let contents: Vec<u8> = (0u32..3000).map(|i| (i % 240) as u8).collect();
+        let s = contents.len() as u64;
+        let mut src = make_file(tmp.path(), "src");
+        src.write_all(&contents).unwrap();
+        src.sync_all().unwrap();
+        let dst = make_file(tmp.path(), "dst");
+        let copied = copy_sparse_fallback(&src, &dst, 0, s + 8192).unwrap();
+        assert_eq!(
+            copied, s,
+            "must return actual source bytes, not the claimed len"
+        );
+        let dst_meta = std::fs::metadata(tmp.path().join("dst")).unwrap();
+        assert_eq!(
+            dst_meta.len(),
+            s,
+            "dst must be sized to the source, not padded"
+        );
+        let got = std::fs::read(tmp.path().join("dst")).unwrap();
+        assert_eq!(got, contents);
+    }
+
+    #[test]
+    fn copies_zero_length() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut src = make_file(tmp.path(), "src");
+        src.write_all(b"non-empty source contents").unwrap();
+        src.sync_all().unwrap();
+        let dst = make_file(tmp.path(), "dst");
+        let copied = copy_file_range_all(&src, &dst, 0).unwrap();
+        assert_eq!(copied, 0);
+        let dst_meta = std::fs::metadata(tmp.path().join("dst")).unwrap();
+        assert_eq!(dst_meta.len(), 0, "zero-length copy must leave dst empty");
+    }
+
+    #[test]
+    fn fallback_all_hole_source() {
+        // a pure-hole source: SEEK_DATA returns ENXIO immediately, so the loop
+        // does no copies and only ftruncate sizes dst. dst must be all zeros,
+        // sized to `len`, and sparse.
+        let tmp = tempfile::tempdir().unwrap();
+        let logical: u64 = 4 * 1024 * 1024;
+        let src = make_file(tmp.path(), "src");
+        nix::unistd::ftruncate(src.as_fd(), to_off_t(logical).unwrap()).unwrap();
+        src.sync_all().unwrap();
+        let dst = make_file(tmp.path(), "dst");
+        let copied = copy_sparse_fallback(&src, &dst, 0, logical).unwrap();
+        assert_eq!(copied, logical);
+        let got = std::fs::read(tmp.path().join("dst")).unwrap();
+        assert_eq!(got.len() as u64, logical);
+        assert!(
+            got.iter().all(|&b| b == 0),
+            "all-hole copy must be all zeros"
+        );
+        let dst_meta = std::fs::metadata(tmp.path().join("dst")).unwrap();
+        assert_eq!(dst_meta.len(), logical);
+        let dst_allocated = dst_meta.blocks() * 512;
+        eprintln!(
+            "all-hole: dst={} blocks ({dst_allocated} bytes), logical={logical}",
+            dst_meta.blocks()
+        );
+        assert!(
+            dst_allocated < logical,
+            "all-hole destination is not sparse: allocated {dst_allocated} >= logical {logical}"
+        );
+    }
+
+    #[test]
+    fn classify_seek_data_routes_by_errno() {
+        // the testable seam for the sparse-vs-dense decision. data offset and a
+        // legitimate trailing hole stay on the sparse path; the "unsupported"
+        // errnos route to dense; a genuine I/O error propagates.
+        assert_eq!(
+            classify_seek_data(Ok(4096)).unwrap(),
+            SparseProbe::Data(4096)
+        );
+        assert_eq!(
+            classify_seek_data(Err(nix::errno::Errno::ENXIO)).unwrap(),
+            SparseProbe::TrailingHole
+        );
+        // EINVAL and EOPNOTSUPP (== ENOTSUP on Linux) mean "fs can't SEEK_DATA".
+        assert_eq!(
+            classify_seek_data(Err(nix::errno::Errno::EINVAL)).unwrap(),
+            SparseProbe::Unsupported
+        );
+        assert_eq!(
+            classify_seek_data(Err(nix::errno::Errno::EOPNOTSUPP)).unwrap(),
+            SparseProbe::Unsupported
+        );
+        assert_eq!(
+            classify_seek_data(Err(nix::errno::Errno::ENOTSUP)).unwrap(),
+            SparseProbe::Unsupported
+        );
+        // a genuine I/O error is NOT masked as "unsupported" — it propagates.
+        let err = classify_seek_data(Err(nix::errno::Errno::EIO)).unwrap_err();
+        assert_eq!(err.raw_os_error(), Some(libc::EIO));
+    }
+
+    #[test]
+    fn dense_copy_is_byte_exact_with_embedded_zeros() {
+        // dense_copy must reproduce the source byte-for-byte, including embedded
+        // zero regions (it does not preserve them as holes, just copies zeros).
+        let tmp = tempfile::tempdir().unwrap();
+        let len: usize = 3 * DENSE_BUF_SIZE + 777; // multiple buffers + a tail.
+        let mut data: Vec<u8> = (0..len)
+            .map(|i| (i.wrapping_mul(37) ^ (i >> 5)) as u8)
+            .collect();
+        // carve out a couple of embedded zero regions (crossing a buffer edge).
+        for b in data.iter_mut().take(DENSE_BUF_SIZE + 4096).skip(100) {
+            *b = 0;
+        }
+        for b in data
+            .iter_mut()
+            .take(2 * DENSE_BUF_SIZE)
+            .skip(2 * DENSE_BUF_SIZE - 500)
+        {
+            *b = 0;
+        }
+        let mut src = make_file(tmp.path(), "src");
+        src.write_all(&data).unwrap();
+        src.sync_all().unwrap();
+        let dst = make_file(tmp.path(), "dst");
+        let copied = dense_copy(&src, &dst, 0, len as u64).unwrap();
+        assert_eq!(copied, len as u64);
+        let got = std::fs::read(tmp.path().join("dst")).unwrap();
+        assert_eq!(got.len(), len, "dense copy must size dst to the source");
+        assert!(got == data, "dense copy bytes differ from source");
+    }
+
+    #[test]
+    fn dense_copy_partial_len_sizes_dst_exactly() {
+        // when `len` is below the source size, dense_copy copies exactly `len`
+        // bytes and ftruncates dst to `len` (matching the sparse path).
+        let tmp = tempfile::tempdir().unwrap();
+        let full: Vec<u8> = (0u32..8192).map(|i| (i % 251) as u8).collect();
+        let len: u64 = 5000;
+        let mut src = make_file(tmp.path(), "src");
+        src.write_all(&full).unwrap();
+        src.sync_all().unwrap();
+        let dst = make_file(tmp.path(), "dst");
+        let copied = dense_copy(&src, &dst, 0, len).unwrap();
+        assert_eq!(copied, len);
+        let got = std::fs::read(tmp.path().join("dst")).unwrap();
+        assert_eq!(got.len() as u64, len);
+        assert_eq!(got, &full[..len as usize]);
+    }
+
+    #[test]
+    fn dense_copy_shrunk_source_not_padded() {
+        // mirrors `fallback_shrunk_source_not_padded` for the dense path: a `len`
+        // larger than the source must size dst to the actual source end and
+        // return the actual bytes, not pad up to `len`.
+        let tmp = tempfile::tempdir().unwrap();
+        let contents: Vec<u8> = (0u32..3000).map(|i| (i % 240) as u8).collect();
+        let s = contents.len() as u64;
+        let mut src = make_file(tmp.path(), "src");
+        src.write_all(&contents).unwrap();
+        src.sync_all().unwrap();
+        let dst = make_file(tmp.path(), "dst");
+        let copied = dense_copy(&src, &dst, 0, s + 8192).unwrap();
+        assert_eq!(
+            copied, s,
+            "dense copy must return actual source bytes, not the claimed len"
+        );
+        let dst_meta = std::fs::metadata(tmp.path().join("dst")).unwrap();
+        assert_eq!(dst_meta.len(), s, "dst must be sized to the source");
+        let got = std::fs::read(tmp.path().join("dst")).unwrap();
+        assert_eq!(got, contents);
+    }
+
+    #[test]
+    fn unsupported_probe_routes_to_dense_byte_exact() {
+        // exercises the fallback selection end-to-end at the seam level: an
+        // "unsupported" SEEK_DATA probe must route to `dense_copy`, which on this
+        // (tmpfs) environment we drive directly because tmpfs supports SEEK_DATA
+        // and a true EINVAL can't be simulated here (see note below). We assert
+        // both halves of the routing contract: (1) the classifier maps the
+        // unsupported errnos to `SparseProbe::Unsupported`, and (2) the
+        // `Unsupported` branch's target (`dense_copy`) yields a byte-exact copy.
+        //
+        // NOTE: a genuine end-to-end SEEK_DATA EINVAL is not simulable in this
+        // environment (tmpfs/ext4 both support SEEK_DATA/SEEK_HOLE); it would
+        // require a FUSE/older filesystem that rejects those whences. The routing
+        // is therefore validated via the testable seam rather than a forced
+        // errno, with the byte-exactness of the dense target asserted directly.
+        assert_eq!(
+            classify_seek_data(Err(nix::errno::Errno::EINVAL)).unwrap(),
+            SparseProbe::Unsupported,
+            "unsupported probe must route to the dense fallback"
+        );
+        let tmp = tempfile::tempdir().unwrap();
+        let data: Vec<u8> = (0u32..200_000).map(|i| (i % 256) as u8).collect();
+        let mut src = make_file(tmp.path(), "src");
+        src.write_all(&data).unwrap();
+        src.sync_all().unwrap();
+        let dst = make_file(tmp.path(), "dst");
+        let copied = dense_copy(&src, &dst, 0, data.len() as u64).unwrap();
+        assert_eq!(copied, data.len() as u64);
+        let got = std::fs::read(tmp.path().join("dst")).unwrap();
+        assert_eq!(got, data, "dense fallback target must be byte-exact");
+    }
+}

--- a/common/src/delete.rs
+++ b/common/src/delete.rs
@@ -1,127 +1,85 @@
 //! rsync-style `--delete` (mirror) support: remove destination entries that
 //! have no counterpart in the source directory.
 
+use std::ffi::OsString;
+use std::sync::Arc;
+
+use anyhow::Context;
+
 use crate::copy::DeleteSettings;
 use crate::progress;
+use crate::safedir::Dir;
 
-/// Remove entries in `dst` whose names are not in `keep` (the source entry
-/// names that passed the filter for this directory).
+/// Remove entries in the already-open destination directory `dst_dir` whose names are not in
+/// `keep` (the source entry names that passed the filter for this directory).
 ///
-/// `relative_dir` is this directory's path relative to the source root, used to
-/// match destination entries against `filter` for exclude-protection. Excluded
-/// destination entries are protected (kept) unless `delete_settings.delete_excluded`
-/// is set. Honors `dry_run` (reports without removing, via [`crate::rm::rm`]).
+/// The destination is enumerated and pruned entirely through `dst_dir`'s pinned file descriptor:
+/// entries come from `dst_dir.read_entries()` and each extraneous entry is removed via
+/// `rm::rm_child` (fd-relative, `O_NOFOLLOW` descent). The destination path is never
+/// re-resolved, so a privileged prune cannot be redirected by a concurrent symlink swap into
+/// deleting a tree outside the destination — the classic mirror-delete symlink race fails closed.
+/// The caller is responsible for opening `dst_dir` `O_NOFOLLOW`: in a real copy it is the held
+/// destination directory; in `--dry-run` (where the create-or-overwrite step is skipped and the
+/// path could still be a symlink-to-directory) the caller opens it `O_NOFOLLOW|O_DIRECTORY`, which
+/// fails closed on a symlink or non-directory before prune is ever invoked.
+///
+/// `relative_dir` is this directory's path relative to the source root, used to match destination
+/// entries against `filter` for exclude-protection. Excluded destination entries are protected
+/// (kept) unless `delete_settings.delete_excluded` is set. Honors `dry_run` (reports without
+/// removing, via `rm::rm_child`).
 #[allow(clippy::too_many_arguments)]
 pub async fn prune_extraneous(
     prog_track: &'static progress::Progress,
-    dst: &std::path::Path,
+    dst_dir: &Arc<Dir>,
     relative_dir: &std::path::Path,
-    keep: &std::collections::HashSet<std::ffi::OsString>,
+    keep: &std::collections::HashSet<OsString>,
     filter: Option<&crate::filter::FilterSettings>,
     delete_settings: &DeleteSettings,
     fail_early: bool,
     dry_run: Option<crate::config::DryRunMode>,
 ) -> Result<crate::rm::Summary, crate::rm::Error> {
     let mut summary = crate::rm::Summary::default();
-    // Destination root: `dst` with this directory's source-relative path stripped. Removed
-    // descendants are matched against the filter relative to this root, so their full (mirror)
-    // relative paths are used — making path/anchored excludes like `cache/*.log` protect
-    // descendants correctly, not just simple basename patterns.
-    let mut dest_root = dst;
-    for _ in relative_dir.components() {
-        dest_root = dest_root.parent().unwrap_or(dest_root);
-    }
-    // In --dry-run the create-or-overwrite step is skipped, so `dst` may still be a file,
-    // symlink, or even a symlink-to-directory at this point. `read_dir` follows symlinks, so
-    // without a `symlink_metadata` pre-check it would walk the symlink's target and preview
-    // deletions OUTSIDE the destination tree. In a real run this can't happen — upstream
-    // create_dir/overwrite guarantees `dst` is a real directory by the time prune runs — so
-    // skip the extra stat there to keep the hot path cheap.
-    if dry_run.is_some() {
-        match tokio::fs::symlink_metadata(dst).await {
-            Ok(meta) if meta.file_type().is_dir() => { /* real directory: fall through */ }
-            Ok(_) => {
-                // not a real directory (file, symlink, special) — nothing to prune
-                return Ok(summary);
-            }
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(summary);
-            }
-            Err(err) => {
-                return Err(crate::rm::Error::new(
-                    anyhow::Error::new(err)
-                        .context(format!("cannot stat destination {dst:?} for delete scan")),
-                    summary,
-                ));
-            }
-        }
-    }
-    let mut entries = match tokio::fs::read_dir(dst).await {
-        Ok(entries) => entries,
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            // destination directory absent (e.g. dry-run never created it): nothing to prune
-            return Ok(summary);
-        }
-        Err(err)
-            if err.kind() == std::io::ErrorKind::NotADirectory
-                || err.raw_os_error() == Some(20) =>
-        {
-            // destination counterpart is not a directory: e.g. `--dry-run --delete` where the real
-            // run would replace a file/symlink at this path with a directory before pruning, but
-            // dry-run skips that overwrite. There is nothing to prune. (In dry-run we already
-            // handled the non-dir case via symlink_metadata above; this arm remains as defense in
-            // depth against a race between that stat and the read_dir below.)
-            return Ok(summary);
-        }
-        Err(err) => {
-            return Err(crate::rm::Error::new(
-                anyhow::Error::new(err)
-                    .context(format!("cannot open destination {dst:?} for delete scan")),
-                summary,
-            ));
-        }
-    };
-    let errors = crate::error_collector::ErrorCollector::default();
-    loop {
-        let (entry, entry_file_type) = match crate::walk::next_entry_probed(
-            &mut entries,
-            congestion::Side::Destination,
-            || format!("failed scanning destination directory {dst:?} for deletion"),
-        )
+    // Enumerate the destination through its pinned fd (no path re-resolution). The returned
+    // `d_type` is a best-effort hint passed to `filter_is_dir`, which resolves authoritatively via
+    // fstat on DT_UNKNOWN. `rm_child` re-classifies each entry authoritatively via `child()`.
+    let entries = dst_dir
+        .read_entries()
         .await
-        {
-            Ok(Some(value)) => value,
-            Ok(None) => break,
-            Err(err) => {
-                errors.push(err);
-                break;
-            }
-        };
-        let name = entry.file_name();
+        .with_context(|| "failed scanning destination directory for deletion".to_string())
+        .map_err(|err| crate::rm::Error::new(err, summary))?;
+    let errors = crate::error_collector::ErrorCollector::default();
+    for (name, hint) in entries {
         if keep.contains(&name) {
             continue;
         }
-        let is_dir = entry_file_type.as_ref().is_some_and(|ft| ft.is_dir());
+        // the exclude-protection decision must use the AUTHORITATIVE is_dir: on filesystems that
+        // report DT_UNKNOWN (NFS, some FUSE mounts) the hint is None, so defaulting to non-dir
+        // would fail to protect a real directory that matches a dir-only exclude pattern like
+        // `cache/`. `filter_is_dir` does one authoritative fstat only in the DT_UNKNOWN+filter
+        // case, preserving the no-cost path when the hint is reliable or no filter is active.
+        let is_dir = crate::walk::filter_is_dir(filter, dst_dir, &name, hint, false).await;
+        // the entry's path relative to the destination (mirror) root: anchors filter matching and
+        // reconstructs the display path inside `rm_child`. Computed once and reused below.
+        let rel = relative_dir.join(&name);
         // exclude-protection: keep destination entries the filter would exclude,
         // unless --delete-excluded was requested.
         if !delete_settings.delete_excluded
             && let Some(filter) = filter
-        {
-            let entry_relative = relative_dir.join(&name);
-            if !matches!(
-                filter.should_include(&entry_relative, is_dir),
+            && !matches!(
+                filter.should_include(&rel, is_dir),
                 crate::filter::FilterResult::Included
-            ) {
-                tracing::debug!("protecting excluded destination entry {:?}", entry.path());
-                continue;
-            }
+            )
+        {
+            tracing::debug!("protecting excluded destination entry {:?}", rel);
+            continue;
         }
-        // Protect excluded descendants when removing an extraneous directory: rm::rm applies
+        // Protect excluded descendants when removing an extraneous directory: rm::rm_child applies
         // the filter recursively (skipping excluded entries), so an extra dir containing e.g.
         // `*.log` files keeps them and survives non-empty — upholding the documented
         // "excluded files are protected by default" guarantee (and matching rsync). With
-        // --delete-excluded we pass no filter so the whole subtree is removed. (rm matches
-        // relative to the entry being removed, so simple patterns protect by basename.)
+        // --delete-excluded we pass no filter so the whole subtree is removed. The filter is
+        // anchored at the destination (mirror) root, so the entry's destination-root-relative path
+        // `relative_dir.join(name)` matches path/anchored patterns like `cache/*.log` correctly.
         let rm_settings = crate::rm::Settings {
             fail_early,
             filter: if delete_settings.delete_excluded {
@@ -132,9 +90,7 @@ pub async fn prune_extraneous(
             time_filter: None,
             dry_run,
         };
-        match crate::rm::rm_with_filter_root(prog_track, &entry.path(), dest_root, &rm_settings)
-            .await
-        {
+        match crate::rm::rm_child(prog_track, dst_dir, &name, &rel, &rm_settings).await {
             Ok(rm_summary) => {
                 summary = summary + rm_summary;
             }
@@ -166,6 +122,14 @@ mod tests {
         DeleteSettings { delete_excluded }
     }
 
+    /// Open `dst` as the destination directory `Dir` the (now fd-relative) prune operates through,
+    /// mirroring what the copy/link call sites do (`O_NOFOLLOW|O_DIRECTORY`, Destination side).
+    async fn open_dst(dst: &std::path::Path) -> anyhow::Result<Arc<Dir>> {
+        Ok(Arc::new(
+            Dir::open_root_dir(dst, false, congestion::Side::Destination).await?,
+        ))
+    }
+
     #[tokio::test]
     #[traced_test]
     async fn removes_entries_not_in_keep_set() -> anyhow::Result<()> {
@@ -180,9 +144,10 @@ mod tests {
         let mut keep = HashSet::new();
         keep.insert(std::ffi::OsString::from("keep.txt"));
 
+        let dst_dir = open_dst(&dst).await?;
         let summary = prune_extraneous(
             &PROGRESS,
-            &dst,
+            &dst_dir,
             std::path::Path::new(""),
             &keep,
             None,
@@ -215,9 +180,10 @@ mod tests {
         let keep = HashSet::new(); // both are extraneous
 
         // default: *.log is protected, data.bin is removed
+        let dst_dir = open_dst(&dst).await?;
         let summary = prune_extraneous(
             &PROGRESS,
-            &dst,
+            &dst_dir,
             std::path::Path::new(""),
             &keep,
             Some(&filter),
@@ -235,9 +201,10 @@ mod tests {
         );
 
         // with delete_excluded: note.log is also removed
+        let dst_dir = open_dst(&dst).await?;
         let summary = prune_extraneous(
             &PROGRESS,
-            &dst,
+            &dst_dir,
             std::path::Path::new(""),
             &keep,
             Some(&filter),
@@ -268,9 +235,10 @@ mod tests {
         let keep = HashSet::new(); // extra_dir is extraneous
 
         // default --delete: the excluded descendant is protected, so the dir survives non-empty
+        let dst_dir = open_dst(&dst).await?;
         let summary = prune_extraneous(
             &PROGRESS,
-            &dst,
+            &dst_dir,
             std::path::Path::new(""),
             &keep,
             Some(&filter),
@@ -288,9 +256,10 @@ mod tests {
         );
 
         // --delete-excluded: the whole extraneous directory is removed
+        let dst_dir = open_dst(&dst).await?;
         let summary = prune_extraneous(
             &PROGRESS,
-            &dst,
+            &dst_dir,
             std::path::Path::new(""),
             &keep,
             Some(&filter),
@@ -320,9 +289,10 @@ mod tests {
         filter.add_exclude("cache/*.log")?;
         let keep = HashSet::new();
 
+        let dst_dir = open_dst(&dst).await?;
         let summary = prune_extraneous(
             &PROGRESS,
-            &dst,
+            &dst_dir,
             std::path::Path::new(""),
             &keep,
             Some(&filter),
@@ -342,15 +312,244 @@ mod tests {
         Ok(())
     }
 
+    /// Regression test for the DT_UNKNOWN + dir-only exclude protection bug (PR #247 review).
+    ///
+    /// On NFS/FUSE filesystems `read_entries` returns `None` for `d_type` (the `DT_UNKNOWN` case).
+    /// The old hint-only `is_dir` computation (`hint.is_some_and(|k| k == Dir)`) produced `false`
+    /// for `None`, so a real destination directory with a `None` hint appeared to be a non-dir.
+    /// A dir-only exclude pattern like `cache/` therefore did NOT protect it, and prune would
+    /// delete the directory when it should have kept it.
+    ///
+    /// The fix replaces the hint-only computation with `filter_is_dir(filter, dst_dir, name, hint)`,
+    /// which performs an authoritative `fstat` when the hint is `None` AND a filter is active.
+    ///
+    /// Since we cannot force `DT_UNKNOWN` on a local tmpfs, we verify the fix indirectly by driving
+    /// `filter_is_dir` with `hint = None` in isolation (exactly as the authoritative fstat path is
+    /// exercised in `walk.rs`'s unit tests), and by confirming that `prune_extraneous` with a
+    /// dir-only exclude retains the matching destination directory end-to-end. On a local fs the hint
+    /// is always `Some(Dir)`, so `filter_is_dir` uses it directly — but the test would fail with the
+    /// old code if the hint were forced to `None`, which is exactly what happens on NFS/FUSE.
     #[tokio::test]
     #[traced_test]
-    async fn dry_run_does_not_follow_dst_symlink_to_directory() -> anyhow::Result<()> {
-        // In a real --delete run, the create-or-overwrite step replaces any non-directory
-        // destination (including a symlink) before prune runs. In --dry-run that overwrite
-        // is skipped, so prune_extraneous can be called with a dst that is still a symlink
-        // pointing to a directory. `tokio::fs::read_dir` follows symlinks, so without a
-        // pre-check it would walk the symlink's target and previews deletions OUTSIDE the
-        // destination tree.
+    async fn protects_dir_only_excluded_directory_dt_unknown() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let dst = tmp.path().join("dst");
+        tokio::fs::create_dir(&dst).await?;
+        // extraneous destination directory `cache/` containing a file; it should be RETAINED by a
+        // `cache/` dir-only exclude even though it has no source counterpart.
+        tokio::fs::create_dir(dst.join("cache")).await?;
+        tokio::fs::write(dst.join("cache").join("item.dat"), b"x").await?;
+        // an unrelated extra file that IS extraneous and not excluded, so it should be removed.
+        tokio::fs::write(dst.join("unrelated.txt"), b"y").await?;
+
+        let mut filter = crate::filter::FilterSettings::new();
+        filter.add_exclude("cache/")?; // dir-only exclude: only protects directories, not files
+
+        let keep = HashSet::new(); // both `cache/` and `unrelated.txt` are extraneous
+
+        // verify the authoritative fstat path via `filter_is_dir` with hint=None (DT_UNKNOWN
+        // simulation): a real directory must classify as `is_dir = true`, so the dir-only exclude
+        // protects it. The old hint-only code returned `false` here, causing the directory to be
+        // pruned instead.
+        let dst_dir = open_dst(&dst).await?;
+        let authoritative_is_dir = crate::walk::filter_is_dir(
+            Some(&filter),
+            &dst_dir,
+            std::ffi::OsStr::new("cache"),
+            None, // DT_UNKNOWN: no hint available (NFS/FUSE case)
+            false,
+        )
+        .await;
+        assert!(
+            authoritative_is_dir,
+            "filter_is_dir with hint=None on a real directory must return true via authoritative fstat"
+        );
+
+        // end-to-end: `prune_extraneous` must retain `cache/` (protected by the dir-only exclude)
+        // and remove `unrelated.txt` (not excluded).
+        let dst_dir = open_dst(&dst).await?;
+        let summary = prune_extraneous(
+            &PROGRESS,
+            &dst_dir,
+            std::path::Path::new(""),
+            &keep,
+            Some(&filter),
+            &delete_settings(false),
+            false,
+            None,
+        )
+        .await
+        .map_err(|e| e.source)?;
+
+        assert_eq!(summary.files_removed, 1); // unrelated.txt
+        assert!(!dst.join("unrelated.txt").exists());
+        assert!(
+            dst.join("cache").exists(),
+            "dir-only exclude `cache/` must protect the destination directory from --delete"
+        );
+        assert!(
+            dst.join("cache").join("item.dat").exists(),
+            "contents of the excluded directory must be preserved"
+        );
+        Ok(())
+    }
+
+    /// Repeatedly swap `dst/extra` between a real directory (holding a real file) and a symlink to
+    /// an OUT-OF-TREE sentinel directory, using rename so each individual state is atomic. Two
+    /// staging names live alongside `extra` and are renamed over it in a tight loop until `stop` is
+    /// set. Runs on a dedicated OS thread so it makes progress regardless of the tokio runtime's
+    /// scheduling. Mirrors rm's `spawn_dir_symlink_swapper`.
+    fn spawn_extra_swapper(
+        dst: std::path::PathBuf,
+        sentinel: std::path::PathBuf,
+        stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            let extra = dst.join("extra");
+            let staged_dir = dst.join("__staged_extra_dir");
+            let staged_link = dst.join("__staged_extra_link");
+            while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                // stage a real directory (with a real file) then swap it in over `extra`.
+                let _ = std::fs::remove_dir_all(&staged_dir);
+                if std::fs::create_dir(&staged_dir).is_ok() {
+                    let _ = std::fs::write(staged_dir.join("real.txt"), b"REAL");
+                    // RENAME_EXCHANGE isn't portable here; remove-then-rename. The window where
+                    // `extra` is briefly absent is fine — prune may error or no-op, an accepted
+                    // failed-closed outcome. (prune must still never touch the sentinel.)
+                    let _ = std::fs::remove_dir_all(&extra);
+                    let _ = std::fs::remove_file(&extra);
+                    let _ = std::fs::rename(&staged_dir, &extra);
+                }
+                // stage a symlink to the out-of-tree sentinel dir, then swap it in over `extra`.
+                let _ = std::fs::remove_file(&staged_link);
+                if std::os::unix::fs::symlink(&sentinel, &staged_link).is_ok() {
+                    let _ = std::fs::remove_dir_all(&extra);
+                    let _ = std::fs::remove_file(&extra);
+                    let _ = std::fs::rename(&staged_link, &extra);
+                }
+            }
+        })
+    }
+
+    /// While `prune_extraneous` prunes an extraneous destination SUBDIRECTORY (`dst/extra`, with no
+    /// source counterpart so the empty keep-set marks it for deletion), a background thread rapidly
+    /// flips `dst/extra` between a real directory and a symlink to a SENTINEL directory tree that
+    /// lives OUTSIDE the destination, holding files that must never be deleted.
+    ///
+    /// Prune is fd-relative: it enumerates and removes children through the destination's own
+    /// pinned `Dir` fd (`rm_child` → `child()` classify + `open_dir` descent). If `extra` is a
+    /// symlink at the moment of descent, `open_dir`'s `O_NOFOLLOW|O_DIRECTORY` fails closed
+    /// (ELOOP/ENOTDIR) and prune never follows it into the sentinel. If `extra` is a symlink at the
+    /// moment of classification it is treated as a leaf and `unlink_at` removes the LINK, never its
+    /// target. Either way the out-of-tree sentinel files survive — the core safety assertion,
+    /// checked on every iteration regardless of timing. Also confirms the run terminates (per-op
+    /// timeout) rather than hanging or following the link.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn prune_extra_dir_swap_never_deletes_out_of_tree_sentinel() -> anyhow::Result<()> {
+        let tmp = tempfile::tempdir()?;
+        let root = tmp.path();
+        // the sentinel tree lives OUTSIDE the destination, reachable only via the swapped symlink.
+        let sentinel = root.join("sentinel_tree");
+        tokio::fs::create_dir(&sentinel).await?;
+        tokio::fs::write(sentinel.join("secret1.txt"), b"SECRET-1").await?;
+        tokio::fs::create_dir(sentinel.join("subdir")).await?;
+        tokio::fs::write(sentinel.join("subdir").join("secret2.txt"), b"SECRET-2").await?;
+
+        let dst = root.join("dst");
+        tokio::fs::create_dir(&dst).await?;
+
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let swapper = spawn_extra_swapper(dst.clone(), sentinel.clone(), stop.clone());
+
+        // empty keep-set: `extra` (and any other entry) is extraneous and marked for pruning.
+        let keep = HashSet::new();
+        let mut pruned = 0usize;
+        let mut errored = 0usize;
+        for i in 0..400 {
+            // give `dst` many sibling extraneous subdirectories with files so prune spends real
+            // time enumerating/removing them concurrently with the swapper's flips, widening the
+            // window in which `extra` is classified/descended mid-swap.
+            for d in 0..16 {
+                let sib = dst.join(format!("sib_{d}"));
+                let _ = tokio::fs::create_dir(&sib).await;
+                for f in 0..4 {
+                    let _ = tokio::fs::write(sib.join(format!("f{f}.txt")), b"x").await;
+                }
+            }
+            let extra = dst.join("extra");
+            if i % 2 == 0 {
+                // deterministically place a symlink-to-sentinel at `extra` (best-effort; the
+                // swapper may immediately flip it — both states are safe).
+                let _ = tokio::fs::remove_dir_all(&extra).await;
+                let _ = tokio::fs::remove_file(&extra).await;
+                let _ = tokio::fs::symlink(&sentinel, &extra).await;
+            } else if tokio::fs::symlink_metadata(&extra).await.is_err() {
+                let _ = tokio::fs::create_dir(&extra).await;
+                let _ = tokio::fs::write(extra.join("real.txt"), b"REAL").await;
+            }
+            // open the destination O_NOFOLLOW (as the real call sites do) and prune it.
+            let dst_dir = open_dst(&dst).await?;
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(30),
+                prune_extraneous(
+                    &PROGRESS,
+                    &dst_dir,
+                    std::path::Path::new(""),
+                    &keep,
+                    None,
+                    &delete_settings(false),
+                    false,
+                    None,
+                ),
+            )
+            .await
+            .expect("prune must not hang under concurrent dir swapping");
+            match result {
+                Ok(_) => pruned += 1,
+                Err(_) => errored += 1, // a swap was caught mid-walk (failed closed) — accepted
+            }
+            // CORE SAFETY ASSERTION (holds on every iteration regardless of timing): the
+            // out-of-tree sentinel tree and its files are NEVER deleted — neither by following a
+            // symlinked `extra` (unlink removes the link, not the target) nor by descending it
+            // (open_dir's O_NOFOLLOW fails closed).
+            assert!(
+                sentinel.exists(),
+                "iteration {i}: sentinel directory was deleted — prune followed the symlink"
+            );
+            let s1 = tokio::fs::read(sentinel.join("secret1.txt")).await;
+            assert!(
+                matches!(&s1, Ok(b) if b == b"SECRET-1"),
+                "iteration {i}: sentinel/secret1.txt was deleted or altered — prune followed the symlink"
+            );
+            let s2 = tokio::fs::read(sentinel.join("subdir").join("secret2.txt")).await;
+            assert!(
+                matches!(&s2, Ok(b) if b == b"SECRET-2"),
+                "iteration {i}: sentinel/subdir/secret2.txt was deleted — prune recursed through the symlink"
+            );
+        }
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        swapper.join().expect("extra swapper thread panicked");
+        // sanity (not the safety assertion): the run did observable work across the iterations.
+        tracing::info!("prune extra-dir swap: pruned={pruned}, errored={errored}");
+        assert!(
+            pruned + errored > 0,
+            "expected at least one observable outcome across the iterations"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn opening_dst_symlink_to_directory_fails_closed() -> anyhow::Result<()> {
+        // prune is now fd-relative: it operates through a `Dir` the caller opens `O_NOFOLLOW`. In a
+        // real --delete run the create-or-overwrite step replaces any non-directory destination
+        // (including a symlink) before prune runs; in --dry-run that overwrite is skipped, so the
+        // destination path could still be a symlink-to-directory. Opening it `O_NOFOLLOW|O_DIRECTORY`
+        // (dereference=false) — exactly what the copy/link prune call sites do — must FAIL CLOSED on
+        // that symlink rather than follow it. This is the guarantee that replaces the old
+        // `symlink_metadata` pre-check: prune can never be handed a Dir that followed a dst symlink,
+        // so it can never preview/perform deletions OUTSIDE the destination tree.
         let tmp = tempfile::tempdir()?;
         let dst_parent = tmp.path().join("dst_parent");
         let outside = tmp.path().join("outside"); // outside the destination tree
@@ -361,26 +560,13 @@ mod tests {
         let dst = dst_parent.join("link_dir");
         std::os::unix::fs::symlink(&outside, &dst)?;
 
-        // keep set empty: anything `read_dir(dst)` returns would look extraneous.
-        let keep = HashSet::new();
-        let summary = prune_extraneous(
-            &PROGRESS,
-            &dst,
-            std::path::Path::new(""),
-            &keep,
-            None,
-            &delete_settings(false),
-            false,
-            Some(crate::config::DryRunMode::Brief),
-        )
-        .await
-        .map_err(|e| e.source)?;
-        assert_eq!(
-            summary.files_removed, 0,
-            "dry-run must not preview deletions reached by following a dst symlink"
+        // opening the symlinked dst O_NOFOLLOW must fail (ELOOP), so the call site skips prune.
+        let result = Dir::open_root_dir(&dst, false, congestion::Side::Destination).await;
+        assert!(
+            result.is_err(),
+            "opening a dst symlink-to-directory O_NOFOLLOW must fail closed, not follow it"
         );
-        assert_eq!(summary.directories_removed, 0);
-        // dry-run never deletes, but assert anyway as a belt-and-braces guard.
+        // the out-of-tree tree is untouched.
         assert!(outside.join("precious.txt").exists());
         Ok(())
     }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -115,6 +115,7 @@ pub mod cli;
 pub mod cmp;
 pub mod config;
 pub mod copy;
+pub mod copy_data;
 pub mod delete;
 pub mod dry_run;
 pub mod error;
@@ -128,12 +129,15 @@ pub mod observability;
 pub mod preserve;
 pub mod remote_tracing;
 pub mod rm;
+pub mod safedir;
 pub mod version;
 
 pub mod filecmp;
 pub mod progress;
 mod testutils;
+pub mod toctou_check;
 pub mod walk;
+pub mod walk_driver;
 
 pub use config::{
     AutoMetaThrottleConfig, DryRunMode, DryRunWarnings, OutputConfig, RuntimeConfig,

--- a/common/src/link.rs
+++ b/common/src/link.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, anyhow};
 use async_recursion::async_recursion;
-use std::os::linux::fs::MetadataExt as LinuxMetadataExt;
+use std::sync::Arc;
 use tracing::instrument;
 
 use crate::copy;
@@ -10,8 +10,8 @@ use crate::copy::{
 use crate::filecmp;
 use crate::preserve;
 use crate::progress;
-use crate::rm;
-use crate::walk::{self, EntryKind};
+use crate::safedir::Dir;
+use crate::walk::{self, EntryKind, LeafPermit, PermitKind};
 
 /// Error type for link operations. See [`crate::error::OperationError`] for
 /// logging conventions and rationale.
@@ -86,43 +86,52 @@ impl std::fmt::Display for Summary {
     }
 }
 
-fn is_hard_link(md1: &std::fs::Metadata, md2: &std::fs::Metadata) -> bool {
-    copy::is_file_type_same(md1, md2)
-        && md2.st_dev() == md1.st_dev()
-        && md2.st_ino() == md1.st_ino()
-}
-
+/// Hard-link the already-classified source entry (pinned by `src_handle`) to `dst_name` within
+/// `dst_dir`, fd-relative and inode-exact.
+///
+/// `dst_dir.hard_link_handle_at` links the EXACT inode `src_handle` pins (via its `O_PATH` fd,
+/// using `linkat(.., "/proc/self/fd/N", .., AT_SYMLINK_FOLLOW)`) rather than re-resolving the
+/// source by name. This closes a TOCTOU window the old by-name `linkat` had: on an actor-writable
+/// source, `name` could be swapped to a different inode (symlink, FIFO, another file) between
+/// classification and the link, so the by-name link would target the replacement while rlink
+/// reported a hard-linked file. Linking the pinned inode means we either hard-link the exact
+/// regular file we classified or fail closed (`ENOENT` when its last link was removed) — never the
+/// swapped-in replacement. `linkat` still refuses to hard-link a directory (`EPERM`).
+///
+/// On `EEXIST` under `--overwrite`, the existing destination is re-classified through `dst_dir`'s
+/// fd and, if it is an identical hard link (same dev+ino), left as is; otherwise it is removed via
+/// the recheck-guarded [`copy::remove_existing`] and the link is retried — mirroring copy's
+/// fd-relative overwrite branches.
 #[instrument(skip(prog_track, settings))]
-async fn hard_link_helper(
+#[allow(clippy::too_many_arguments)]
+async fn hard_link_entry_fd(
     prog_track: &'static progress::Progress,
-    src: &std::path::Path,
-    src_metadata: &std::fs::Metadata,
-    dst: &std::path::Path,
+    src_handle: &crate::safedir::Handle,
+    dst_dir: &Arc<Dir>,
+    dst_name: &std::ffi::OsStr,
+    dst_path: &std::path::Path,
     settings: &Settings,
 ) -> Result<Summary, Error> {
     let mut link_summary = Summary::default();
-    match crate::walk::run_metadata_probed(
-        congestion::Side::Destination,
-        congestion::MetadataOp::HardLink,
-        tokio::fs::hard_link(src, dst),
-    )
-    .await
-    {
+    match dst_dir.hard_link_handle_at(src_handle, dst_name).await {
         Ok(()) => {}
         Err(error)
             if settings.copy_settings.overwrite
                 && error.kind() == std::io::ErrorKind::AlreadyExists =>
         {
             tracing::debug!("'dst' already exists, check if we need to update");
-            let dst_metadata = crate::walk::run_metadata_probed(
-                congestion::Side::Destination,
-                congestion::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(dst),
-            )
-            .await
-            .with_context(|| format!("cannot read {dst:?} metadata"))
-            .map_err(|err| Error::new(err, Default::default()))?;
-            if is_hard_link(src_metadata, &dst_metadata) {
+            let dst_handle = dst_dir
+                .child(dst_name)
+                .await
+                .with_context(|| format!("cannot read {dst_path:?} metadata"))
+                .map_err(|err| Error::new(err, Default::default()))?;
+            // identical hard link: same file type and same (dev, ino) as the source entry. Both
+            // handles pin their inodes (O_PATH), so a matching (dev, ino) genuinely proves the two
+            // names already resolve to the same inode — no change needed.
+            if dst_handle.kind() == src_handle.kind()
+                && dst_handle.dev() == src_handle.dev()
+                && dst_handle.ino() == src_handle.ino()
+            {
                 tracing::debug!("no change, leaving file as is");
                 prog_track.hard_links_unchanged.inc();
                 return Ok(Summary {
@@ -131,36 +140,30 @@ async fn hard_link_helper(
                 });
             }
             tracing::info!("'dst' file type changed, removing and hard-linking");
-            let rm_summary = rm::rm(
+            // recheck-guarded, fd-relative removal contained to dst_dir (mirrors copy.rs).
+            let rm_summary = copy::remove_existing(
                 prog_track,
-                dst,
-                &rm::Settings {
-                    fail_early: settings.copy_settings.fail_early,
-                    filter: None,
-                    dry_run: None,
-                    time_filter: None,
-                },
+                dst_dir,
+                dst_name,
+                dst_path,
+                &dst_handle,
+                &settings.copy_settings,
             )
             .await
             .map_err(|err| {
-                let rm_summary = err.summary;
-                link_summary.copy_summary.rm_summary = rm_summary;
+                link_summary.copy_summary.rm_summary = err.summary.rm_summary;
                 Error::new(err.source, link_summary)
             })?;
             link_summary.copy_summary.rm_summary = rm_summary;
-            crate::walk::run_metadata_probed(
-                congestion::Side::Destination,
-                congestion::MetadataOp::HardLink,
-                tokio::fs::hard_link(src, dst),
-            )
-            .await
-            .with_context(|| format!("failed to hard link {src:?} to {dst:?}"))
-            .map_err(|err| Error::new(err, link_summary))?;
+            dst_dir
+                .hard_link_handle_at(src_handle, dst_name)
+                .await
+                .with_context(|| format!("failed to hard link to {dst_path:?}"))
+                .map_err(|err| Error::new(err, link_summary))?;
         }
         Err(error) => {
             return Err(Error::new(
-                anyhow::Error::from(error)
-                    .context(format!("failed to hard link {src:?} to {dst:?}")),
+                anyhow::Error::from(error).context(format!("failed to hard link to {dst_path:?}")),
                 link_summary,
             ));
         }
@@ -171,7 +174,17 @@ async fn hard_link_helper(
 }
 
 /// Public entry point for link operations.
-/// Internally delegates to link_internal with source_root tracking for proper filter matching.
+///
+/// The dual-tree link walk is fd-based: the source, optional `update`, and destination roots are
+/// opened relative to their parent directories and every per-entry operation is performed through
+/// file-descriptor-relative syscalls (see [`crate::safedir`]). Hard links are made inode-exact
+/// through the already-classified source `Handle` (`linkat` via `/proc/self/fd/N` with
+/// `AT_SYMLINK_FOLLOW`), so the link targets the exact regular file that was classified, even if
+/// its directory entry is concurrently swapped — never a re-resolved name; entries that must be
+/// copied instead of hard-linked are delegated to `copy::copy_child` with the held parent `Dir`s —
+/// no path is re-resolved from a root. This closes the TOCTOU window the old path-based walk had
+/// between classifying an entry and acting on it. `--dereference` is the one exception — copy still
+/// resolves symlinks by path (`canonicalize`) and is not hardened.
 #[instrument(skip(prog_track, settings))]
 pub async fn link(
     prog_track: &'static progress::Progress,
@@ -182,6 +195,9 @@ pub async fn link(
     settings: &Settings,
     is_fresh: bool,
 ) -> Result<Summary, Error> {
+    // `cwd` is retained for API/signature parity (callers still pass it) but the fd-based walk
+    // reconstructs every path from the explicit roots, so it is no longer threaded into the walk.
+    let _ = cwd;
     // A missing --update root is destructive under both --update-exclusive (materialized set =
     // update set, so nothing materializes) AND --delete (the source-only keep_set makes any dst
     // entry the missing update tree WOULD have protected look extraneous, and prune wipes it).
@@ -224,35 +240,170 @@ pub async fn link(
             }
         }
     }
+    // Source: decompose via the shared helper so `.`/`..` operands (e.g. `rlink . dst`, `rlink
+    // tree/.. dst`) are canonicalized to a real directory + basename instead of being rejected; `/`
+    // is still rejected. (The destination and `--update` operands keep their direct split below.)
+    let src_operand = crate::walk::split_root_operand(src)
+        .await
+        .map_err(|err| Error::new(err, Default::default()))?;
+    let src = src_operand.display.as_path();
+    let src_name = src_operand.name.as_os_str();
     // check filter for top-level source (files, directories, and symlinks)
     if let Some(ref filter) = settings.filter {
-        let src_name = src.file_name().map(std::path::Path::new);
-        if let Some(name) = src_name {
-            let src_metadata = crate::walk::run_metadata_probed(
-                congestion::Side::Source,
-                congestion::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(src),
-            )
-            .await
-            .with_context(|| format!("failed reading metadata from {:?}", &src))
-            .map_err(|err| Error::new(err, Default::default()))?;
-            let is_dir = src_metadata.is_dir();
-            let result = filter.should_include_root_item(name, is_dir);
-            match result {
-                crate::filter::FilterResult::Included => {}
-                result => {
-                    let kind = EntryKind::from_metadata(&src_metadata);
-                    if let Some(mode) = settings.dry_run {
-                        crate::dry_run::report_skip(src, &result, mode, kind.label_long());
-                    }
-                    kind.inc_skipped(prog_track);
-                    return Ok(skipped_summary_for(kind));
+        let src_metadata = crate::walk::run_metadata_probed(
+            congestion::Side::Source,
+            congestion::MetadataOp::Stat,
+            tokio::fs::symlink_metadata(src),
+        )
+        .await
+        .with_context(|| format!("failed reading metadata from {:?}", &src))
+        .map_err(|err| Error::new(err, Default::default()))?;
+        let is_dir = src_metadata.is_dir();
+        let result = filter.should_include_root_item(std::path::Path::new(src_name), is_dir);
+        match result {
+            crate::filter::FilterResult::Included => {}
+            result => {
+                let kind = EntryKind::from_metadata(&src_metadata);
+                if let Some(mode) = settings.dry_run {
+                    crate::dry_run::report_skip(src, &result, mode, kind.label_long());
                 }
+                kind.inc_skipped(prog_track);
+                return Ok(skipped_summary_for(kind));
             }
         }
     }
+    // Open the parent directories of the source, destination, and (optional) update roots so each
+    // root entry is opened and classified relative to a directory fd — the same fd-relative path
+    // every nested entry takes. The roots are then handed to `link_internal` by their basenames,
+    // exactly like child entries. The source was decomposed above (via `split_root_operand`, which
+    // canonicalizes `.`/`..` and rejects `/`); the destination keeps the direct split — a `.`/`..`
+    // destination is not a meaningful link target, and rejecting it avoids clobbering the cwd.
+    let (Some(dst_parent_path), Some(_dst_name)) = (dst.parent(), dst.file_name()) else {
+        return Err(Error::new(
+            anyhow!(
+                "link destination {:?} has no parent directory or file name",
+                dst
+            ),
+            Default::default(),
+        ));
+    };
+    // empty parent (relative path with a single component) means the current directory.
+    let resolve_parent = |p: &std::path::Path| -> std::path::PathBuf {
+        if p.as_os_str().is_empty() {
+            std::path::PathBuf::from(".")
+        } else {
+            p.to_path_buf()
+        }
+    };
+    // the helper already normalized the source's empty parent to ".".
+    let src_parent_path = src_operand.parent.clone();
+    let dst_parent_path = resolve_parent(dst_parent_path);
+    // open the operand's TRUSTED parent prefix following symlinks normally (the prefix is trusted
+    // up to and including the operand's container — only entries strictly below the named root are
+    // O_NOFOLLOW-hardened). a symlinked parent (e.g. `rlink symlinkdir/src dst`) is followed.
+    let src_parent = Dir::open_parent_dir(&src_parent_path, congestion::Side::Source)
+        .await
+        .with_context(|| format!("cannot open source parent directory {:?}", src_parent_path))
+        .map_err(|err| Error::new(err, Default::default()))?;
+    // cross from the trusted parent prefix into the hardened tree (O_NOFOLLOW below here).
+    let src_parent = Arc::new(src_parent.into_tree());
+    // In dry-run we never touch the destination, so we don't open its parent at all (it may not
+    // even exist). `dst_parent == None` is the signal throughout the walk that destination
+    // operations must be skipped.
+    let dst_parent = if settings.dry_run.is_some() {
+        None
+    } else {
+        // the destination's TRUSTED parent prefix is resolved following symlinks (see the source
+        // parent above): a symlinked destination container must be followed into the real dir.
+        let dir = Dir::open_parent_dir(&dst_parent_path, congestion::Side::Destination)
+            .await
+            .with_context(|| {
+                format!(
+                    "cannot open destination parent directory {:?}",
+                    dst_parent_path
+                )
+            })
+            .map_err(|err| Error::new(err, Default::default()))?;
+        // cross from the trusted parent prefix into the hardened tree (O_NOFOLLOW below here).
+        Some(Arc::new(dir.into_tree()))
+    };
+    // The update tree (if present) is rooted at `update`; open its parent and remember the root
+    // basename so `link_internal` can classify it via the held fd. A missing update root is handled
+    // inside `link_internal` (recursive early-return / silent None fallback) exactly as before.
+    //
+    // For plain `--update` (no `--delete`, no `--update-exclusive`) a missing parent is treated the
+    // same as a missing update root: fall back silently to no-update mode. This preserves the long-
+    // standing behavior where `rlink --update /tmp/no/such src dst` (with `/tmp/no` absent) proceeds
+    // by linking from `src` rather than erroring — the existing missing-update-root fallback already
+    // applies to that case; the parent-open merely must not ENOENT-fail before `link_internal` can
+    // apply it. Under `--delete` or `--update-exclusive` the missing-root is already rejected above,
+    // so those cases never reach here with a missing update; any open_parent_dir error there is
+    // unexpected and propagates as before.
+    let update_parent = match update.as_ref() {
+        Some(update_path) => {
+            // decompose the update operand the same way as the source: the update tree is a READ
+            // tree, so `.`/`..`/`dir/..` are meaningful and `split_root_operand` canonicalizes them
+            // (and rejects `/`). This makes `rlink --update . src dst` / `--update tree/.. src dst`
+            // work instead of erroring, matching the source-operand handling. The helper already
+            // normalizes an empty parent to ".", so no `resolve_parent` is needed here.
+            let update_operand = crate::walk::split_root_operand(update_path)
+                .await
+                .map_err(|err| Error::new(err, Default::default()))?;
+            let update_parent_path = update_operand.parent;
+            let update_name = update_operand.name;
+            // the update tree's TRUSTED parent prefix is resolved following symlinks (see the
+            // source parent above): a symlinked update container must be followed into the real dir.
+            let fallback_eligible =
+                !settings.update_exclusive && settings.copy_settings.delete.is_none();
+            match Dir::open_parent_dir(&update_parent_path, congestion::Side::Source).await {
+                // cross from the trusted parent prefix into the hardened tree (O_NOFOLLOW below).
+                Ok(dir) => Some((Arc::new(dir.into_tree()), update_name)),
+                Err(err)
+                    if fallback_eligible
+                        && (matches!(
+                            err.kind(),
+                            std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+                        ) || err.raw_os_error() == Some(libc::ENOTDIR)) =>
+                {
+                    // the update path's parent (or an ancestor) doesn't exist — treat the whole
+                    // update tree as absent and fall back to no-update mode, exactly as when the
+                    // update ROOT itself is missing (handled inside link_internal).
+                    tracing::debug!(
+                        "update parent {:?} not found ({:#}); falling back to no-update mode",
+                        update_parent_path,
+                        err
+                    );
+                    None
+                }
+                Err(err) => {
+                    return Err(Error::new(
+                        anyhow::Error::new(err).context(format!(
+                            "cannot open update parent directory {:?}",
+                            update_parent_path
+                        )),
+                        Default::default(),
+                    ));
+                }
+            }
+        }
+        None => None,
+    };
+    let update_ref = update_parent
+        .as_ref()
+        .map(|(dir, name)| (dir, name.as_os_str()));
     link_internal(
-        prog_track, cwd, src, dst, src, update, settings, is_fresh, None,
+        prog_track,
+        &src_parent,
+        update_ref,
+        dst_parent.as_ref(),
+        src_name,
+        src,
+        dst,
+        update.as_deref(),
+        std::path::Path::new(""),
+        settings,
+        is_fresh,
+        None,
     )
     .await
 }
@@ -296,18 +447,6 @@ impl DeleteKeepSet {
             set.insert(name.to_owned());
         }
     }
-    /// Update loop, filtered-out branch: an update entry at this name is filtered out, so
-    /// nothing materializes from the update side. Drop a src-side registration ONLY if the
-    /// source loop actually materialized something (caller tracks this via `processed_files`).
-    /// Skipped specials stay registered — their `record_src` happened, but `processed_files`
-    /// was not populated, so their dst counterpart is retained per `--skip-specials` semantics.
-    fn drop_src_when_update_filtered(&mut self, name: &std::ffi::OsStr, src_materialized: bool) {
-        if let Some(set) = &mut self.inner
-            && src_materialized
-        {
-            set.remove(name);
-        }
-    }
     /// Borrow the underlying set for `prune_extraneous`. `None` means `--delete` is off and
     /// the caller should skip the prune entirely.
     fn as_set(&self) -> Option<&std::collections::HashSet<std::ffi::OsString>> {
@@ -315,239 +454,359 @@ impl DeleteKeepSet {
     }
 }
 
-#[instrument(skip(prog_track, settings, open_file_guard))]
+/// Per-entry worker of the fd-based dual-tree link walk.
+///
+/// `src_parent` is the open source directory holding `name`; `update` is `Some((dir, name))` when
+/// an update tree is present at this level (its directory handle plus the update root's basename
+/// for the root entry); `dst_parent` is the open destination directory (`None` in dry-run).
+/// `src_root`/`dst_root`/`update_root` are the user-specified roots and `rel_path` is this entry's
+/// path relative to those roots (empty for the root entry) — joined onto a root they reconstruct
+/// the real path used for diagnostics, `rm`, and `--dereference`. `rel_path` is also this entry's
+/// logical filter path.
+///
+/// The src entry is classified via `src_parent.child(name)` (fstat-authoritative; the getdents
+/// hint is only a spawn-loop heuristic). When an update entry exists at this name it is classified
+/// too, and the hard-link-vs-copy decision mirrors the old `--update` overlay logic exactly:
+/// a type-mismatch / changed file / symlink in the update tree is COPIED from the update version
+/// via [`copy::copy_child`]; an unchanged file is HARD-LINKED from the source; a directory recurses
+/// the dual tree. With no update tree, a source file is hard-linked, a source symlink is copied,
+/// and a directory recurses.
+///
+/// `permit` is the leaf permit the spawn loop pre-acquired for a regular-file src hint (via
+/// [`walk::preacquire_leaf_permit`]). It is USED only on the one path that copies a *changed*
+/// same-type regular file from the update tree (the data copy reuses it); on every other path it is
+/// dropped at the single consolidated drop site below — see that comment for why this is rlink's
+/// acknowledged dual-tree special case.
+#[instrument(skip(prog_track, src_parent, update, dst_parent, settings, permit))]
 #[async_recursion]
 #[allow(clippy::too_many_arguments)]
 async fn link_internal(
     prog_track: &'static progress::Progress,
-    cwd: &std::path::Path,
-    src: &std::path::Path,
-    dst: &std::path::Path,
-    source_root: &std::path::Path,
-    update: &Option<std::path::PathBuf>,
+    src_parent: &Arc<Dir>,
+    update: Option<(&Arc<Dir>, &std::ffi::OsStr)>,
+    dst_parent: Option<&Arc<Dir>>,
+    name: &std::ffi::OsStr,
+    src_root: &std::path::Path,
+    dst_root: &std::path::Path,
+    update_root: Option<&std::path::Path>,
+    rel_path: &std::path::Path,
     settings: &Settings,
-    mut is_fresh: bool,
-    open_file_guard: Option<throttle::OpenFileGuard>,
+    is_fresh: bool,
+    permit: Option<LeafPermit>,
 ) -> Result<Summary, Error> {
     let _prog_guard = prog_track.ops.guard();
-    tracing::debug!("reading source metadata");
-    let src_metadata = crate::walk::run_metadata_probed(
-        congestion::Side::Source,
-        congestion::MetadataOp::Stat,
-        tokio::fs::symlink_metadata(src),
-    )
-    .await
-    .with_context(|| format!("failed reading metadata from {:?}", &src))
-    .map_err(|err| Error::new(err, Default::default()))?;
-    let update_metadata_opt = match update {
-        Some(update) => {
-            tracing::debug!("reading 'update' metadata");
-            let update_metadata_res = crate::walk::run_metadata_probed(
-                congestion::Side::Source,
-                congestion::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(update),
+    // real filesystem paths reconstructed from the roots + accumulated relative path. used for
+    // diagnostics, the path-based `--delete` prune scan / `rm`, the `--dereference` canonicalize
+    // fallback inside copy, and to derive `dst_name`. joining an empty `rel_path` (the root entry)
+    // would append a trailing separator, so use the root verbatim when `rel_path` is empty.
+    let (src_path, dst_path) = if rel_path.as_os_str().is_empty() {
+        (src_root.to_path_buf(), dst_root.to_path_buf())
+    } else {
+        (src_root.join(rel_path), dst_root.join(rel_path))
+    };
+    let update_path = update_root.map(|root| {
+        if rel_path.as_os_str().is_empty() {
+            root.to_path_buf()
+        } else {
+            root.join(rel_path)
+        }
+    });
+    // the destination entry's name within `dst_parent`. for nested entries this equals the source
+    // `name`, but for the root the source and destination basenames differ (e.g. linking `foo` to
+    // `bar`), so destination operations must use this name.
+    let dst_name = dst_path
+        .file_name()
+        .ok_or_else(|| {
+            Error::new(
+                anyhow!("link destination {:?} has no file name", &dst_path),
+                Default::default(),
             )
-            .await;
-            match update_metadata_res {
-                Ok(update_metadata) => Some(update_metadata),
-                Err(error) => {
-                    if error.kind() == std::io::ErrorKind::NotFound {
-                        if settings.update_exclusive {
-                            // the path is missing from update, we're done
-                            return Ok(Default::default());
-                        }
-                        None
-                    } else {
-                        return Err(Error::new(
-                            anyhow!("failed reading metadata from {:?}", &update),
-                            Default::default(),
-                        ));
+        })?
+        .to_owned();
+    tracing::debug!("classifying source entry");
+    let src_handle = src_parent
+        .child(name)
+        .await
+        .with_context(|| format!("failed reading metadata from {:?}", &src_path))
+        .map_err(|err| Error::new(err, Default::default()))?;
+    // classify the update entry at this name (if an update tree is present at this level). a
+    // NotFound is the "this path is missing from update" case; under --update-exclusive it means
+    // we're done (nothing materializes), otherwise we fall back to no-update mode for this entry.
+    let mut update_handle = match update {
+        Some((update_dir, update_name)) => {
+            tracing::debug!("classifying 'update' entry");
+            match update_dir.child(update_name).await {
+                Ok(handle) => Some(handle),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    if settings.update_exclusive {
+                        // the path is missing from update, we're done
+                        return Ok(Default::default());
                     }
+                    None
+                }
+                Err(error) => {
+                    return Err(Error::new(
+                        anyhow::Error::new(error)
+                            .context(format!("failed reading metadata from {:?}", &update_path)),
+                        Default::default(),
+                    ));
                 }
             }
         }
         None => None,
     };
-    if let Some(update_metadata) = update_metadata_opt.as_ref() {
-        let update = update.as_ref().unwrap();
-        if !copy::is_file_type_same(&src_metadata, update_metadata) {
+    // Re-evaluate the filter using the UPDATE entry's authoritative type before letting it drive
+    // the materialization decision below. The spawn loop in `link_dir_contents` evaluated the
+    // filter against the SOURCE entry's type; when the same name is a TYPE MISMATCH (e.g. src
+    // `cache` is a file, update `cache` is a directory) a type-dependent pattern like the dir-only
+    // `cache/` can pass the src (a dir-only pattern doesn't match a file) yet exclude the update.
+    // Without this check the type-mismatch branch would `delegate_copy` the excluded update entry
+    // (`copy_child` does NOT re-apply the top-level filter to the delegated root), copying an
+    // excluded subtree. Note a filtered-out update reaching here is necessarily a type mismatch: if
+    // the pattern were type-independent it would have excluded the src too, so the src loop would
+    // not have spawned this worker.
+    if let Some(handle) = update_handle.as_ref() {
+        let update_is_dir = handle.kind() == EntryKind::Dir;
+        // For the ROOT entry (`rel_path` empty) judge the update side with root-item semantics —
+        // symmetric with how the source root was filtered (`should_include_root_item` at the top of
+        // `link`) and with how main's delegated copy filtered the update root — rather than the
+        // nested `should_include("")` path, which would judge the root by different rules than the
+        // source (e.g. a non-anchored `--include data` includes a root file `data` under root-item
+        // semantics but not under the nested empty-path check). Nested entries keep the accumulated
+        // `rel_path` with the normal nested filter.
+        let update_excluded = match settings.filter.as_ref() {
+            Some(filter) if rel_path.as_os_str().is_empty() => {
+                let (_, update_name) =
+                    update.expect("update_handle is Some only when update is Some");
+                !matches!(
+                    filter.should_include_root_item(
+                        std::path::Path::new(update_name),
+                        update_is_dir,
+                    ),
+                    crate::filter::FilterResult::Included
+                )
+            }
+            _ => walk::should_skip_entry(&settings.filter, rel_path, update_is_dir).is_some(),
+        };
+        if update_excluded {
+            if settings.update_exclusive {
+                // --update-exclusive materializes only the (filter-passing) update set, so an
+                // excluded update entry materializes nothing — exactly the NotFound case above.
+                // The src is not materialized; under --delete its keep-set entry was never recorded
+                // (`record_src` is a no-op when `src_records_disabled`), so the dst counterpart is
+                // pruned/exclude-protected by the prune scan, never materialized-then-pruned.
+                tracing::debug!(
+                    "update entry {:?} is filtered out under --update-exclusive; materializing nothing",
+                    update_path
+                );
+                return Ok(Default::default());
+            }
+            // Normal --update (union): the update's version of this name is excluded, so the src's
+            // version stands. Treat the update entry as absent and fall through to the no-update
+            // src handling (hard-link a src file, copy a src symlink, recurse a src dir). The src
+            // already passed its own filter in the spawn loop, so its --delete keep-set entry
+            // correctly stays recorded.
+            tracing::debug!(
+                "update entry {:?} is filtered out; falling back to source-only handling",
+                update_path
+            );
+            update_handle = None;
+        }
+    }
+    // ── rlink's acknowledged dual-tree special case (design spec §4): the single permit-drop site ──
+    //
+    // The spawn loop in `link_dir_contents` pre-acquired this leaf permit (open-files pool) for a
+    // regular-file src `hint`, but the authoritative dual-tree decision below may instead COPY
+    // (possibly recursing, when the update entry is a directory), HARD-LINK, SKIP, or recurse a
+    // directory. The permit is USED on exactly ONE path: copying a *changed* same-type regular file
+    // from the update tree (`copy_child` reuses it for the data copy). On every other path — both
+    // the recursing ones (a type-mismatch where the update side may be a directory, and a same-type
+    // directory) and the non-recursive leaf ones (hard-link, symlink copy, special, no-update) — the
+    // permit must NOT be held: a recursing path holding it across `copy_child`/`link_dir_entry` is
+    // the hold-and-wait deadlock the leaf-permit lifecycle eliminates, and a leaf path holding the
+    // mismatched permit across its own `.await` is pointless.
+    //
+    // So decide once, here, before any `.await` that isn't the intended copy: extract the open-files
+    // guard for the file-changed-copy path and drop the permit for everything else. Replacing the
+    // seven hand-maintained `drop(open_file_guard)` sites with this one is the Class-1 cleanup; this
+    // is the one site exempted from the Phase H no-manual-drop lint, because rlink's dual-tree walk
+    // is not a `WalkVisitor` and cannot use the driver's single drop-before-recurse home.
+    let is_file_changed_copy = match update_handle.as_ref() {
+        Some(update_handle) => {
+            update_handle.kind() == src_handle.kind()
+                && update_handle.kind() == EntryKind::File
+                && !filecmp::metadata_equal(
+                    &settings.update_compare,
+                    src_handle.meta(),
+                    update_handle.meta(),
+                )
+        }
+        None => false,
+    };
+    let copy_guard: Option<throttle::OpenFileGuard> = if is_file_changed_copy {
+        // keep the permit for the data copy: hand the inner open-files guard to `copy_child`.
+        match permit {
+            Some(LeafPermit::OpenFile(guard)) => Some(guard),
+            // a non-OpenFile permit can never reach rlink (its `want` only takes from the OpenFile
+            // pool), and `None` means the pool was disabled — either way there is nothing to pass.
+            _ => None,
+        }
+    } else {
+        // every non-copy / recursing branch: release the leaf permit now (the consolidated drop).
+        drop(permit);
+        None
+    };
+    if let Some(update_handle) = update_handle.as_ref() {
+        let (update_dir, update_name) = update.unwrap();
+        let update_path = update_path.as_deref().unwrap();
+        if update_handle.kind() != src_handle.kind() {
             // file type changed, just copy the updated one
             tracing::debug!(
                 "link: file type of {:?} ({:?}) and {:?} ({:?}) differs - copying from update",
-                src,
-                src_metadata.file_type(),
-                update,
-                update_metadata.file_type()
+                src_path,
+                src_handle.kind(),
+                update_path,
+                update_handle.kind()
             );
-            // release any caller-supplied open-files permit before delegating
-            // to copy::copy. The permit was acquired for the src entry's file
-            // type at the spawn site, but here `update` has a *different* file
-            // type (we just checked `!is_file_type_same`), so the permit is
-            // mismatched. More importantly, copy::copy → copy_internal will
-            // acquire its own open-files permit for any file it copies; if we
-            // were still holding one here, a saturated pool would deadlock the
-            // inner acquire.
-            drop(open_file_guard);
-            // delegate at this entry's logical path (relative to the link root) so that, under
-            // --delete, pruning inside the delegated subtree matches include/exclude descendants
-            // at the correct filter root (e.g. `node/*.log`) — mirroring the update-only
-            // delegation. With an empty base, a path-anchored exclude would fail to protect a
-            // descendant like `node/keep.log` and delete it.
-            let filter_base = walk::relative_to_root(src, source_root);
-            let copy_summary = copy::copy_with_filter_base(
+            // the leaf permit was already released at the consolidated drop site above (this is the
+            // type-mismatch path, where the update side may be a directory and we recurse via copy).
+            // delegate at this entry's logical path so that, under --delete, pruning inside the
+            // delegated subtree matches include/exclude descendants at the correct filter root
+            // (e.g. `node/*.log`). pass the HELD update parent + name, never a re-resolved path.
+            return delegate_copy(
                 prog_track,
-                update,
-                dst,
-                &settings.copy_settings,
-                &settings.preserve,
+                update_dir,
+                dst_parent,
+                update_name,
+                update_path,
+                &dst_path,
+                rel_path,
+                settings,
                 is_fresh,
-                filter_base,
+                None,
             )
-            .await
-            .map_err(|err| {
-                let copy_summary = err.summary;
-                let link_summary = Summary {
-                    copy_summary,
-                    ..Default::default()
-                };
-                Error::new(err.source, link_summary)
-            })?;
-            return Ok(Summary {
-                copy_summary,
-                ..Default::default()
-            });
+            .await;
         }
-        if update_metadata.is_file() {
+        if update_handle.kind() == EntryKind::File {
             // check if the file is unchanged and if so hard-link, otherwise copy from the updated one
-            if filecmp::metadata_equal(&settings.update_compare, &src_metadata, update_metadata) {
+            if filecmp::metadata_equal(
+                &settings.update_compare,
+                src_handle.meta(),
+                update_handle.meta(),
+            ) {
+                // unchanged file: hard-link from src. the permit was already dropped above (this is
+                // not the file-changed-copy path), so `copy_guard` is None and there is nothing held.
                 tracing::debug!("no change, hard link 'src'");
-                return hard_link_helper(prog_track, src, &src_metadata, dst, settings).await;
+                if settings.dry_run.is_some() {
+                    crate::dry_run::report_action("link", &src_path, Some(&dst_path), "file");
+                    return Ok(Summary {
+                        hard_links_created: 1,
+                        ..Default::default()
+                    });
+                }
+                let dst_dir =
+                    dst_parent.expect("destination parent must be open for a real hard link");
+                return hard_link_entry_fd(
+                    prog_track,
+                    &src_handle,
+                    dst_dir,
+                    &dst_name,
+                    &dst_path,
+                    settings,
+                )
+                .await;
             }
             tracing::debug!(
                 "link: {:?} metadata has changed, copying from {:?}",
-                src,
-                update
+                src_path,
+                update_path
             );
-            // use the caller's pre-acquired permit (the spawn loop pre-acquires
-            // for regular-file entries so this is the common path); fall back to
-            // acquiring a new one for callers that don't pre-acquire (top-level
-            // `link` and the file-type-changed path above).
-            let _guard = match open_file_guard {
-                Some(g) => g,
-                None => throttle::open_file_permit().await,
-            };
-            return Ok(Summary {
-                copy_summary: copy::copy_file(
-                    prog_track,
-                    update,
-                    dst,
-                    update_metadata,
-                    &settings.copy_settings,
-                    &settings.preserve,
-                    is_fresh,
-                )
-                .await
-                .map_err(|err| {
-                    let copy_summary = err.summary;
-                    let link_summary = Summary {
-                        copy_summary,
-                        ..Default::default()
-                    };
-                    Error::new(err.source, link_summary)
-                })?,
-                ..Default::default()
-            });
-        }
-        if update_metadata.is_symlink() {
-            tracing::debug!("'update' is a symlink so just symlink that");
-            // delegate at this entry's logical path (relative to the link root) so the inner
-            // filter re-check in copy_with_filter_base uses nested semantics. With an empty
-            // filter_base it would fall back to should_include_root_item on the bare basename
-            // and reject a path-anchored include like `dir/link`, leaving the entry unmaterialized
-            // while the outer loop's keep_set entry still shielded the stale dst from pruning.
-            let filter_base = walk::relative_to_root(src, source_root);
-            let copy_summary = copy::copy_with_filter_base(
+            // changed file: delegate to copy, reusing the pre-acquired permit (the common path: the
+            // spawn loop pre-acquires for regular-file hints). `copy_guard` is the open-files guard
+            // the consolidated decision above extracted for exactly this path. copy_child
+            // re-classifies and applies its own --overwrite/dry-run logic for a file.
+            return delegate_copy(
                 prog_track,
-                update,
-                dst,
-                &settings.copy_settings,
-                &settings.preserve,
+                update_dir,
+                dst_parent,
+                update_name,
+                update_path,
+                &dst_path,
+                rel_path,
+                settings,
                 is_fresh,
-                filter_base,
+                copy_guard,
             )
-            .await
-            .map_err(|err| {
-                let copy_summary = err.summary;
-                let link_summary = Summary {
-                    copy_summary,
-                    ..Default::default()
-                };
-                Error::new(err.source, link_summary)
-            })?;
-            return Ok(Summary {
-                copy_summary,
-                ..Default::default()
-            });
+            .await;
+        }
+        if update_handle.kind() == EntryKind::Symlink {
+            // update symlink: copy it. the permit was already dropped at the consolidated site.
+            tracing::debug!("'update' is a symlink so just symlink that");
+            return delegate_copy(
+                prog_track,
+                update_dir,
+                dst_parent,
+                update_name,
+                update_path,
+                &dst_path,
+                rel_path,
+                settings,
+                is_fresh,
+                None,
+            )
+            .await;
         }
     } else {
-        // update hasn't been specified, if this is a file just hard-link the source or symlink if it's a symlink
-        tracing::debug!("no 'update' specified");
-        if src_metadata.is_file() {
-            // handle dry-run mode for top-level files
+        // update hasn't been specified (or is absent at this name): hard-link a source file,
+        // copy a source symlink.
+        // the permit (if any) was already released at the consolidated drop site above, so the
+        // no-update hard-link / symlink-copy paths here hold nothing.
+        tracing::debug!("no 'update' entry");
+        if src_handle.kind() == EntryKind::File {
             if settings.dry_run.is_some() {
-                crate::dry_run::report_action("link", src, Some(dst), "file");
+                crate::dry_run::report_action("link", &src_path, Some(&dst_path), "file");
                 return Ok(Summary {
                     hard_links_created: 1,
                     ..Default::default()
                 });
             }
-            return hard_link_helper(prog_track, src, &src_metadata, dst, settings).await;
-        }
-        if src_metadata.is_symlink() {
-            tracing::debug!("'src' is a symlink so just symlink that");
-            // delegate at this entry's logical path so the inner filter re-check uses nested
-            // semantics — see the matching comment above on the update-symlink branch.
-            let filter_base = walk::relative_to_root(src, source_root);
-            let copy_summary = copy::copy_with_filter_base(
+            let dst_dir = dst_parent.expect("destination parent must be open for a real hard link");
+            return hard_link_entry_fd(
                 prog_track,
-                src,
-                dst,
-                &settings.copy_settings,
-                &settings.preserve,
-                is_fresh,
-                filter_base,
+                &src_handle,
+                dst_dir,
+                &dst_name,
+                &dst_path,
+                settings,
             )
-            .await
-            .map_err(|err| {
-                let copy_summary = err.summary;
-                let link_summary = Summary {
-                    copy_summary,
-                    ..Default::default()
-                };
-                Error::new(err.source, link_summary)
-            })?;
-            return Ok(Summary {
-                copy_summary,
-                ..Default::default()
-            });
+            .await;
+        }
+        if src_handle.kind() == EntryKind::Symlink {
+            tracing::debug!("'src' is a symlink so just symlink that");
+            return delegate_copy(
+                prog_track, src_parent, dst_parent, name, &src_path, &dst_path, rel_path, settings,
+                is_fresh, None,
+            )
+            .await;
         }
     }
-    if !src_metadata.is_dir() {
+    if src_handle.kind() != EntryKind::Dir {
+        // special file (or unsupported type): non-recursive; the permit is already released above.
         if settings.copy_settings.skip_specials {
             tracing::debug!(
-                "skipping special file {:?} (type: {:?})",
-                src,
-                src_metadata.file_type()
+                "skipping special file {:?} (kind: {:?})",
+                src_path,
+                src_handle.kind()
             );
             if let Some(mode) = settings.dry_run {
                 match mode {
                     crate::config::DryRunMode::Brief => {}
-                    crate::config::DryRunMode::All => println!("skip special {:?}", src),
+                    crate::config::DryRunMode::All => println!("skip special {:?}", src_path),
                     crate::config::DryRunMode::Explain => {
                         println!(
                             "skip special {:?} (unsupported file type: {:?})",
-                            src,
-                            src_metadata.file_type()
+                            src_path,
+                            src_handle.kind()
                         );
                     }
                 }
@@ -564,131 +823,266 @@ async fn link_internal(
         return Err(Error::new(
             anyhow!(
                 "copy: {:?} -> {:?} failed, unsupported src file type: {:?}",
-                src,
-                dst,
-                src_metadata.file_type()
+                src_path,
+                dst_path,
+                src_handle.kind()
             ),
             Default::default(),
         ));
     }
-    assert!(update_metadata_opt.is_none() || update_metadata_opt.as_ref().unwrap().is_dir());
-    tracing::debug!("process contents of 'src' directory");
-    let mut src_entries = tokio::fs::read_dir(src)
-        .await
-        .with_context(|| format!("cannot open directory {src:?} for reading"))
-        .map_err(|err| Error::new(err, Default::default()))?;
-    // handle dry-run mode for directories at the top level
-    if settings.dry_run.is_some() {
-        crate::dry_run::report_action("link", src, Some(dst), "dir");
-        // still need to recurse to show contents
-    }
-    let copy_summary = if settings.dry_run.is_some() {
-        // skip actual directory creation in dry-run mode
-        CopySummary {
-            directories_created: 1,
-            ..Default::default()
-        }
-    } else if let Err(error) = crate::walk::run_metadata_probed(
-        congestion::Side::Destination,
-        congestion::MetadataOp::MkDir,
-        tokio::fs::create_dir(dst),
+    // directory: recurse the dual tree. the leaf permit was released at the consolidated drop site
+    // above — this recursing path never holds it (the hold-and-wait deadlock invariant).
+    debug_assert!(
+        update_handle.is_none() || update_handle.as_ref().unwrap().kind() == EntryKind::Dir
+    );
+    // Only drive the dual-tree update walk when an update directory entry actually exists at this
+    // name. If `update_handle` is None (the update tree has no counterpart for this src dir, the
+    // recursive "update missing" case), process this subtree in no-update mode: hard-link the whole
+    // source subtree. Passing the parent update tuple here would make `link_dir_entry` try to
+    // `open_dir` a non-existent update child.
+    let update_for_dir = update.filter(|_| update_handle.is_some());
+    let update_root_for_dir = update_root.filter(|_| update_handle.is_some());
+    link_dir_entry(
+        prog_track,
+        src_parent,
+        &src_handle,
+        update_for_dir,
+        update_handle.as_ref().map(crate::safedir::Handle::meta),
+        dst_parent,
+        name,
+        &dst_name,
+        src_root,
+        dst_root,
+        update_root_for_dir,
+        rel_path,
+        &src_path,
+        &dst_path,
+        update_path.as_deref().filter(|_| update_handle.is_some()),
+        settings,
+        is_fresh,
     )
     .await
-    {
-        assert!(!is_fresh, "unexpected error creating directory: {:?}", &dst);
-        if settings.copy_settings.overwrite && error.kind() == std::io::ErrorKind::AlreadyExists {
-            // check if the destination is a directory - if so, leave it
-            //
-            // N.B. the permissions may prevent us from writing to it but the alternative is to open up the directory
-            // while we're writing to it which isn't safe
-            let dst_metadata = crate::walk::run_metadata_probed(
-                congestion::Side::Destination,
-                congestion::MetadataOp::Stat,
-                // symlink_metadata (not metadata): do not follow a destination symlink. A
-                // symlinked directory is then treated as "not a directory" below and replaced,
-                // rather than copied/pruned *through* — which under --delete could delete files
-                // outside the destination tree. Mirrors copy.rs.
-                tokio::fs::symlink_metadata(dst),
-            )
-            .await
-            .with_context(|| format!("failed reading metadata from {:?}", &dst))
-            .map_err(|err| Error::new(err, Default::default()))?;
-            if dst_metadata.is_dir() {
-                tracing::debug!("'dst' is a directory, leaving it as is");
-                CopySummary {
-                    directories_unchanged: 1,
-                    ..Default::default()
-                }
-            } else {
-                tracing::info!("'dst' is not a directory, removing and creating a new one");
-                let mut copy_summary = CopySummary::default();
-                let rm_summary = rm::rm(
-                    prog_track,
-                    dst,
-                    &rm::Settings {
-                        fail_early: settings.copy_settings.fail_early,
-                        filter: None,
-                        dry_run: None,
-                        time_filter: None,
-                    },
-                )
-                .await
-                .map_err(|err| {
-                    let rm_summary = err.summary;
-                    copy_summary.rm_summary = rm_summary;
-                    Error::new(
-                        err.source,
-                        Summary {
-                            copy_summary,
-                            ..Default::default()
-                        },
-                    )
-                })?;
-                crate::walk::run_metadata_probed(
-                    congestion::Side::Destination,
-                    congestion::MetadataOp::MkDir,
-                    tokio::fs::create_dir(dst),
-                )
-                .await
-                .with_context(|| format!("cannot create directory {dst:?}"))
-                .map_err(|err| {
-                    copy_summary.rm_summary = rm_summary;
-                    Error::new(
-                        err,
-                        Summary {
-                            copy_summary,
-                            ..Default::default()
-                        },
-                    )
-                })?;
-                // anything copied into dst may assume they don't need to check for conflicts
-                is_fresh = true;
-                CopySummary {
-                    rm_summary,
-                    directories_created: 1,
-                    ..Default::default()
-                }
-            }
-        } else {
-            return Err(error)
-                .with_context(|| format!("cannot create directory {dst:?}"))
-                .map_err(|err| Error::new(err, Default::default()))?;
-        }
-    } else {
-        // new directory created, anything copied into dst may assume they don't need to check for conflicts
-        is_fresh = true;
-        CopySummary {
-            directories_created: 1,
-            ..Default::default()
-        }
-    };
-    // track whether we created this directory (vs it already existing)
-    // this is used later to decide if we should clean up an empty directory
-    let we_created_this_dir = copy_summary.directories_created == 1;
-    let mut link_summary = Summary {
+}
+
+/// Delegate a single entry to the fd-based copy ([`copy::copy_child`]), passing the HELD parent
+/// directory handles plus the entry `name` — never re-resolving a path. `filter_base` for the
+/// delegation is the entry's logical relative path (so `--delete` pruning inside the subtree
+/// matches include/exclude patterns at the entry's true path). The returned copy summary is folded
+/// into a link `Summary`.
+#[allow(clippy::too_many_arguments)]
+async fn delegate_copy(
+    prog_track: &'static progress::Progress,
+    src_parent: &Arc<Dir>,
+    dst_parent: Option<&Arc<Dir>>,
+    name: &std::ffi::OsStr,
+    src_path: &std::path::Path,
+    dst_path: &std::path::Path,
+    filter_base: &std::path::Path,
+    settings: &Settings,
+    is_fresh: bool,
+    open_file_guard: Option<throttle::OpenFileGuard>,
+) -> Result<Summary, Error> {
+    let copy_summary = copy::copy_child(
+        prog_track,
+        src_parent,
+        dst_parent,
+        name,
+        src_path,
+        dst_path,
+        filter_base,
+        &settings.copy_settings,
+        &settings.preserve,
+        is_fresh,
+        open_file_guard,
+    )
+    .await
+    .map_err(|err| {
+        let copy_summary = err.summary;
+        Error::new(
+            err.source,
+            Summary {
+                copy_summary,
+                ..Default::default()
+            },
+        )
+    })?;
+    Ok(Summary {
         copy_summary,
         ..Default::default()
+    })
+}
+
+/// Resolve (create / reuse / overwrite) the destination directory fd-relative, open the source
+/// (and update) directories, then recurse via [`link_dir_contents`]. Mirrors copy's
+/// [`copy::resolve_dst_dir`] for the overwrite branches (recheck-guarded, fd-relative removal).
+#[allow(clippy::too_many_arguments)]
+async fn link_dir_entry(
+    prog_track: &'static progress::Progress,
+    src_parent: &Arc<Dir>,
+    src_handle: &crate::safedir::Handle,
+    update: Option<(&Arc<Dir>, &std::ffi::OsStr)>,
+    update_meta: Option<&crate::safedir::FileMeta>,
+    dst_parent: Option<&Arc<Dir>>,
+    name: &std::ffi::OsStr,
+    dst_name: &std::ffi::OsStr,
+    src_root: &std::path::Path,
+    dst_root: &std::path::Path,
+    update_root: Option<&std::path::Path>,
+    rel_path: &std::path::Path,
+    src_path: &std::path::Path,
+    dst_path: &std::path::Path,
+    update_path: Option<&std::path::Path>,
+    settings: &Settings,
+    is_fresh: bool,
+) -> Result<Summary, Error> {
+    let src_dir = src_parent
+        .open_dir(name)
+        .await
+        .with_context(|| format!("cannot open directory {:?} for reading", src_path))
+        .map_err(|err| Error::new(err, Default::default()))?;
+    let src_dir = Arc::new(src_dir);
+    // open the update directory too (it has the same file type as src here — both are dirs).
+    let update_dir = match update {
+        Some((update_parent, update_name)) => {
+            let dir = update_parent
+                .open_dir(update_name)
+                .await
+                .with_context(|| {
+                    format!("cannot open update directory {:?} for reading", update_path)
+                })
+                .map_err(|err| Error::new(err, Default::default()))?;
+            Some(Arc::new(dir))
+        }
+        None => None,
     };
+    // dry-run: report the directory and traverse its contents, but never create a destination dir.
+    if settings.dry_run.is_some() {
+        crate::dry_run::report_action("link", src_path, Some(dst_path), "dir");
+        let base = Summary {
+            copy_summary: CopySummary {
+                directories_created: 1, // report as would-be-created
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        return link_dir_contents(
+            prog_track,
+            &src_dir,
+            src_handle,
+            update_dir.as_ref(),
+            update_meta,
+            None, // dry-run: no destination dir
+            None, // dry-run: no destination parent
+            dst_name,
+            src_root,
+            dst_root,
+            update_root,
+            rel_path,
+            src_path,
+            dst_path,
+            true, // treat as "created" so empty-dir cleanup can suppress the dry-run count
+            is_fresh,
+            settings,
+            base,
+        )
+        .await;
+    }
+    // real link: dst_parent is Some.
+    let dst_parent = dst_parent.expect("destination parent must be open for a real link");
+    let copy::DirSlot {
+        dir: dst_dir,
+        summary: base,
+        is_fresh: child_is_fresh,
+        we_created,
+    } = match copy::resolve_dst_dir(
+        prog_track,
+        dst_parent,
+        dst_name,
+        dst_path,
+        &settings.copy_settings,
+        is_fresh,
+    )
+    .await
+    .map_err(|err| {
+        Error::new(
+            err.source,
+            Summary {
+                copy_summary: err.summary,
+                ..Default::default()
+            },
+        )
+    })? {
+        copy::DirResolution::Skip(summary) => {
+            return Ok(Summary {
+                copy_summary: summary,
+                ..Default::default()
+            });
+        }
+        copy::DirResolution::Proceed(slot) => slot,
+    };
+    link_dir_contents(
+        prog_track,
+        &src_dir,
+        src_handle,
+        update_dir.as_ref(),
+        update_meta,
+        Some(&dst_dir),
+        Some(dst_parent),
+        dst_name,
+        src_root,
+        dst_root,
+        update_root,
+        rel_path,
+        src_path,
+        dst_path,
+        we_created,
+        child_is_fresh,
+        settings,
+        Summary {
+            copy_summary: base,
+            ..Default::default()
+        },
+    )
+    .await
+}
+
+/// The dual-tree body of a directory link: enumerate the source entries (hard-linking unchanged
+/// files, delegating copies, recursing into subdirectories), then enumerate the update entries and
+/// copy those not present in the source, then run `--delete` pruning, empty-directory cleanup, and
+/// finally apply the directory's own metadata.
+///
+/// `dst_dir == None` / `dst_parent == None` means dry-run (no destination mutation). `base` carries
+/// the `directories_created`/`directories_unchanged` contribution from resolving this directory.
+#[allow(clippy::too_many_arguments)]
+async fn link_dir_contents(
+    prog_track: &'static progress::Progress,
+    src_dir: &Arc<Dir>,
+    // classify handles, retained for caller threading; directory metadata is now read from the
+    // opened `src_dir`/`update_dir` fds (read-side fidelity), so these are no longer read here.
+    _src_handle: &crate::safedir::Handle,
+    update_dir: Option<&Arc<Dir>>,
+    _update_meta: Option<&crate::safedir::FileMeta>,
+    dst_dir: Option<&Arc<Dir>>,
+    dst_parent: Option<&Arc<Dir>>,
+    dst_name: &std::ffi::OsStr,
+    src_root: &std::path::Path,
+    dst_root: &std::path::Path,
+    update_root: Option<&std::path::Path>,
+    rel_path: &std::path::Path,
+    src_path: &std::path::Path,
+    dst_path: &std::path::Path,
+    we_created_this_dir: bool,
+    is_fresh: bool,
+    settings: &Settings,
+    base: Summary,
+) -> Result<Summary, Error> {
+    tracing::debug!("process contents of 'src' directory");
+    let src_entries = src_dir
+        .read_entries()
+        .await
+        .with_context(|| format!("cannot open directory {src_path:?} for reading"))
+        .map_err(|err| Error::new(err, base))?;
+    let mut link_summary = base;
     let mut join_set = tokio::task::JoinSet::new();
     let errors = crate::error_collector::ErrorCollector::default();
     // create a set of all the files we already processed
@@ -700,30 +1094,36 @@ async fn link_internal(
     let mut keep_set = DeleteKeepSet::new(
         settings.copy_settings.delete.as_ref(),
         settings.update_exclusive,
-        update.is_some(),
+        update_dir.is_some(),
     );
     // iterate through src entries and recursively call "link" on each one
-    loop {
-        let Some((src_entry, entry_file_type)) =
-            crate::walk::next_entry_probed(&mut src_entries, congestion::Side::Source, || {
-                format!("failed traversing directory {:?}", &src)
-            })
-            .await
-            .map_err(|err| Error::new(err, link_summary))?
-        else {
-            break;
-        };
-        let cwd_path = cwd.to_owned();
-        let entry_path = src_entry.path();
-        let entry_name = entry_path.file_name().unwrap();
-        let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
-        let entry_is_dir = entry_kind == EntryKind::Dir;
+    for (entry_name, hint) in src_entries {
+        // classification for the special-skip, symlink-dispatch, and permit pre-acquire decisions
+        // uses the cheap getdents hint; `link_internal` re-classifies authoritatively via fstat
+        // before acting. an unknown hint (DT_UNKNOWN) is treated as a regular file for those, the
+        // same default the old path-based walk used when `file_type()` was unavailable.
+        let entry_kind = hint.unwrap_or(EntryKind::File);
         let entry_is_symlink = entry_kind == EntryKind::Symlink;
-        // compute relative path from source_root for filter matching
-        let relative_path = walk::relative_to_root(&entry_path, source_root);
-        // apply filter if configured
+        let entry_rel = rel_path.join(&entry_name);
+        let entry_path = src_path.join(&entry_name);
+        // the dir-ness that drives the FILTER decision AND the dry-run recurse-vs-leaf branch
+        // below must be AUTHORITATIVE: on a DT_UNKNOWN entry, defaulting to non-dir would wrongly
+        // omit a real directory's whole subtree under an is_dir-dependent filter, or (in dry-run,
+        // even with NO filter) preview it as a leaf and never descend into it. `filter_is_dir`
+        // fstats when a filter is active OR — via force_authoritative — when dry-run needs the
+        // type for control flow. One extra fstat only in those DT_UNKNOWN cases (never follows
+        // symlinks).
+        let entry_is_dir = walk::filter_is_dir(
+            settings.filter.as_ref(),
+            src_dir,
+            &entry_name,
+            hint,
+            settings.dry_run.is_some(),
+        )
+        .await;
+        // apply filter if configured (logical path == entry_rel, since link's filter_base is empty)
         if let Some(skip_result) =
-            walk::should_skip_entry(&settings.filter, relative_path, entry_is_dir)
+            walk::should_skip_entry(&settings.filter, &entry_rel, entry_is_dir)
         {
             if let Some(mode) = settings.dry_run {
                 crate::dry_run::report_skip(&entry_path, &skip_result, mode, entry_kind.label());
@@ -735,7 +1135,7 @@ async fn link_internal(
         }
         // keep-set: a source entry has a destination counterpart that must not be pruned, even
         // when --skip-specials skips copying it (computed before the skip-specials check below).
-        keep_set.record_src(entry_name);
+        keep_set.record_src(&entry_name);
         // skip special files (sockets, FIFOs, devices) when --skip-specials is set
         if settings.copy_settings.skip_specials && entry_kind == EntryKind::Special {
             tracing::debug!("skipping special file {:?}", &entry_path);
@@ -748,8 +1148,7 @@ async fn link_internal(
                     crate::config::DryRunMode::Explain => {
                         println!(
                             "skip special {:?} (unsupported file type: {:?})",
-                            &entry_path,
-                            entry_file_type.unwrap()
+                            &entry_path, entry_kind
                         );
                     }
                 }
@@ -758,172 +1157,190 @@ async fn link_internal(
             prog_track.specials_skipped.inc();
             continue;
         }
-        processed_files.insert(entry_name.to_owned());
-        let dst_path = dst.join(entry_name);
-        let update_path = update.as_ref().map(|s| s.join(entry_name));
-        // handle dry-run mode for link operations
-        if let Some(_mode) = settings.dry_run {
-            crate::dry_run::report_action("link", &entry_path, Some(&dst_path), entry_kind.label());
-            // for directories in dry-run, still need to recurse to show all entries
-            if entry_is_dir {
-                let settings = settings.clone();
-                let source_root = source_root.to_owned();
-                let do_link = || async move {
-                    link_internal(
-                        prog_track,
-                        &cwd_path,
-                        &entry_path,
-                        &dst_path,
-                        &source_root,
-                        &update_path,
-                        &settings,
-                        true,
-                        None,
-                    )
-                    .await
-                };
-                join_set.spawn(do_link());
-            } else if entry_is_symlink {
+        processed_files.insert(entry_name.clone());
+        // dry-run for non-directory entries: report the would-be action without recursing.
+        if settings.dry_run.is_some() && !entry_is_dir {
+            let dst_entry_path = dst_path.join(&entry_name);
+            crate::dry_run::report_action(
+                "link",
+                &entry_path,
+                Some(&dst_entry_path),
+                entry_kind.label(),
+            );
+            if entry_is_symlink {
                 // for symlinks in dry-run, count as symlink (in copy_summary)
                 link_summary.copy_summary.symlinks_created += 1;
             } else {
-                // for files in dry-run, count the "would be created" hard link
+                // for files in dry-run, count the "would be created" hard link.
+                // N.B. when an update tree is present, link_internal decides file-vs-copy
+                // per-entry; the dry-run hint here counts a hard link, matching the old walk which
+                // likewise counted a hard link for a regular-file src entry in dry-run.
                 link_summary.hard_links_created += 1;
             }
             continue;
         }
+        // for regular-file entries, pre-acquire a leaf permit (open-files pool) BEFORE spawning so we
+        // don't create unbounded tasks. `preacquire_leaf_permit` is the shared lifecycle primitive:
+        // its `want` opts in only for a regular-file hint, so directories take none (they recurse and
+        // would deadlock against a saturated pool), symlinks take none (they pass through to copy,
+        // which handles permits internally), and a DT_UNKNOWN hint takes none for the same reason —
+        // exactly the original `hint == Some(File)` policy. `link_internal` re-classifies
+        // authoritatively and either uses the permit (changed-file copy) or drops it.
+        //
+        // Acquire-then-IMMEDIATELY-spawn (the permit is moved into `do_link` and spawned on the next
+        // line, in the same loop step) is load-bearing: collecting a Vec of pre-acquired permits and
+        // spawning later would hold N permits before any task runs and self-deadlock a saturated pool.
+        // This mirrors the single-tree driver's incremental acquire-then-spawn loop
+        // (`walk_driver::walk_dir_contents`, joined via `walk_driver::join_and_fold`).
+        let permit = walk::preacquire_leaf_permit(PermitKind::OpenFile, hint, |h| {
+            h == Some(EntryKind::File)
+        })
+        .await;
+        let src_parent = Arc::clone(src_dir);
+        let dst_parent = dst_dir.map(Arc::clone);
+        let update_parent = update_dir.map(Arc::clone);
         let settings = settings.clone();
-        let source_root = source_root.to_owned();
-        // for regular-file entries, acquire the open file permit BEFORE spawning so
-        // we don't create unbounded tasks. mirrors the pattern in copy.rs.
-        // directories must NOT pre-acquire because they recurse and would deadlock
-        // against a saturated semaphore. symlinks aren't pre-acquired because they
-        // can pass through to copy::copy which handles permits internally.
-        let entry_is_regular_file = entry_file_type.as_ref().is_some_and(|ft| ft.is_file());
-        let open_file_guard = if entry_is_regular_file {
-            Some(throttle::open_file_permit().await)
-        } else {
-            None
-        };
-        let do_link = || async move {
+        let src_root = src_root.to_owned();
+        let dst_root = dst_root.to_owned();
+        let update_root = update_root.map(std::path::Path::to_path_buf);
+        let do_link = move || async move {
+            let update_ref = update_parent
+                .as_ref()
+                .map(|dir| (dir, entry_name.as_os_str()));
             link_internal(
                 prog_track,
-                &cwd_path,
-                &entry_path,
-                &dst_path,
-                &source_root,
-                &update_path,
+                &src_parent,
+                update_ref,
+                dst_parent.as_ref(),
+                &entry_name,
+                &src_root,
+                &dst_root,
+                update_root.as_deref(),
+                &entry_rel,
                 &settings,
                 is_fresh,
-                open_file_guard,
+                permit,
             )
             .await
         };
         join_set.spawn(do_link());
     }
-    // unfortunately ReadDir is opening file-descriptors and there's not a good way to limit this,
-    // one thing we CAN do however is to drop it as soon as we're done with it
-    drop(src_entries);
     // only process update if the path was provided and the directory is present
-    if update_metadata_opt.is_some() {
-        let update = update.as_ref().unwrap();
+    if let Some(update_dir) = update_dir {
+        let update_root = update_root.expect("update_dir present implies update_root present");
         tracing::debug!("process contents of 'update' directory");
-        let mut update_entries = tokio::fs::read_dir(update)
+        let update_entries = update_dir
+            .read_entries()
             .await
-            .with_context(|| format!("cannot open directory {:?} for reading", &update))
+            .with_context(|| {
+                format!(
+                    "cannot open directory {:?} for reading",
+                    update_path_dbg(update_root, rel_path)
+                )
+            })
             .map_err(|err| Error::new(err, link_summary))?;
-        // Iterate through update entries and for each one that's not present in src call "copy".
+        // Iterate through update entries and for each one that's not present in src, copy it.
         //
         // We deliberately do NOT pre-acquire any permit here. Two cycles rule out the
         // straightforward options:
-        //   * `open_file_permit`: copy::copy → copy_internal re-acquires open-files for
-        //     each file; a saturated pool would deadlock the inner acquire if we held one
-        //     across the call.
-        //   * `pending_meta_permit`: with --overwrite, copy::copy → copy_file → rm::rm
-        //     drains pending_meta for child entries (rm.rs spawn loop). N tasks here each
-        //     holding a pending_meta permit would deadlock waiting on each other's inner rm.
+        //   * `open_file_permit`: copy_child → copy_internal re-acquires open-files for each file;
+        //     a saturated pool would deadlock the inner acquire if we held one across the call.
+        //   * `pending_meta_permit`: with --overwrite, copy_child → copy_file_fd → rm::rm drains
+        //     pending_meta for child entries (rm.rs spawn loop). N tasks here each holding a
+        //     pending_meta permit would deadlock waiting on each other's inner rm.
         //
-        // The spawn count at this site is naturally bounded by the number of update-only
-        // entries (user input — typically modest) and per-task tokio overhead is small.
-        // Each spawned task's actual work is throttled by copy::copy's own internal
-        // open-files backpressure inside copy_internal's spawn loop.
-        loop {
-            let Some((update_entry, entry_file_type)) = crate::walk::next_entry_probed(
-                &mut update_entries,
-                congestion::Side::Source,
-                || format!("failed traversing directory {:?}", &update),
+        // The spawn count at this site is naturally bounded by the number of update-only entries
+        // (user input — typically modest). Each spawned task's work is throttled by copy's own
+        // internal open-files backpressure inside copy_internal's spawn loop.
+        for (entry_name, hint) in update_entries {
+            let entry_kind = hint.unwrap_or(EntryKind::File);
+            let entry_rel = rel_path.join(&entry_name);
+            // the FILTER `is_dir` decision must use the AUTHORITATIVE type: on a DT_UNKNOWN update
+            // entry with an is_dir-dependent include filter, defaulting to non-dir would wrongly
+            // omit a real directory's whole subtree. one extra fstat only in that DT_UNKNOWN+filter
+            // case (never follows symlinks).
+            let entry_is_dir = walk::filter_is_dir(
+                settings.filter.as_ref(),
+                update_dir,
+                &entry_name,
+                hint,
+                // used only for the filter decision here — no dry-run recurse-vs-leaf shortcut
+                // (delegate_copy reclassifies authoritatively) — so no need to force an fstat.
+                false,
             )
-            .await
-            .map_err(|err| Error::new(err, link_summary))?
-            else {
-                break;
-            };
-            let entry_path = update_entry.path();
-            let entry_name = entry_path.file_name().unwrap();
+            .await;
+            // evaluate the filter for this update entry at its logical path. This MUST run
+            // regardless of `--delete`: `copy_child` wraps `copy_internal`, which (unlike the old
+            // path-based `copy_with_filter_base`) does NOT re-apply a top-level filter to the entry
+            // it is handed, so without this skip an `--exclude`'d update-only entry would be copied.
+            let skip_result = walk::should_skip_entry(&settings.filter, &entry_rel, entry_is_dir);
+            let filtered_out = skip_result.is_some();
             // keep-set: every filter-passing update entry is materialized at the destination
-            // (entries also in `src` are linked, update-only entries are copied). Computed
-            // before the dedup `continue` so entries also present in `src` are covered — this
-            // is what makes --update-exclusive mirror the update set exactly.
-            if settings.copy_settings.delete.is_some() {
-                let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
-                let relative_path = walk::relative_to_root(src, source_root).join(entry_name);
-                let filtered_out = walk::should_skip_entry(
-                    &settings.filter,
-                    &relative_path,
-                    entry_kind == EntryKind::Dir,
-                )
-                .is_some();
-                if filtered_out {
-                    // The update entry at this name is filtered out, so nothing materializes
-                    // from the update side. `drop_src_when_update_filtered` undoes a src-side
-                    // registration ONLY when the source loop actually materialized something —
-                    // a `--skip-specials` source special stays registered (its dst counterpart
-                    // must be retained per --skip-specials semantics).
-                    keep_set.drop_src_when_update_filtered(
-                        entry_name,
-                        processed_files.contains(entry_name),
-                    );
-                } else {
-                    keep_set.record_update(entry_name);
-                }
+            // (entries also in `src` are linked, update-only entries are copied). Computed before
+            // the dedup `continue` so entries also present in `src` are covered — this is what
+            // makes --update-exclusive mirror the update set exactly.
+            //
+            // A filtered-out update entry contributes NOTHING here and never drops an existing
+            // src-side registration: when the src loop materialized a same-name entry it can only
+            // be a TYPE MISMATCH (a type-independent pattern would have excluded the src too), and
+            // the union semantics keep the src's version (`link_internal` falls back to source-only
+            // handling), so its keep-set entry must survive — pruning it would delete what we just
+            // materialized. Under --update-exclusive `record_src` was a no-op, so there is likewise
+            // nothing to keep. Either way the filtered-out branch leaves the keep-set untouched.
+            if settings.copy_settings.delete.is_some() && !filtered_out {
+                keep_set.record_update(&entry_name);
             }
-            if processed_files.contains(entry_name) {
+            if processed_files.contains(&entry_name) {
                 // we already must have considered this file, skip it
                 continue;
             }
+            // filtered-out update-only entry: skip the delegation entirely (matching the old
+            // `copy_with_filter_base`'s top-level filter), and record the skip in the summary /
+            // counters exactly as the source loop does for a filtered src entry.
+            if let Some(skip_result) = skip_result {
+                let update_entry_path = update_root.join(&entry_rel);
+                if let Some(mode) = settings.dry_run {
+                    crate::dry_run::report_skip(
+                        &update_entry_path,
+                        &skip_result,
+                        mode,
+                        entry_kind.label(),
+                    );
+                }
+                tracing::debug!(
+                    "skipping update entry {:?} due to filter",
+                    &update_entry_path
+                );
+                link_summary = link_summary + skipped_summary_for(entry_kind);
+                entry_kind.inc_skipped(prog_track);
+                continue;
+            }
             tracing::debug!("found a new entry in the 'update' directory");
-            let dst_path = dst.join(entry_name);
-            let update_path = update.join(entry_name);
-            // filter-base for the delegated copy: this update entry's path relative to the
-            // source root, so any --delete pruning inside it matches the include/exclude filter
-            // at the entry's true relative path (e.g. cache/*.log), not relative to the entry.
-            let filter_base = walk::relative_to_root(src, source_root).join(entry_name);
+            let update_entry_path = update_root.join(&entry_rel);
+            let dst_entry_path = dst_path.join(&entry_name);
+            let update_parent = Arc::clone(update_dir);
+            let dst_parent = dst_dir.map(Arc::clone);
             let settings = settings.clone();
-            let do_copy = || async move {
-                let copy_summary = copy::copy_with_filter_base(
+            let do_copy = move || async move {
+                // filter-base for the delegated copy: this update entry's path relative to the
+                // source root, so any --delete pruning inside it matches the include/exclude filter
+                // at the entry's true relative path (e.g. cache/*.log), not relative to the entry.
+                delegate_copy(
                     prog_track,
-                    &update_path,
-                    &dst_path,
-                    &settings.copy_settings,
-                    &settings.preserve,
+                    &update_parent,
+                    dst_parent.as_ref(),
+                    &entry_name,
+                    &update_entry_path,
+                    &dst_entry_path,
+                    &entry_rel,
+                    &settings,
                     is_fresh,
-                    &filter_base,
+                    None,
                 )
                 .await
-                .map_err(|err| {
-                    link_summary.copy_summary = link_summary.copy_summary + err.summary;
-                    Error::new(err.source, link_summary)
-                })?;
-                Ok(Summary {
-                    copy_summary,
-                    ..Default::default()
-                })
             };
             join_set.spawn(do_copy());
         }
-        // unfortunately ReadDir is opening file-descriptors and there's not a good way to limit this,
-        // one thing we CAN do however is to drop it as soon as we're done with it
-        drop(update_entries);
     }
     while let Some(res) = join_set.join_next().await {
         match res {
@@ -931,10 +1348,9 @@ async fn link_internal(
                 Ok(summary) => link_summary = link_summary + summary,
                 Err(error) => {
                     tracing::error!(
-                        "link: {:?} {:?} -> {:?} failed with: {:#}",
-                        src,
-                        update,
-                        dst,
+                        "link: {:?} -> {:?} failed with: {:#}",
+                        src_path,
+                        dst_path,
                         &error
                     );
                     link_summary = link_summary + error.summary;
@@ -953,45 +1369,81 @@ async fn link_internal(
         }
     }
     // rsync-style --delete for rlink: remove destination entries the link operation did not
-    // materialize. `keep_set` holds exactly the materialized names: src ∪ update normally, or
-    // just the update set under --update-exclusive (where source-only entries are not
-    // materialized and so are pruned, matching `rsync --link-dest --delete`).
+    // materialize. `keep_set` holds exactly the materialized names: src ∪ update normally, or just
+    // the update set under --update-exclusive (where source-only entries are not materialized and
+    // so are pruned, matching `rsync --link-dest --delete`).
     if let Some(delete_settings) = &settings.copy_settings.delete {
         if errors.has_errors() {
-            // rsync-style safety: skip pruning when this subtree's link/update pass reported
-            // errors — deleting based on a run that did not fully succeed could remove data
-            // unexpectedly. (rsync likewise skips --delete on I/O errors.)
+            // rsync-style safety: skip pruning when this subtree's link/update pass reported errors
+            // — deleting based on a run that did not fully succeed could remove data unexpectedly.
             tracing::warn!(
                 "skipping --delete pruning of {:?} because the link/update pass reported errors",
-                dst
+                dst_path
             );
         } else {
-            let relative_dir = walk::relative_to_root(src, source_root);
-            match crate::delete::prune_extraneous(
-                prog_track,
-                dst,
-                relative_dir,
-                keep_set
-                    .as_set()
-                    .expect("--delete is on, so DeleteKeepSet is active"),
-                settings.filter.as_ref(),
-                delete_settings,
-                settings.copy_settings.fail_early,
-                settings.dry_run,
-            )
-            .await
-            {
-                Ok(rm_summary) => {
-                    link_summary.copy_summary.rm_summary =
-                        link_summary.copy_summary.rm_summary + rm_summary;
-                }
-                Err(err) => {
-                    link_summary.copy_summary.rm_summary =
-                        link_summary.copy_summary.rm_summary + err.summary;
-                    if settings.copy_settings.fail_early {
-                        return Err(Error::new(err.source, link_summary));
+            // the prune scan runs through the destination directory's own pinned fd. In a real link
+            // we already hold it (`dst_dir`); in --dry-run the create-or-overwrite step is skipped,
+            // so open it `O_NOFOLLOW|O_DIRECTORY` (dereference=false) — a symlink or non-directory
+            // fails closed and prune is skipped, never following the symlink to delete a tree
+            // OUTSIDE the destination. A missing dir likewise skips.
+            let prune_dir: Option<Arc<Dir>> = match dst_dir {
+                Some(dir) => Some(Arc::clone(dir)),
+                None => {
+                    match Dir::open_root_dir(dst_path, false, congestion::Side::Destination).await {
+                        Ok(dir) => Some(Arc::new(dir)),
+                        Err(err)
+                            if matches!(
+                                err.kind(),
+                                std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+                            ) || err.raw_os_error() == Some(libc::ELOOP)
+                                || err.raw_os_error() == Some(libc::ENOTDIR) =>
+                        {
+                            tracing::debug!(
+                                "skipping --delete pruning of {:?}: not a real directory",
+                                dst_path
+                            );
+                            None
+                        }
+                        Err(err) => {
+                            let err = anyhow::Error::new(err).context(format!(
+                                "cannot open destination {dst_path:?} for delete scan"
+                            ));
+                            if settings.copy_settings.fail_early {
+                                return Err(Error::new(err, link_summary));
+                            }
+                            errors.push(err);
+                            None
+                        }
                     }
-                    errors.push(err.source);
+                }
+            };
+            if let Some(prune_dir) = prune_dir {
+                match crate::delete::prune_extraneous(
+                    prog_track,
+                    &prune_dir,
+                    rel_path,
+                    keep_set
+                        .as_set()
+                        .expect("--delete is on, so DeleteKeepSet is active"),
+                    settings.filter.as_ref(),
+                    delete_settings,
+                    settings.copy_settings.fail_early,
+                    settings.dry_run,
+                )
+                .await
+                {
+                    Ok(rm_summary) => {
+                        link_summary.copy_summary.rm_summary =
+                            link_summary.copy_summary.rm_summary + rm_summary;
+                    }
+                    Err(err) => {
+                        link_summary.copy_summary.rm_summary =
+                            link_summary.copy_summary.rm_summary + err.summary;
+                        if settings.copy_settings.fail_early {
+                            return Err(Error::new(err.source, link_summary));
+                        }
+                        errors.push(err.source);
+                    }
                 }
             }
         }
@@ -1007,13 +1459,12 @@ async fn link_internal(
         || link_summary.copy_summary.files_copied > 0
         || link_summary.copy_summary.symlinks_created > 0
         || child_dirs_created > 0;
-    let relative_path = walk::relative_to_root(src, source_root);
-    let is_root = src == source_root;
+    let is_root = rel_path.as_os_str().is_empty();
     match check_empty_dir_cleanup(
         settings.filter.as_ref(),
         we_created_this_dir,
         anything_linked,
-        relative_path,
+        rel_path,
         is_root,
         settings.dry_run.is_some(),
     ) {
@@ -1021,7 +1472,7 @@ async fn link_internal(
         EmptyDirAction::DryRunSkip => {
             tracing::debug!(
                 "dry-run: directory {:?} would not be created (nothing to link inside)",
-                &dst
+                dst_path
             );
             link_summary.copy_summary.directories_created = 0;
             return Ok(link_summary);
@@ -1029,15 +1480,24 @@ async fn link_internal(
         EmptyDirAction::Remove => {
             tracing::debug!(
                 "directory {:?} has nothing to link inside, removing empty directory",
-                &dst
+                dst_path
             );
-            match crate::walk::run_metadata_probed(
-                congestion::Side::Destination,
-                congestion::MetadataOp::RmDir,
-                tokio::fs::remove_dir(dst),
-            )
-            .await
-            {
+            // remove the empty directory fd-relative, through its parent dir handle: `rmdir_at`
+            // operates on `dst_name` within the held `dst_parent` fd (never by path) and only
+            // succeeds on an empty directory, so it is contained to `dst_parent`. `dst_parent` is
+            // always Some here (None only in dry-run, where this arm is unreachable).
+            let rmdir_result = match dst_parent {
+                Some(dst_parent) => dst_parent.rmdir_at(dst_name).await,
+                None => {
+                    crate::walk::run_metadata_probed(
+                        congestion::Side::Destination,
+                        congestion::MetadataOp::RmDir,
+                        tokio::fs::remove_dir(dst_path),
+                    )
+                    .await
+                }
+            };
+            match rmdir_result {
                 Ok(()) => {
                     link_summary.copy_summary.directories_created = 0;
                     return Ok(link_summary);
@@ -1046,7 +1506,7 @@ async fn link_internal(
                     // removal failed (not empty, permission error, etc.) — keep directory
                     tracing::debug!(
                         "failed to remove empty directory {:?}: {:#}, keeping",
-                        &dst,
+                        dst_path,
                         &err
                     );
                     // fall through to apply metadata
@@ -1054,29 +1514,33 @@ async fn link_internal(
             }
         }
     }
-    // apply directory metadata regardless of whether all children linked successfully.
-    // the directory itself was created earlier in this function (we would have returned
-    // early if create_dir failed), so we should preserve the source metadata.
-    // skip metadata setting in dry-run mode since directory wasn't actually created
+    // apply directory metadata regardless of whether all children linked successfully. the
+    // directory itself was created/opened above. skipped in dry-run (no directory exists). prefer
+    // the update directory's metadata when an update tree is present at this level (it is the
+    // materialized version, matching the old `update_metadata_opt` preference), else the source
+    // directory's. The metadata is read from the SAME fd whose contents were enumerated (read-side
+    // fidelity, docs/tocttou.md), not the classify handles.
     tracing::debug!("set 'dst' directory metadata");
-    let metadata_result = if settings.dry_run.is_some() {
-        Ok(()) // skip metadata setting in dry-run mode
-    } else {
-        let preserve_metadata = if let Some(update_metadata) = update_metadata_opt.as_ref() {
-            update_metadata
-        } else {
-            &src_metadata
-        };
-        preserve::set_dir_metadata(&settings.preserve, preserve_metadata, dst).await
+    let metadata_result = match dst_dir {
+        Some(dst_dir) => {
+            let meta_dir = update_dir.unwrap_or(src_dir);
+            match meta_dir.meta().await {
+                Ok(preserve_meta) => {
+                    crate::safedir::set_dir_metadata_fd(&settings.preserve, &preserve_meta, dst_dir)
+                        .await
+                }
+                Err(e) => Err(e),
+            }
+        }
+        None => Ok(()),
     };
     if errors.has_errors() {
         // child failures take precedence - log metadata error if it also failed
         if let Err(metadata_err) = metadata_result {
             tracing::error!(
-                "link: {:?} {:?} -> {:?} failed to set directory metadata: {:#}",
-                src,
-                update,
-                dst,
+                "link: {:?} -> {:?} failed to set directory metadata: {:#}",
+                src_path,
+                dst_path,
                 &metadata_err
             );
         }
@@ -1084,12 +1548,27 @@ async fn link_internal(
         return Err(Error::new(errors.into_error().unwrap(), link_summary));
     }
     // no child failures, so metadata error is the primary error
-    metadata_result.map_err(|err| Error::new(err, link_summary))?;
+    metadata_result
+        .with_context(|| format!("failed setting directory metadata on {:?}", dst_path))
+        .map_err(|err| Error::new(err, link_summary))?;
     Ok(link_summary)
+}
+
+/// Reconstruct an update entry's path purely for a diagnostic message.
+fn update_path_dbg(
+    update_root: &std::path::Path,
+    rel_path: &std::path::Path,
+) -> std::path::PathBuf {
+    if rel_path.as_os_str().is_empty() {
+        update_root.to_path_buf()
+    } else {
+        update_root.join(rel_path)
+    }
 }
 
 #[cfg(test)]
 mod link_tests {
+    use crate::rm;
     use crate::testutils;
     use std::os::unix::fs::PermissionsExt;
     use tracing_test::traced_test;
@@ -1166,43 +1645,45 @@ mod link_tests {
         }
 
         #[test]
-        fn drop_src_when_update_filtered_drops_materialized_src_entry() {
-            // The type-change case: src had a regular file at `node`, update has an excluded
-            // dir at `node/`. Source materialized — drop the keep-set entry so the stale dst
-            // is pruned.
+        fn filtered_out_update_keeps_materialized_src_entry_in_normal_mode() {
+            // Type-mismatch under normal `--update` (union): src had a regular file at `node`,
+            // update has a dir at `node/` excluded by the dir-only `node/` pattern. The src's
+            // version of the name stands (`link_internal` falls back to source-only handling), so
+            // the keep-set entry recorded by the source loop MUST survive — pruning it would
+            // delete the file we just materialized. The filtered-out update branch is therefore a
+            // no-op on the keep-set: `node` stays.
             let d = delete_on();
             let mut k = DeleteKeepSet::new(Some(&d), false, true);
             k.record_src(OsStr::new("node"));
-            assert!(k.as_set().unwrap().contains(OsStr::new("node")));
-            k.drop_src_when_update_filtered(OsStr::new("node"), /* src_materialized */ true);
-            assert!(!k.as_set().unwrap().contains(OsStr::new("node")));
+            // (the update loop's filtered-out branch records nothing and removes nothing)
+            assert!(
+                k.as_set().unwrap().contains(OsStr::new("node")),
+                "src entry must stay in the keep-set when its update counterpart is filtered out"
+            );
         }
 
         #[test]
-        fn drop_src_when_update_filtered_keeps_skipped_special() {
+        fn filtered_out_update_keeps_skipped_special() {
             // The skip-special case: source loop ran `record_src` but never reached
             // `processed_files.insert` (it `continue`d on the skip-special branch). The dst
-            // counterpart must be retained per --skip-specials semantics.
+            // counterpart must be retained per --skip-specials semantics, and a filtered-out
+            // update entry at the same name does not change that.
             let d = delete_on();
             let mut k = DeleteKeepSet::new(Some(&d), false, true);
             k.record_src(OsStr::new("pipe"));
-            k.drop_src_when_update_filtered(OsStr::new("pipe"), /* src_materialized */ false);
             assert!(k.as_set().unwrap().contains(OsStr::new("pipe")));
         }
 
         #[test]
-        fn drop_src_when_update_filtered_no_op_when_delete_off() {
-            let mut k = DeleteKeepSet::new(None, false, false);
-            // Should not panic, and as_set stays None.
-            k.drop_src_when_update_filtered(OsStr::new("foo"), true);
-            assert!(k.as_set().is_none());
-        }
-
-        #[test]
-        fn full_directory_pass_matches_old_keep_set_semantics() {
+        fn full_directory_pass_keep_set_union_semantics() {
             // Models the union of src + update under plain `--delete --update` (no
             // --update-exclusive). Names: src has `keep`, `pipe` (special, skipped),
-            // `node` (file). update has `from_upd`, `node` (excluded dir).
+            // `node` (file). update has `from_upd`, `node` (a dir excluded by the dir-only
+            // `node/` pattern). Under union semantics the excluded update `node/` does not
+            // displace the src `node` file: `link_internal` materializes the src version, so
+            // `node` STAYS in the keep-set (the filtered-out update branch records/removes
+            // nothing). This is the corrected behavior versus the old type-mismatch bug, where
+            // the excluded update dir was copied AND the src keep-set entry was dropped.
             let d = delete_on();
             let mut k = DeleteKeepSet::new(Some(&d), false, true);
 
@@ -1211,16 +1692,16 @@ mod link_tests {
             k.record_src(OsStr::new("pipe")); // --skip-specials: continues, processed_files NOT populated
             k.record_src(OsStr::new("node"));
 
-            // update loop
+            // update loop: only filter-passing update entries are recorded; `node` is filtered out
+            // and so contributes nothing (and does not drop the src `node`).
             k.record_update(OsStr::new("from_upd"));
-            // `node` filtered out in update; processed_files HAS `node` (source materialized it).
-            k.drop_src_when_update_filtered(OsStr::new("node"), true);
 
             let set: std::collections::HashSet<OsString> = k.as_set().unwrap().clone();
-            let expected: std::collections::HashSet<OsString> = ["keep", "pipe", "from_upd"]
-                .into_iter()
-                .map(OsString::from)
-                .collect();
+            let expected: std::collections::HashSet<OsString> =
+                ["keep", "pipe", "node", "from_upd"]
+                    .into_iter()
+                    .map(OsString::from)
+                    .collect();
             assert_eq!(set, expected);
         }
     }
@@ -1282,6 +1763,85 @@ mod link_tests {
             testutils::FileEqualityCheck::Timestamp,
         )
         .await?;
+        Ok(())
+    }
+
+    // Regression: a source operand whose final component is `.`/`..` (e.g. `rlink tree/.. dst`)
+    // must be linked, not rejected — `split_root_operand` canonicalizes it. Uses `tree/sub/..`
+    // (== `tree`) rather than `.` to avoid touching the process-wide cwd.
+    #[tokio::test]
+    async fn links_dot_dot_source_operand() -> Result<(), anyhow::Error> {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = testutils::create_temp_dir().await?;
+        let tree = tmp.join("tree");
+        tokio::fs::create_dir(&tree).await?;
+        tokio::fs::write(tree.join("a.txt"), "hello").await?;
+        tokio::fs::create_dir(tree.join("sub")).await?;
+        let src = tree.join("sub").join(".."); // == tree
+        let dst = tmp.join("dst");
+        let summary = link(
+            &PROGRESS,
+            &tmp,
+            &src,
+            &dst,
+            &None,
+            &common_settings(false, false),
+            false,
+        )
+        .await?;
+        assert_eq!(
+            summary.hard_links_created, 1,
+            "the dot-dot source's file must be hard-linked"
+        );
+        assert!(
+            dst.join("sub").is_dir(),
+            "the dot-dot source's subdir must be created"
+        );
+        // the dst file shares the src inode (a hard link, not a copy).
+        let src_ino = std::fs::metadata(tree.join("a.txt"))?.ino();
+        let dst_ino = std::fs::metadata(dst.join("a.txt"))?.ino();
+        assert_eq!(src_ino, dst_ino, "dst must be a hard link to the src inode");
+        Ok(())
+    }
+
+    // Regression: an `--update` operand whose final component is `.`/`..` (e.g.
+    // `rlink --update tree/.. src dst`) must be accepted, not rejected — the update tree is a READ
+    // tree, so `split_root_operand` canonicalizes it the same as the source. Uses `tree/sub/..`
+    // (== `tree`) rather than `.` to avoid touching the process-wide cwd; src == update == tree so
+    // the file links deterministically from the update tree.
+    #[tokio::test]
+    async fn links_dot_dot_update_operand() -> Result<(), anyhow::Error> {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = testutils::create_temp_dir().await?;
+        let tree = tmp.join("tree");
+        tokio::fs::create_dir(&tree).await?;
+        tokio::fs::write(tree.join("a.txt"), "hello").await?;
+        tokio::fs::create_dir(tree.join("sub")).await?;
+        let dst = tmp.join("dst");
+        // the --update operand spelled with a trailing `..` (== tree); it must be canonicalized and
+        // used, not rejected with "has no parent directory or file name".
+        let update_operand = tree.join("sub").join(".."); // == tree
+        let summary = link(
+            &PROGRESS,
+            &tmp,
+            &tree,
+            &dst,
+            &Some(update_operand),
+            &common_settings(false, false),
+            false,
+        )
+        .await?;
+        assert_eq!(
+            summary.hard_links_created, 1,
+            "the file must be hard-linked from the dot-dot update tree"
+        );
+        // the dst file shares the update tree's inode (linked from it, not copied).
+        let update_ino = std::fs::metadata(tree.join("a.txt"))?.ino();
+        let dst_ino = std::fs::metadata(dst.join("a.txt"))?.ino();
+        assert_eq!(
+            update_ino, dst_ino,
+            "dst must be hard-linked from the update tree inode"
+        );
         Ok(())
     }
 
@@ -2580,6 +3140,340 @@ mod link_tests {
             );
             Ok(())
         }
+
+        /// Regression: an update-only entry matching an `--exclude` pattern must NOT be copied to
+        /// the destination when `--delete` is OFF. The fd-based link delegates update-only entries
+        /// to `copy::copy_child` (which wraps `copy_internal` and does not re-apply a top-level
+        /// filter), so the update loop must evaluate the filter itself — independently of `--delete`
+        /// — and skip the delegation, matching the old path-based `copy_with_filter_base`.
+        #[tokio::test]
+        #[traced_test]
+        async fn update_only_excluded_entry_not_copied_without_delete() -> Result<(), anyhow::Error>
+        {
+            let test_path = testutils::create_temp_dir().await?;
+            // src has `keep.txt`; update has `keep.txt` (also in src) plus update-only `extra.txt`
+            // and `wanted.txt`. With `--exclude extra.txt` and NO `--delete`, `extra.txt` must be
+            // skipped while `wanted.txt` is copied.
+            let src = test_path.join("src");
+            let update = test_path.join("update");
+            let dst = test_path.join("dst");
+            tokio::fs::create_dir(&src).await?;
+            tokio::fs::create_dir(&update).await?;
+            tokio::fs::write(src.join("keep.txt"), "keep").await?;
+            tokio::fs::write(update.join("keep.txt"), "keep").await?;
+            tokio::fs::write(update.join("extra.txt"), "EXCLUDED").await?;
+            tokio::fs::write(update.join("wanted.txt"), "wanted").await?;
+
+            let mut filter = FilterSettings::new();
+            filter.add_exclude("extra.txt").unwrap();
+            let mut settings = common_settings(false, false);
+            settings.filter = Some(filter);
+            // --delete is OFF (the bug only manifests with delete off).
+            assert!(settings.copy_settings.delete.is_none());
+
+            let summary = link(
+                &PROGRESS,
+                &test_path,
+                &src,
+                &dst,
+                &Some(update.clone()),
+                &settings,
+                false,
+            )
+            .await?;
+
+            assert!(
+                !dst.join("extra.txt").exists(),
+                "update-only entry matching --exclude must NOT be copied when --delete is off"
+            );
+            assert!(
+                dst.join("wanted.txt").exists(),
+                "non-excluded update-only entry should be copied"
+            );
+            assert!(dst.join("keep.txt").exists(), "shared entry should exist");
+            assert_eq!(
+                summary.copy_summary.files_skipped, 1,
+                "the excluded update-only file should be counted skipped"
+            );
+            Ok(())
+        }
+
+        /// Verify a hard-link relationship between two paths by inode + device identity.
+        fn are_hardlinked(a: &std::path::Path, b: &std::path::Path) -> bool {
+            use std::os::unix::fs::MetadataExt;
+            match (std::fs::symlink_metadata(a), std::fs::symlink_metadata(b)) {
+                (Ok(ma), Ok(mb)) => ma.ino() == mb.ino() && ma.dev() == mb.dev(),
+                _ => false,
+            }
+        }
+
+        /// The chatgpt-codex re-review scenario (PR #247): in rlink's dual-tree walk the source
+        /// loop evaluates the filter against the SOURCE entry's type. When `src/cache` is a FILE
+        /// and `update/cache` is a DIRECTORY, a dir-only exclude `cache/` passes the src file (a
+        /// dir-only pattern doesn't match a file), so `link_internal` runs and hits its
+        /// type-mismatch branch. Before the fix that branch unconditionally delegated a copy of the
+        /// UPDATE entry — and `copy_child` does not re-apply the top-level filter to the delegated
+        /// root — so the excluded `cache/` directory was copied. The fix re-checks the filter using
+        /// the UPDATE entry's type; the excluded update is dropped and, under union (`--update`)
+        /// semantics, the src `cache` FILE is materialized instead.
+        ///
+        /// This test FAILS without the fix: `dst/cache` is created as the excluded update directory
+        /// (and the src file is not materialized).
+        #[tokio::test]
+        #[traced_test]
+        async fn type_mismatch_excluded_update_dir_not_copied_src_file_kept()
+        -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let src = test_path.join("src");
+            let update = test_path.join("update");
+            let dst = test_path.join("dst");
+            tokio::fs::create_dir(&src).await?;
+            tokio::fs::create_dir(&update).await?;
+            // src `cache` is a FILE; update `cache` is a DIRECTORY (the type mismatch).
+            tokio::fs::write(src.join("cache"), "SRC-FILE").await?;
+            tokio::fs::create_dir(update.join("cache")).await?;
+            tokio::fs::write(update.join("cache").join("inner.dat"), "EXCLUDED").await?;
+            // a non-conflicting shared file to confirm normal linking still happens.
+            tokio::fs::write(src.join("keep.txt"), "keep").await?;
+            tokio::fs::write(update.join("keep.txt"), "keep").await?;
+            // pin an identical mtime (incl. nsec) on both `keep.txt` copies so the
+            // size+mtime `update_compare` deterministically treats them as unchanged and
+            // hard-links from src. Two separate writes can otherwise land on different
+            // nanoseconds, flakily comparing as changed and copying instead (the bytes are
+            // identical either way) — see PR #247 CI flake on test-musl-debug.
+            let keep_mtime = filetime::FileTime::from_unix_time(1_700_000_000, 0);
+            filetime::set_file_mtime(src.join("keep.txt"), keep_mtime)?;
+            filetime::set_file_mtime(update.join("keep.txt"), keep_mtime)?;
+
+            let mut filter = FilterSettings::new();
+            filter.add_exclude("cache/").unwrap(); // dir-only: matches a dir `cache`, not a file
+            let mut settings = common_settings(false, false);
+            settings.filter = Some(filter);
+            assert!(settings.copy_settings.delete.is_none());
+
+            let summary = link(
+                &PROGRESS,
+                &test_path,
+                &src,
+                &dst,
+                &Some(update.clone()),
+                &settings,
+                false,
+            )
+            .await?;
+
+            // the excluded update directory must NOT be copied.
+            assert!(
+                !dst.join("cache").join("inner.dat").exists(),
+                "excluded update directory `cache/` must not be copied"
+            );
+            assert!(
+                !dst.join("cache").is_dir(),
+                "dst/cache must not be the excluded update directory"
+            );
+            // the src `cache` FILE stands (union semantics) and is hard-linked from src.
+            assert!(
+                dst.join("cache").is_file(),
+                "src `cache` file must be materialized when the update dir is excluded"
+            );
+            assert_eq!(
+                tokio::fs::read_to_string(dst.join("cache")).await?,
+                "SRC-FILE"
+            );
+            assert!(
+                are_hardlinked(&src.join("cache"), &dst.join("cache")),
+                "the src `cache` file must be hard-linked into the destination"
+            );
+            assert!(
+                dst.join("keep.txt").exists(),
+                "shared entry should still link"
+            );
+            // `cache` (src file, union) and `keep.txt` (unchanged) are both hard-linked from src;
+            // nothing is copied. Exactly one directory is created — the `dst` root — proving the
+            // excluded `cache/` subtree added no directory.
+            assert_eq!(summary.hard_links_created, 2);
+            assert_eq!(summary.copy_summary.files_copied, 0);
+            assert_eq!(
+                summary.copy_summary.directories_created, 1,
+                "only the dst root is created; the excluded `cache/` dir must not be"
+            );
+            Ok(())
+        }
+
+        /// The REVERSE type mismatch (the symmetric code path): `src/data` is a DIRECTORY and
+        /// `update/data` is a FILE. The dir-only include `data/` matches the directory form of the
+        /// name but not the file form, and `data/**` includes the directory's contents. So the src
+        /// `data` directory (and its `inner.txt`) passes the filter and the src loop spawns the
+        /// worker, while the update `data` FILE is `ExcludedByDefault` (no include matches a file
+        /// named `data`). The type-mismatch branch re-checks the filter using the update FILE's
+        /// type, finds it excluded, and (union semantics) materializes the src DIRECTORY instead of
+        /// copying the excluded update file. Without the fix the excluded update file would replace
+        /// the src directory at the destination.
+        #[tokio::test]
+        #[traced_test]
+        async fn reverse_type_mismatch_excluded_update_file_not_copied_src_dir_kept()
+        -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let src = test_path.join("src");
+            let update = test_path.join("update");
+            let dst = test_path.join("dst");
+            tokio::fs::create_dir(&src).await?;
+            tokio::fs::create_dir(&update).await?;
+            // src `data` is a DIRECTORY (with a file inside); update `data` is a FILE.
+            tokio::fs::create_dir(src.join("data")).await?;
+            tokio::fs::write(src.join("data").join("inner.txt"), "SRC-DIR-CONTENT").await?;
+            tokio::fs::write(update.join("data"), "UPDATE-FILE-EXCLUDED").await?;
+
+            // `data/` (dir-only) includes the directory form of the name; `data/**` includes its
+            // contents. The update FILE `data` matches neither and is excluded by type — the
+            // symmetric form of the bot's scenario.
+            let mut filter = FilterSettings::new();
+            filter.add_include("data/").unwrap();
+            filter.add_include("data/**").unwrap();
+            let mut settings = common_settings(false, false);
+            settings.filter = Some(filter);
+            assert!(settings.copy_settings.delete.is_none());
+
+            link(
+                &PROGRESS,
+                &test_path,
+                &src,
+                &dst,
+                &Some(update.clone()),
+                &settings,
+                false,
+            )
+            .await?;
+
+            // the excluded update FILE must NOT overwrite/replace the src directory.
+            assert!(
+                dst.join("data").is_dir(),
+                "src `data` directory must be materialized when the update file is excluded"
+            );
+            assert!(
+                dst.join("data").join("inner.txt").exists(),
+                "src directory contents must be linked through"
+            );
+            assert!(
+                are_hardlinked(
+                    &src.join("data").join("inner.txt"),
+                    &dst.join("data").join("inner.txt")
+                ),
+                "src directory's file must be hard-linked into the destination"
+            );
+            Ok(())
+        }
+
+        /// `--update-exclusive` + the type-mismatch scenario: src `cache` is a FILE, update `cache`
+        /// is a DIRECTORY excluded by `cache/`. Under exclusive mode only the (filter-passing)
+        /// update set materializes, so an EXCLUDED update entry materializes NOTHING — the src is
+        /// not materialized (it is not a fallback under exclusivity), and no stale src copy is left.
+        /// This mirrors the NotFound-under-exclusive case (`return Ok(Default::default())`).
+        #[tokio::test]
+        #[traced_test]
+        async fn type_mismatch_excluded_update_dir_update_exclusive_materializes_nothing()
+        -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let src = test_path.join("src");
+            let update = test_path.join("update");
+            let dst = test_path.join("dst");
+            tokio::fs::create_dir(&src).await?;
+            tokio::fs::create_dir(&update).await?;
+            tokio::fs::write(src.join("cache"), "SRC-FILE").await?;
+            tokio::fs::create_dir(update.join("cache")).await?;
+            tokio::fs::write(update.join("cache").join("inner.dat"), "EXCLUDED").await?;
+            // a filter-passing update-only file proves the rest of the exclusive copy still works.
+            tokio::fs::write(update.join("wanted.txt"), "wanted").await?;
+
+            let mut filter = FilterSettings::new();
+            filter.add_exclude("cache/").unwrap();
+            let mut settings = common_settings(false, false);
+            settings.update_exclusive = true;
+            settings.filter = Some(filter);
+
+            link(
+                &PROGRESS,
+                &test_path,
+                &src,
+                &dst,
+                &Some(update.clone()),
+                &settings,
+                false,
+            )
+            .await?;
+
+            assert!(
+                !dst.join("cache").exists(),
+                "under --update-exclusive an excluded-update type-mismatch must materialize nothing \
+                 (no excluded dir, no stale src file)"
+            );
+            assert!(
+                dst.join("wanted.txt").exists(),
+                "filter-passing update-only entries are still copied under --update-exclusive"
+            );
+            Ok(())
+        }
+
+        /// `--delete` + the type-mismatch scenario under normal `--update`: the src `cache` FILE is
+        /// materialized (union) and MUST be retained by the keep-set — never materialized-then-pruned
+        /// — while a pre-existing extraneous dst entry is removed. Also confirms the excluded update
+        /// directory leaves no leftover. `prune_extraneous` would otherwise prune the dst `cache`
+        /// file (a dir-only `cache/` exclude does not protect a file), so correctness depends on
+        /// `cache` staying in the keep-set.
+        #[tokio::test]
+        #[traced_test]
+        async fn type_mismatch_excluded_update_dir_delete_keeps_src_file()
+        -> Result<(), anyhow::Error> {
+            let test_path = testutils::create_temp_dir().await?;
+            let src = test_path.join("src");
+            let update = test_path.join("update");
+            let dst = test_path.join("dst");
+            tokio::fs::create_dir(&src).await?;
+            tokio::fs::create_dir(&update).await?;
+            tokio::fs::create_dir(&dst).await?;
+            tokio::fs::write(src.join("cache"), "SRC-FILE").await?;
+            tokio::fs::create_dir(update.join("cache")).await?;
+            tokio::fs::write(update.join("cache").join("inner.dat"), "EXCLUDED").await?;
+            // pre-existing extraneous dst entry that --delete should prune.
+            tokio::fs::write(dst.join("stale.txt"), "stale").await?;
+
+            let mut filter = FilterSettings::new();
+            filter.add_exclude("cache/").unwrap();
+            let mut settings = common_settings(false, true); // --delete implies --overwrite
+            settings.filter = Some(filter);
+            settings.copy_settings.delete = Some(copy::DeleteSettings {
+                delete_excluded: false,
+            });
+
+            link(
+                &PROGRESS,
+                &test_path,
+                &src,
+                &dst,
+                &Some(update.clone()),
+                &settings,
+                false,
+            )
+            .await?;
+
+            assert!(
+                dst.join("cache").is_file(),
+                "src `cache` file must survive --delete (kept in the keep-set, not pruned)"
+            );
+            assert_eq!(
+                tokio::fs::read_to_string(dst.join("cache")).await?,
+                "SRC-FILE"
+            );
+            assert!(
+                !dst.join("cache").is_dir(),
+                "the excluded update directory must leave no leftover"
+            );
+            assert!(
+                !dst.join("stale.txt").exists(),
+                "extraneous dst entry must be pruned by --delete"
+            );
+            Ok(())
+        }
     }
     mod dry_run_tests {
         use super::*;
@@ -3151,6 +4045,131 @@ mod link_tests {
                 let content = tokio::fs::read_to_string(dst.join(format!("u{}", i))).await?;
                 assert_eq!(content, format!("upd-{}", i));
             }
+            Ok(())
+        }
+    }
+
+    /// TOCTOU hardening: a source entry being hard-linked is concurrently swapped between a real
+    /// regular file and a symlink to a sentinel OUTSIDE the source tree. rlink classifies the entry
+    /// via `child` (fstat) before acting and links the pinned inode inode-exactly
+    /// (`hard_link_handle_at`), so a swap is either caught (the entry is linked/copied as a symlink,
+    /// or the op fails closed) or the real file is hard-linked. The sentinel's secret content must
+    /// NEVER appear at the destination as a regular file, and the sentinel inode must never gain a
+    /// new hard link.
+    mod race_tests {
+        use super::*;
+
+        // Repeatedly swap `dir/entry_name` between a real regular file (content `REAL_CONTENT`) and
+        // a symlink pointing at `sentinel`, using rename so each individual state is atomic. Runs on
+        // a dedicated OS thread so it makes progress regardless of the tokio runtime's scheduling.
+        fn spawn_file_symlink_swapper(
+            dir: std::path::PathBuf,
+            entry_name: &'static str,
+            sentinel: std::path::PathBuf,
+            stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        ) -> std::thread::JoinHandle<()> {
+            std::thread::spawn(move || {
+                let entry = dir.join(entry_name);
+                let staged_real = dir.join("__staged_real");
+                let staged_link = dir.join("__staged_link");
+                while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    let _ = std::fs::remove_file(&staged_real);
+                    if std::fs::write(&staged_real, b"REAL_CONTENT").is_err() {
+                        continue;
+                    }
+                    let _ = std::fs::rename(&staged_real, &entry);
+                    let _ = std::fs::remove_file(&staged_link);
+                    let _ = std::os::unix::fs::symlink(&sentinel, &staged_link);
+                    let _ = std::fs::rename(&staged_link, &entry);
+                }
+            })
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        #[traced_test]
+        async fn hard_link_entry_swap_never_leaks_sentinel() -> Result<(), anyhow::Error> {
+            let tmp_dir = testutils::create_temp_dir().await?;
+            let test_path = tmp_dir.as_path();
+            // sentinel lives OUTSIDE the source tree with distinctive content; we also track its
+            // hard-link count to prove `linkat(flags=0)` never gives it a new hard link.
+            let sentinel = test_path.join("sentinel_secret");
+            tokio::fs::write(&sentinel, "SENTINEL_SECRET_CONTENT").await?;
+            let sentinel_links_before = {
+                use std::os::unix::fs::MetadataExt;
+                tokio::fs::symlink_metadata(&sentinel).await?.nlink()
+            };
+            let src = test_path.join("src");
+            let sub = src.join("sub");
+            tokio::fs::create_dir(&src).await?;
+            tokio::fs::create_dir(&sub).await?;
+            tokio::fs::write(sub.join("entry"), "REAL_CONTENT").await?;
+
+            let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let swapper =
+                spawn_file_symlink_swapper(sub.clone(), "entry", sentinel.clone(), stop.clone());
+
+            // overwrite=true so each iteration's destination need not be empty; no update tree, so
+            // `src/sub/entry` takes the hard-link path (or copy-as-symlink when caught mid-swap).
+            let settings = common_settings(false, true);
+            let mut caught_swaps = 0usize;
+            let mut linked_real = 0usize;
+            for i in 0..200 {
+                let dst = test_path.join(format!("dst_{i}"));
+                let result = tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    link(&PROGRESS, test_path, &src, &dst, &None, &settings, false),
+                )
+                .await
+                .expect("link must not hang under concurrent swapping");
+                match result {
+                    Ok(_) => {}
+                    Err(_) => caught_swaps += 1, // a swap was caught mid-link (failed closed)
+                }
+                // CORE ASSERTION: if a regular file landed at the destination it holds the REAL
+                // content — never the sentinel's secret. The entry may instead be a symlink
+                // (linkat made a hard link to the symlink inode, or copy reproduced the symlink) or
+                // be absent. A symlink that resolves to the sentinel is fine: it is a link, not a
+                // copy of the secret bytes, and it did not give the sentinel a new hard link.
+                let entry_dst = dst.join("sub").join("entry");
+                if let Ok(md) = tokio::fs::symlink_metadata(&entry_dst).await
+                    && md.file_type().is_file()
+                {
+                    let content = tokio::fs::read_to_string(&entry_dst).await?;
+                    assert_ne!(
+                        content, "SENTINEL_SECRET_CONTENT",
+                        "iteration {i}: sentinel content leaked into the destination as a regular file"
+                    );
+                    assert_eq!(
+                        content, "REAL_CONTENT",
+                        "iteration {i}: a regular destination file must hold the real content"
+                    );
+                    linked_real += 1;
+                }
+                let _ = tokio::fs::remove_dir_all(&dst).await;
+            }
+
+            stop.store(true, std::sync::atomic::Ordering::Relaxed);
+            swapper.join().expect("swapper thread panicked");
+
+            // the sentinel must never have gained a hard link from a `linkat` that followed the
+            // swapped-in symlink (flags=0 links the symlink inode itself, not its target).
+            let sentinel_links_after = {
+                use std::os::unix::fs::MetadataExt;
+                tokio::fs::symlink_metadata(&sentinel).await?.nlink()
+            };
+            assert_eq!(
+                sentinel_links_after, sentinel_links_before,
+                "the sentinel file must never gain a hard link (linkat must not follow the symlink)"
+            );
+            // sanity: the run did observable work (this is not the safety assertion — the safety
+            // assertions above hold on every iteration regardless of timing).
+            tracing::info!(
+                "link file/symlink swap: caught_swaps={caught_swaps}, linked_real={linked_real}"
+            );
+            assert!(
+                caught_swaps + linked_real > 0,
+                "expected at least one observable outcome across 200 iterations"
+            );
             Ok(())
         }
     }

--- a/common/src/preserve.rs
+++ b/common/src/preserve.rs
@@ -1,8 +1,6 @@
-use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::prelude::PermissionsExt;
-use tracing::instrument;
 
 pub trait Metadata {
     fn uid(&self) -> u32;
@@ -125,160 +123,39 @@ pub struct Settings {
     pub symlink: SymlinkSettings,
 }
 
-#[instrument]
-async fn set_owner<Meta: Metadata + std::fmt::Debug>(
-    settings: &UserAndTimeSettings,
-    path: &std::path::Path,
-    metadata: &Meta,
-) -> Result<()> {
-    if !settings.uid && !settings.gid {
-        return Ok(());
-    }
-    let settings = settings.to_owned();
-    let dst = path.to_owned();
-    let uid = metadata.uid();
-    let gid = metadata.gid();
-    crate::walk::run_metadata_probed(
-        congestion::Side::Destination,
-        congestion::MetadataOp::Chmod,
-        async {
-            tokio::task::spawn_blocking(move || -> Result<()> {
-                tracing::debug!("setting uid and gid");
-                let uid_val = if settings.uid { Some(uid.into()) } else { None };
-                let gid_val = if settings.gid { Some(gid.into()) } else { None };
-                nix::unistd::fchownat(
-                    nix::fcntl::AT_FDCWD,
-                    &dst,
-                    uid_val,
-                    gid_val,
-                    nix::fcntl::AtFlags::AT_SYMLINK_NOFOLLOW,
-                )
-                .with_context(|| {
-                    format!(
-                        "cannot set {:?} owner to {:?} and/or group id to {:?}",
-                        &dst, &uid_val, &gid_val
-                    )
-                })?;
-                Ok(())
-            })
-            .await?
-        },
-    )
-    .await
-}
-
-#[instrument]
-async fn set_time<Meta: Metadata + std::fmt::Debug>(
-    settings: &UserAndTimeSettings,
-    path: &std::path::Path,
-    metadata: &Meta,
-) -> Result<()> {
-    if !settings.time {
-        return Ok(());
-    }
-    let dst = path.to_owned();
-    let atime = metadata.atime();
-    let atime_nsec = metadata.atime_nsec();
-    let mtime = metadata.mtime();
-    let mtime_nsec = metadata.mtime_nsec();
-    crate::walk::run_metadata_probed(
-        congestion::Side::Destination,
-        congestion::MetadataOp::Chmod,
-        async {
-            tokio::task::spawn_blocking(move || -> Result<()> {
-                tracing::debug!("setting timestamps");
-                let atime_spec = nix::sys::time::TimeSpec::new(atime, atime_nsec);
-                let mtime_spec = nix::sys::time::TimeSpec::new(mtime, mtime_nsec);
-                nix::sys::stat::utimensat(
-                    nix::fcntl::AT_FDCWD,
-                    &dst,
-                    &atime_spec,
-                    &mtime_spec,
-                    nix::sys::stat::UtimensatFlags::NoFollowSymlink,
-                )
-                .with_context(|| format!("failed setting timestamps for {:?}", &dst))?;
-                Ok(())
-            })
-            .await?
-        },
-    )
-    .await
-}
-
-pub async fn set_file_metadata<Meta: Metadata + std::fmt::Debug>(
-    settings: &Settings,
-    metadata: &Meta,
-    path: &std::path::Path,
-) -> Result<()> {
-    let permissions = if settings.file.mode_mask == 0o7777 {
-        // special case for default preserve
-        metadata.permissions()
+/// Compute the file permission bits to apply, honoring the mode mask.
+///
+/// When `mode_mask == 0o7777` (the "preserve everything" case) the source mode
+/// is returned verbatim, including setuid/setgid/sticky bits. Otherwise the mode
+/// is masked with `mode_mask` (e.g. the default `0o0777` strips the special
+/// bits, mimicking `cp`). The returned value is always confined to the
+/// permission bits (`0o7777`); file-type bits are never included.
+///
+/// This is the single source of truth for the destination create-mode and the fd-based metadata
+/// appliers in `crate::safedir`.
+#[must_use]
+pub fn masked_file_mode<Meta: Metadata>(settings: &FileSettings, metadata: &Meta) -> u32 {
+    let mode = metadata.permissions().mode();
+    if settings.mode_mask == 0o7777 {
+        // special case for default preserve: keep all permission bits verbatim
+        mode & 0o7777
     } else {
-        std::fs::Permissions::from_mode(metadata.permissions().mode() & settings.file.mode_mask)
-    };
-    // ordering: chown → chmod → utimensat
-    //
-    // chown first because fchownat clears setuid/setgid on regular files;
-    // chmod afterwards restores them. utimensat last because both chown and
-    // chmod update ctime and may touch mtime, so we set the desired
-    // timestamps as the final step.
-    //
-    // if chown fails (e.g. EPERM when not root), we bail out early rather
-    // than applying permissions for an unverified owner — setting setuid on
-    // a file whose ownership we couldn't control would be a security risk.
-    set_owner(&settings.file.user_and_time, path, metadata).await?;
-    let file = crate::walk::run_metadata_probed(
-        congestion::Side::Destination,
-        congestion::MetadataOp::Stat,
-        tokio::fs::File::open(path),
-    )
-    .await?;
-    crate::walk::run_metadata_probed(
-        congestion::Side::Destination,
-        congestion::MetadataOp::Chmod,
-        file.set_permissions(permissions.clone()),
-    )
-    .await
-    .with_context(|| format!("cannot set {:?} permissions to {:?}", &path, &permissions))?;
-    drop(file);
-    set_time(&settings.file.user_and_time, path, metadata).await?;
-    Ok(())
+        mode & settings.mode_mask
+    }
 }
 
-pub async fn set_dir_metadata<Meta: Metadata + std::fmt::Debug>(
-    settings: &Settings,
-    metadata: &Meta,
-    path: &std::path::Path,
-) -> Result<()> {
-    let permissions = if settings.dir.mode_mask == 0o7777 {
-        // special case for default preserve
-        metadata.permissions()
+/// Compute the directory permission bits to apply, honoring the mode mask.
+///
+/// Mirrors [`masked_file_mode`] for directories. See that function for details.
+#[must_use]
+pub fn masked_dir_mode<Meta: Metadata>(settings: &DirSettings, metadata: &Meta) -> u32 {
+    let mode = metadata.permissions().mode();
+    if settings.mode_mask == 0o7777 {
+        // special case for default preserve: keep all permission bits verbatim
+        mode & 0o7777
     } else {
-        std::fs::Permissions::from_mode(metadata.permissions().mode() & settings.dir.mode_mask)
-    };
-    // same ordering as set_file_metadata: chown → chmod → utimensat.
-    // see that function for rationale.
-    set_owner(&settings.dir.user_and_time, path, metadata).await?;
-    crate::walk::run_metadata_probed(
-        congestion::Side::Destination,
-        congestion::MetadataOp::Chmod,
-        tokio::fs::set_permissions(path, permissions.clone()),
-    )
-    .await
-    .with_context(|| format!("cannot set {:?} permissions to {:?}", &path, &permissions))?;
-    set_time(&settings.dir.user_and_time, path, metadata).await?;
-    Ok(())
-}
-
-pub async fn set_symlink_metadata<Meta: Metadata + std::fmt::Debug>(
-    settings: &Settings,
-    metadata: &Meta,
-    path: &std::path::Path,
-) -> Result<()> {
-    // we don't set permissions for symlinks, only owner and time
-    set_owner(&settings.symlink.user_and_time, path, metadata).await?;
-    set_time(&settings.symlink.user_and_time, path, metadata).await?;
-    Ok(())
+        mode & settings.mode_mask
+    }
 }
 
 #[must_use]

--- a/common/src/rm.rs
+++ b/common/src/rm.rs
@@ -1,11 +1,18 @@
 use anyhow::{Context, anyhow};
-use async_recursion::async_recursion;
+use std::ffi::OsStr;
+use std::os::fd::{AsFd, OwnedFd};
 use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::sync::Arc;
 use tracing::instrument;
 
 use crate::filter::TimeFilter;
 use crate::progress;
-use crate::walk::{self, EntryKind};
+use crate::safedir::{self, Dir, Handle};
+use crate::walk::{EntryKind, LeafPermit, PermitKind};
+use crate::walk_driver::{
+    DirAction, DirPreResult, EntryCx, ProcessedChildren, WalkVisitor, process_entry,
+};
 
 /// Error type for remove operations. See [`crate::error::OperationError`] for
 /// logging conventions and rationale.
@@ -108,29 +115,58 @@ impl std::fmt::Display for Summary {
     }
 }
 
-/// RAII guard that restores a directory's original mode on drop.
+/// RAII guard that restores a relaxed directory's original mode on drop, fd-pinned.
 ///
-/// `rm_internal` chmod-relaxes a read-only directory to `0o777` to clear its contents. If the
-/// directory is retained (filter-protected children, time-filter skip, ENOTEMPTY) or any error
-/// occurs after the relax, the original mode must be restored — otherwise a `--delete`/`rrm`
-/// run leaves a protected tree world-writable. Drop fires on every exit path (retain, error,
-/// panic-unwind) without callers having to remember it; the success-remove path calls
-/// [`Self::defuse`] because the directory no longer exists.
+/// To clear a read-only directory's contents, [`RmVisitor::dir_pre`] chmod-relaxes it (via the directory's
+/// own `O_PATH` handle, before `open_dir`). If the directory is then retained (filter-protected
+/// children, time-filter skip, ENOTEMPTY) or any error occurs after the relax, the original mode
+/// must be restored — otherwise an `rrm` run leaves a protected tree world-readable/executable.
+/// Drop fires on every exit path (retain, error, panic-unwind) without callers having to remember
+/// it; the success-remove path calls [`Self::defuse`] because the directory no longer exists.
 ///
-/// Drop runs synchronously (it can't be async), so it uses `std::fs::set_permissions`: one
-/// chmod syscall — negligible cost, no need to round-trip through the tokio blocking pool just
-/// for cleanup. Best-effort: a restore failure is logged, not fatal.
-struct RelaxedDirGuard<'a> {
-    path: &'a std::path::Path,
-    /// Original mode to restore on drop. `None` means defused (no restore).
+/// # Race safety
+///
+/// The guard holds a dup of the directory's `O_PATH` handle fd, and restores via
+/// [`safedir::chmod_via_proc_fd_sync`] — a chmod of the EXACT inode that fd pins, through its
+/// `/proc/self/fd/N` magic symlink. This is inode-exact and immune to a concurrent
+/// rename/symlink swap of the directory's name: there is no path re-resolution that an attacker
+/// could redirect. It is the synchronous counterpart of the relax (`chmod_via_proc_fd`), so the
+/// relax and the restore target the same pinned inode. This is the TOCTOU-safe replacement for
+/// the old path-based `std::fs::set_permissions(path, ...)` restore.
+///
+/// Drop runs synchronously (it can't be async), so it issues one ungated `fchmodat` — negligible
+/// cost, no need to round-trip through the tokio blocking pool just for cleanup. Best-effort: a
+/// restore failure is logged, not fatal.
+///
+/// # Lifecycle (leak-free even under fd exhaustion)
+///
+/// The guard is built in two steps so the relax can never outlive the ability to restore:
+/// 1. [`Self::prepare`] dups the `O_PATH` fd and records the original mode while leaving the guard
+///    *disarmed* (Drop is a no-op). This is the only fallible step (the dup) — and it runs BEFORE
+///    the relax chmod. If it fails (e.g. `EMFILE`), no relax has happened yet, so there is nothing
+///    to leak.
+/// 2. After the relax chmod succeeds, [`Self::arm`] flips the guard to active, so every subsequent
+///    exit path (retain, error, panic-unwind) restores the original mode.
+///
+/// The success-delete path calls [`Self::defuse`] (the directory no longer exists).
+struct RelaxedDirGuard {
+    /// Dup of the directory's `O_PATH` handle fd, pinning the inode to restore.
+    fd: OwnedFd,
+    /// Original mode to restore on drop. `None` means disarmed/defused (no restore).
     mode: Option<u32>,
 }
 
-impl<'a> RelaxedDirGuard<'a> {
-    fn new(path: &'a std::path::Path) -> Self {
-        Self { path, mode: None }
+impl RelaxedDirGuard {
+    /// Dup the directory's `O_PATH` handle fd, returning a *disarmed* guard (Drop restores nothing
+    /// yet). Call this BEFORE relaxing the directory's mode so the restore fd is secured first; if
+    /// the dup fails (e.g. `EMFILE`) the caller must not relax — nothing to leak. Once the relax
+    /// chmod succeeds, call [`Self::arm`] with the original mode to make the restore fire on every
+    /// later exit path.
+    fn prepare(handle: &Handle) -> std::io::Result<Self> {
+        let fd = handle.as_fd().try_clone_to_owned()?;
+        Ok(Self { fd, mode: None })
     }
-    /// Record the original mode so it's restored on drop.
+    /// Arm the guard so Drop restores `original_mode`. Called after the relax chmod succeeds.
     fn arm(&mut self, original_mode: u32) {
         self.mode = Some(original_mode);
     }
@@ -140,15 +176,13 @@ impl<'a> RelaxedDirGuard<'a> {
     }
 }
 
-impl Drop for RelaxedDirGuard<'_> {
+impl Drop for RelaxedDirGuard {
     fn drop(&mut self) {
         if let Some(mode) = self.mode.take()
-            && let Err(err) =
-                std::fs::set_permissions(self.path, std::fs::Permissions::from_mode(mode))
+            && let Err(err) = safedir::chmod_via_proc_fd_sync(self.fd.as_fd(), mode)
         {
             tracing::warn!(
-                "failed to restore original permissions on retained directory {:?}: {:#}",
-                self.path,
+                "failed to restore original permissions on retained directory (fd-pinned inode): {:#}",
                 err
             );
         }
@@ -156,81 +190,246 @@ impl Drop for RelaxedDirGuard<'_> {
 }
 
 /// Public entry point for remove operations.
-/// Internally delegates to rm_internal with source_root tracking for proper filter matching.
+///
+/// The walk is fd-based (see [`crate::safedir`]): the root operand is opened relative to its
+/// parent directory and every entry is classified and removed through file-descriptor-relative
+/// syscalls. A privileged `rrm` therefore cannot be redirected by a concurrent symlink swap
+/// into deleting a tree outside the intended target (the classic `rm -rf` symlink race) — the
+/// `O_NOFOLLOW|O_DIRECTORY` opens in [`Dir::open_dir`] catch a directory→symlink swap mid-walk
+/// and fail closed (ELOOP/ENOTDIR) rather than descending the link, and leaf removal uses
+/// `unlinkat` (never follows a symlink). The recursive walk skeleton — enumeration, the
+/// leaf-permit lifecycle, spawning, the single drop-before-recurse site, and the error fold —
+/// lives in the generic [`crate::walk_driver`]; this module supplies the remove visitor.
 #[instrument(skip(prog_track, settings))]
 pub async fn rm(
     prog_track: &'static progress::Progress,
     path: &std::path::Path,
     settings: &Settings,
 ) -> Result<Summary, Error> {
-    // check filter for top-level path (files, directories, and symlinks)
+    // decompose the operand into (parent dir, final component) so the root entry is opened and
+    // classified relative to a directory fd — the same fd-relative shape every nested entry takes.
+    // `.`/`..` operands (e.g. `rrm .`) are canonicalized so they still name a directory; `/` is
+    // rejected. rm reads and removes "the" tree; we gate it on the Source side (matching the
+    // existing rm code, which probes its stat/readdir on Source and only the destructive
+    // unlink/rmdir on Destination).
+    let operand = crate::walk::split_root_operand(path)
+        .await
+        .map_err(|err| Error::new(err, Default::default()))?;
+    let parent_path = operand.parent.as_path();
+    let name = operand.name.as_os_str();
+    let path = operand.display.as_path();
+    // the operand's TRUSTED parent prefix is resolved following symlinks normally (the prefix is
+    // trusted up to and including the operand's container — only entries strictly below the named
+    // root are O_NOFOLLOW-hardened). a symlinked parent (e.g. `rrm symlinkdir/foo`) is followed; the
+    // operand itself is still classified via `child(name)` with O_NOFOLLOW (a symlink root is
+    // removed as the link itself).
+    let parent = Dir::open_parent_dir(parent_path, congestion::Side::Source)
+        .await
+        .with_context(|| format!("cannot open parent directory {parent_path:?}"))
+        .map_err(|err| Error::new(err, Default::default()))?;
+    // cross from the trusted parent prefix into the hardened tree (O_NOFOLLOW below here).
+    let parent = Arc::new(parent.into_tree());
     if let Some(ref filter) = settings.filter {
-        let path_name = path.file_name().map(std::path::Path::new);
-        if let Some(name) = path_name {
-            let path_metadata = crate::walk::run_metadata_probed(
-                congestion::Side::Source,
-                congestion::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(path),
-            )
+        // the top-level include/exclude filter is checked against `path` itself (its file name);
+        // classify the root via its parent fd purely to evaluate the root filter. the driver
+        // re-classifies the root authoritatively in `process_entry`, so this handle is just a probe.
+        let root_handle = parent
+            .child(name)
             .await
-            .with_context(|| format!("failed reading metadata from {:?}", &path))
+            .with_context(|| format!("failed reading metadata from {path:?}"))
             .map_err(|err| Error::new(err, Default::default()))?;
-            let is_dir = path_metadata.is_dir();
-            let result = filter.should_include_root_item(name, is_dir);
-            match result {
-                crate::filter::FilterResult::Included => {}
-                result => {
-                    let kind = EntryKind::from_metadata(&path_metadata);
-                    if let Some(mode) = settings.dry_run {
-                        crate::dry_run::report_skip(path, &result, mode, kind.label_long());
-                    }
-                    kind.inc_skipped(prog_track);
-                    return Ok(skipped_summary_for(kind));
+        let name_path = std::path::Path::new(name);
+        let result =
+            filter.should_include_root_item(name_path, root_handle.kind() == EntryKind::Dir);
+        match result {
+            crate::filter::FilterResult::Included => {}
+            result => {
+                let kind = root_handle.kind();
+                if let Some(mode) = settings.dry_run {
+                    crate::dry_run::report_skip(path, &result, mode, kind.label_long());
                 }
+                kind.inc_skipped(prog_track);
+                return Ok(skipped_summary_for(kind));
             }
         }
     }
-    // note: the time filter (applied to files, symlinks, and directories) is handled
-    // inside rm_internal, so we don't duplicate the check here.
-    rm_internal(prog_track, path, path, settings).await
+    // the root entry's owned context: rel_path/filter_path empty (the root), real_path = the
+    // operand. rm has no delegated subtree, so `filter_path == rel_path`. The root is processed
+    // exactly like a nested child via `process_entry`, with no pre-acquired permit (it is not
+    // spawned from the backpressure-limited walk loop).
+    let visitor = Arc::new(RmVisitor {
+        prog_track,
+        settings: settings.clone(),
+    });
+    let root_cx = EntryCx {
+        parent: Arc::clone(&parent),
+        name: name.to_owned(),
+        rel_path: PathBuf::new(),
+        filter_path: PathBuf::new(),
+        real_path: path.to_path_buf(),
+        dry_run: settings.dry_run.is_some(),
+        prog_track,
+    };
+    process_entry(visitor, root_cx, (), None).await // rm has no second tree → root context `()`
 }
 
-/// Like [`rm`], but evaluates the include/exclude filter relative to `filter_root` instead of
-/// `path`. Used by `--delete` pruning: when removing an extraneous destination subtree,
-/// descendant excludes must be matched against their full destination-root-relative paths
-/// (which mirror the source-relative paths the filter targets), so path/anchored patterns
-/// like `cache/*.log` protect the right entries. The caller is responsible for the top-level
-/// filter decision on `path`.
-pub async fn rm_with_filter_root(
+/// Remove a single child entry of an already-open directory, fd-relative.
+///
+/// This is the fd-based counterpart of path-based [`rm`]. It is used by two callers that
+/// already hold the relevant directory as an open [`Dir`] and want to remove one of its children
+/// through that pinned fd rather than re-resolving the entry by absolute path (the redirectable
+/// window):
+/// - `--delete` pruning (see [`crate::delete::prune_extraneous`]) removes each extraneous entry.
+/// - the remote-copy destination (`rcpd`) replaces a non-matching destination subtree (a
+///   directory/file/symlink in the way of the entry it must create) through the parent directory
+///   fd held in its directory tracker.
+///
+/// The entry is classified via `parent.child(name)` (`O_PATH|O_NOFOLLOW`, so a symlink is
+/// classified as a symlink, never followed) and then removed through the same fd-relative remove
+/// machinery (driven by [`crate::walk_driver::process_entry`]): leaves via `unlinkat`, directories
+/// by recursing with `O_NOFOLLOW|O_DIRECTORY` descent and the fd-pinned relax guard. A privileged
+/// caller therefore cannot be redirected by a concurrent symlink swap of `name` into deleting a
+/// tree outside the directory it holds.
+///
+/// `rel_path` is the entry's path relative to the mirror/destination root: seeded as the root
+/// entry's `rel_path`/`filter_path`/`real_path`, it both anchors include/exclude filter matching
+/// against the entry's destination-root-relative path and reconstructs the entry's display path for
+/// diagnostics / dry-run output. The caller is responsible for the top-level decision on `name`
+/// (keep-set membership, exclude-protection, overwrite-recheck); this only removes the subtree.
+pub async fn rm_child(
     prog_track: &'static progress::Progress,
-    path: &std::path::Path,
-    filter_root: &std::path::Path,
+    parent: &Arc<Dir>,
+    name: &OsStr,
+    rel_path: &std::path::Path,
     settings: &Settings,
 ) -> Result<Summary, Error> {
-    rm_internal(prog_track, path, filter_root, settings).await
+    // build the child's owned context rooted at `rel_path`: the display path and the filter path
+    // then each equal `rel_path` (the destination-root-relative path), anchoring include/exclude
+    // matching against the entry's full root-relative path, and each descendant extends it by one
+    // component (exactly the bare-roots behavior the old `WalkRoots { operand: "", filter: "" }`
+    // produced via `operand.join(rel_path)`). these paths are pure display/filter strings — they
+    // are never opened, so there is no dst path for an attacker to redirect.
+    let visitor = Arc::new(RmVisitor {
+        prog_track,
+        settings: settings.clone(),
+    });
+    let root_cx = EntryCx {
+        parent: Arc::clone(parent),
+        name: name.to_owned(),
+        rel_path: rel_path.to_path_buf(),
+        filter_path: rel_path.to_path_buf(),
+        real_path: rel_path.to_path_buf(),
+        dry_run: settings.dry_run.is_some(),
+        prog_track,
+    };
+    // a `rm_child` entry point is not spawned from the backpressure-limited walk loop, so it never
+    // pre-acquires a pending-meta permit. `process_entry` classifies `name` authoritatively via
+    // `child()` (a swap of `name` to a symlink is caught there — classified as a symlink leaf,
+    // never descended) and dispatches to the visitor.
+    process_entry(visitor, root_cx, (), None).await
 }
-#[instrument(skip(prog_track, settings))]
-#[async_recursion]
-async fn rm_internal(
+/// The remove walk's [`WalkVisitor`]. The driver owns enumeration, the leaf-permit lifecycle,
+/// spawning, the single drop-before-recurse site, and the error fold; this visitor supplies rm's
+/// per-entry bodies (leaf removal in [`WalkVisitor::visit_leaf`], the relax-guard + metadata
+/// snapshot in [`WalkVisitor::dir_pre`], and the post-order `rmdir` decision in
+/// [`WalkVisitor::dir_post`]). rm has no second tree, so [`Self::DirContext`] is `()`.
+struct RmVisitor {
     prog_track: &'static progress::Progress,
-    path: &std::path::Path,
-    source_root: &std::path::Path,
-    settings: &Settings,
-) -> Result<Summary, Error> {
-    let _ops_guard = prog_track.ops.guard();
-    tracing::debug!("read path metadata");
-    let src_metadata = crate::walk::run_metadata_probed(
-        congestion::Side::Source,
-        congestion::MetadataOp::Stat,
-        tokio::fs::symlink_metadata(path),
-    )
-    .await
-    .with_context(|| format!("failed reading metadata from {:?}", &path))
-    .map_err(|err| Error::new(err, Default::default()))?;
-    if !src_metadata.is_dir() {
+    settings: Settings,
+}
+
+/// State threaded from [`WalkVisitor::dir_pre`] to [`WalkVisitor::dir_post`] (same task) — what the
+/// post-order `rmdir` decision needs.
+///
+/// The [`RelaxedDirGuard`] lives here precisely so the error path restores the relaxed mode: on a
+/// child failure the `?` after the contents walk in the driver's `process_entry` returns early
+/// (fail-early) or `dir_post` returns the combined error (keep-going) — either way `dir_post` never
+/// reaches its `defuse()`, so the guard's `Drop` restores the original directory mode (matching the
+/// old code's local `relaxed_guard` dropping on the early-return error paths).
+struct RmDirState {
+    /// Restores the relaxed directory mode on every retain/error path (fd-pinned, inode-exact);
+    /// `defuse`d only after a successful `rmdir`. `None` in dry-run (no relax happens) and when the
+    /// directory already had owner rwx (no relax needed).
+    guard: Option<RelaxedDirGuard>,
+    /// The directory's PRISTINE full metadata, snapshotted in `dir_pre` BEFORE the relax or any
+    /// child removal, so the directory's own time filter sees timestamps unperturbed by clearing
+    /// its contents (removing children bumps mtime). `Some` iff a time filter is configured.
+    time_metadata: Option<anyhow::Result<std::fs::Metadata>>,
+    /// Whether the directory does NOT directly match an include pattern while includes are active —
+    /// the path-only half of the "traversed only" decision. Combined in `dir_post` with
+    /// "nothing was removed" (derived from the children's folded summary) to reproduce the old
+    /// `traversed_only` exactly.
+    matches_no_include: bool,
+}
+
+impl WalkVisitor for RmVisitor {
+    type Summary = Summary;
+    type DirContext = ();
+    type DirState = RmDirState;
+
+    fn root_dir_context(&self) {}
+
+    fn permit_kind(&self) -> PermitKind {
+        // we use the pending-meta semaphore (not open-files) because rm is reachable from
+        // copy_file's overwrite path, which already holds an open-files permit; using a distinct
+        // semaphore avoids that cross-pool deadlock. rm holds no open fd across leaf work.
+        PermitKind::PendingMeta
+    }
+
+    fn want_permit(&self, hint: Option<EntryKind>) -> bool {
+        // pre-acquire only for a positively-known leaf hint. We deliberately skip pre-acquire when
+        // the getdents hint is unknown (DT_UNKNOWN -> None): the entry could actually be a
+        // directory, and a chain of such unknown-typed directories holding permits while recursing
+        // would deadlock the pending-meta pool. Directories also skip pre-acquire for the same
+        // reason. The authoritative type is still the child's fstat; this is only the hint.
+        hint.is_some_and(|ft| ft != EntryKind::Dir)
+    }
+
+    fn fail_early(&self) -> bool {
+        self.settings.fail_early
+    }
+
+    fn filter(&self) -> Option<&crate::filter::FilterSettings> {
+        self.settings.filter.as_ref()
+    }
+
+    fn on_skip(
+        &self,
+        cx: &EntryCx,
+        kind: EntryKind,
+        skip_result: &crate::filter::FilterResult,
+    ) -> Summary {
+        // mirror the old spawn loop's inline filter-skip: the dry-run "skip ..." line plus the
+        // matching `*_skipped` counter. the driver already did the shared progress increment.
+        if let Some(mode) = self.settings.dry_run {
+            crate::dry_run::report_skip(&cx.real_path, skip_result, mode, kind.label());
+        }
+        skipped_summary_for(kind)
+    }
+
+    async fn visit_leaf(
+        &self,
+        cx: &EntryCx,
+        _parent_ctx: &(),
+        handle: Handle,
+        kind: EntryKind,
+        permit: Option<LeafPermit>,
+    ) -> Result<Summary, Error> {
+        // leaf: hold the permit through the (non-recursive) removal, then drop on return (the
+        // driver drops it for directories, never here).
+        let _permit = permit;
+        let prog_track = self.prog_track;
+        let settings = &self.settings;
+        let parent = &cx.parent;
+        let name = cx.name.as_os_str();
+        let path = cx.real_path.as_path();
         tracing::debug!("not a directory, just remove");
-        let is_symlink = src_metadata.file_type().is_symlink();
-        let file_size = if is_symlink { 0 } else { src_metadata.len() };
+        let is_symlink = kind == EntryKind::Symlink;
+        let file_size = if is_symlink {
+            0
+        } else {
+            crate::preserve::Metadata::size(handle.meta())
+        };
         // apply time filter before removing (files/symlinks only)
         if let Some(ref time_filter) = settings.time_filter {
             let entry_type = if is_symlink { "symlink" } else { "file" };
@@ -250,7 +449,39 @@ async fn rm_internal(
                     }
                 }
             };
-            match time_filter.matches(&src_metadata) {
+            // the time filter needs full std metadata (btime for --created-before), which the
+            // fd snapshot does not carry; read it inode-exact through the pinned handle so a
+            // concurrent swap of `name` cannot redirect the stat to a different inode.
+            let metadata =
+                match safedir::stat_meta_via_proc_fd(&handle, congestion::Side::Source).await {
+                    Ok(md) => md,
+                    Err(err) => {
+                        let err = anyhow::Error::new(err).context(format!(
+                            "failed reading metadata for time filter on {path:?}"
+                        ));
+                        if settings.fail_early {
+                            return Err(Error::new(err, Default::default()));
+                        }
+                        // log and skip — never delete an entry whose age we cannot verify.
+                        if is_unsupported_io_error(&err) {
+                            tracing::warn!(
+                                "time filter evaluation unsupported for {} {:?}, skipping: {:#}",
+                                entry_type,
+                                &path,
+                                &err
+                            );
+                        } else {
+                            tracing::error!(
+                                "time filter evaluation failed for {} {:?}, skipping: {:#}",
+                                entry_type,
+                                &path,
+                                &err
+                            );
+                        }
+                        return Ok(make_skipped_summary());
+                    }
+                };
+            match time_filter.matches(&metadata) {
                 Ok(result) => {
                     if let Some(skip_reason) = result.as_skip_reason() {
                         if let Some(mode) = settings.dry_run {
@@ -297,13 +528,13 @@ async fn rm_internal(
                 ..Default::default()
             });
         }
-        if let Err(err) = crate::walk::run_metadata_probed(
-            congestion::Side::Destination,
-            congestion::MetadataOp::Unlink,
-            tokio::fs::remove_file(path),
-        )
-        .await
-        .with_context(|| format!("failed removing {:?}", &path))
+        // fd-relative removal of the link/file itself: unlink_at never follows a symlink, and is
+        // resolved relative to the parent dir fd, so it cannot be redirected outside the tree.
+        // gated on the Destination side to match the side the path-based rm used for remove_file.
+        if let Err(err) = parent
+            .unlink_at_on(name, congestion::Side::Destination)
+            .await
+            .with_context(|| format!("failed removing {:?}", &path))
         {
             return Err(Error::new(err, Default::default()));
         }
@@ -316,295 +547,285 @@ async fn rm_internal(
         }
         prog_track.files_removed.inc();
         prog_track.bytes_removed.add(file_size);
-        return Ok(Summary {
+        Ok(Summary {
             bytes_removed: file_size,
             files_removed: 1,
             ..Default::default()
-        });
+        })
     }
-    tracing::debug!("remove contents of the directory first");
-    // When the directory is read-only we relax it to 0o777 so its contents can be cleared.
-    // `relaxed_guard` records the original mode and restores it on Drop — covering every
-    // retain branch (filter-protected children, time-filter skip, ENOTEMPTY) AND every error
-    // path that returns before the directory is removed. The success-remove path calls
-    // `defuse()` because the directory no longer exists. Dry-run skips the relax entirely,
-    // so the guard stays unarmed.
-    let mut relaxed_guard = RelaxedDirGuard::new(path);
-    if settings.dry_run.is_none() && src_metadata.permissions().readonly() {
-        tracing::debug!("directory is read-only - change the permissions");
-        let original_mode = src_metadata.permissions().mode() & 0o7777;
-        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o777))
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to make '{:?}' directory readable and writeable",
-                    &path
+
+    async fn dir_pre(&self, cx: &EntryCx, _parent_ctx: &(), handle: &Handle) -> DirPreResult<Self> {
+        let settings = &self.settings;
+        let path = cx.real_path.as_path();
+        tracing::debug!("remove contents of the directory first");
+        // Snapshot the directory's full metadata NOW, before relaxing its mode or removing any
+        // child. The directory's own time filter (evaluated in `dir_post`, after its children are
+        // processed) must use these pristine timestamps: removing children bumps the directory's
+        // mtime, so a fresh stat at the end would wrongly see the directory as "just modified".
+        // This mirrors the old code's `src_metadata` captured at entry. We read full std metadata
+        // (not just the fd snapshot) because `--created-before` needs btime; it's read inode-exact
+        // through the pinned handle. Only fetched when a time filter is configured. The relax below
+        // changes only mode/ctime, never mtime/btime, so taking the snapshot before it is correct.
+        let time_metadata: Option<anyhow::Result<std::fs::Metadata>> =
+            if settings.time_filter.is_some() {
+                Some(
+                    safedir::stat_meta_via_proc_fd(handle, congestion::Side::Source)
+                        .await
+                        .map_err(|err| {
+                            anyhow::Error::new(err).context(format!(
+                                "failed reading metadata for time filter on {path:?}"
+                            ))
+                        }),
                 )
-            })
+            } else {
+                None
+            };
+        // the path-only half of the "traversed only" decision: a directory is "traversed only" when
+        // include filters are active and the directory itself doesn't directly match an include
+        // pattern (it was entered only to search for matching content). `dir_post` combines this
+        // with "nothing was removed". exclude-only filters never produce traversed-only directories
+        // because `directly_matches_include` returns true when no includes exist.
+        let matches_no_include = settings.filter.as_ref().is_some_and(|f| {
+            f.has_includes() && !f.directly_matches_include(&cx.filter_path, true)
+        });
+        // When the directory lacks owner write/execute we relax it so its contents can be cleared.
+        // The relax goes through the directory's OWN `O_PATH` handle (via /proc), which works even
+        // on a 0000-mode dir a non-root owner cannot open O_RDONLY — so it must happen BEFORE
+        // `open_dir`. The guard (carried in `RmDirState`) restores the original mode on Drop
+        // (fd-pinned, inode-exact) — covering every retain branch (filter-protected children,
+        // time-filter skip, ENOTEMPTY) AND every error path that returns before the directory is
+        // removed (the driver drops the state without calling `dir_post`, or `dir_post` returns the
+        // error before `defuse`). The success-remove path calls `defuse()` because the directory no
+        // longer exists. Dry-run skips the relax entirely, so no guard.
+        let mut guard: Option<RelaxedDirGuard> = None;
+        if settings.dry_run.is_none() {
+            let original_mode =
+                crate::preserve::Metadata::permissions(handle.meta()).mode() & 0o7777;
+            // relax unless the owner already has full r/w/x. read is needed to enumerate the dir
+            // (open_dir + getdents), and write+execute to unlink/rmdir its entries. 0o700 = u+rwx.
+            // this is a superset of the old `readonly()` (no-write) trigger, and also covers dirs
+            // missing owner read/execute that the old path-based read_dir would have failed on.
+            if original_mode & 0o700 != 0o700 {
+                tracing::debug!("directory is not writable/traversable - relax the permissions");
+                // SECURE the restore fd BEFORE relaxing: dup the O_PATH handle into a (still
+                // disarmed) guard first. The dup is the only fallible step and it runs while the dir
+                // still has its original restrictive mode — so if it fails (e.g. EMFILE under fd
+                // exhaustion) we return without ever relaxing, and there is no more-permissive mode
+                // left behind.
+                let mut g = RelaxedDirGuard::prepare(handle)
+                    .with_context(|| {
+                        format!("failed to set up permission-restore guard for {path:?}")
+                    })
+                    .map_err(|err| Error::new(err, Default::default()))?;
+                // gated as a Destination Chmod: the relax is a permission mutation that enables the
+                // removal, so it shares the destructive side/bucket with the unlink/rmdir below.
+                safedir::chmod_via_proc_fd(handle, congestion::Side::Destination, 0o700)
+                    .await
+                    .with_context(|| {
+                        format!("failed to make {path:?} directory readable and writeable")
+                    })
+                    .map_err(|err| Error::new(err, Default::default()))?;
+                // relax succeeded: arm so Drop restores the original mode on every exit path below.
+                g.arm(original_mode);
+                guard = Some(g);
+            }
+        }
+        // open the directory's real fd via the parent fd with O_NOFOLLOW|O_DIRECTORY: a directory
+        // entry swapped to a symlink mid-walk fails closed here (ELOOP/ENOTDIR) — descent never
+        // follows it outside the tree. this is the core rm -rf race closure. an open failure
+        // returns the error with the guard still armed in scope, so the relaxed mode is restored on
+        // Drop (matching the old early-return error path).
+        let dir = cx
+            .parent
+            .open_dir(&cx.name)
+            .await
+            .with_context(|| format!("failed reading directory {path:?}"))
             .map_err(|err| Error::new(err, Default::default()))?;
-        relaxed_guard.arm(original_mode);
-    }
-    let mut entries = match tokio::fs::read_dir(path).await {
-        Ok(entries) => entries,
-        Err(err) => {
-            return Err(Error::new(
-                anyhow::Error::new(err).context(format!("failed reading directory {:?}", &path)),
-                Default::default(),
-            ));
-        }
-    };
-    let mut join_set = tokio::task::JoinSet::new();
-    let errors = crate::error_collector::ErrorCollector::default();
-    let mut skipped_files = 0;
-    let mut skipped_symlinks = 0;
-    let mut skipped_dirs = 0;
-    loop {
-        let next_entry =
-            crate::walk::next_entry_probed(&mut entries, congestion::Side::Source, || {
-                format!("failed traversing directory {:?}", &path)
-            })
-            .await;
-        let Some((entry, entry_file_type)) = (match next_entry {
-            Ok(opt) => opt,
-            Err(err) => {
-                return Err(Error::new(err, Default::default()));
-            }
-        }) else {
-            break;
-        };
-        let entry_path = entry.path();
-        let entry_kind = EntryKind::from_file_type(entry_file_type.as_ref());
-        let entry_is_dir = entry_kind == EntryKind::Dir;
-        // compute relative path from source_root for filter matching
-        let relative_path = walk::relative_to_root(&entry_path, source_root);
-        // apply filter if configured
-        if let Some(skip_result) =
-            walk::should_skip_entry(&settings.filter, relative_path, entry_is_dir)
-        {
-            if let Some(mode) = settings.dry_run {
-                crate::dry_run::report_skip(&entry_path, &skip_result, mode, entry_kind.label());
-            }
-            tracing::debug!("skipping {:?} due to filter", &entry_path);
-            // increment skipped counters - will be added to rm_summary below
-            match entry_kind {
-                EntryKind::Dir => skipped_dirs += 1,
-                EntryKind::Symlink => skipped_symlinks += 1,
-                EntryKind::File | EntryKind::Special => skipped_files += 1,
-            }
-            entry_kind.inc_skipped(prog_track);
-            continue;
-        }
-        let settings = settings.clone();
-        let source_root = source_root.to_owned();
-        // for positively-known leaf entries (files, symlinks, special),
-        // acquire the pending-meta permit BEFORE spawning so we don't create
-        // unbounded tasks. We deliberately skip pre-acquire when
-        // `entry_file_type` is None (file_type() lookup failed): the entry
-        // could actually be a directory, and a chain of such unknown-typed
-        // directories holding permits while recursing would deadlock the
-        // pending-meta pool. Directories also skip pre-acquire for the same
-        // reason. We use the pending-meta semaphore (not open-files) because
-        // rm operations don't hold fds — and rm is reachable from copy_file's
-        // overwrite path, which already holds an open-files permit; using a
-        // distinct semaphore avoids that cross-pool deadlock.
-        let known_leaf = entry_file_type.as_ref().is_some_and(|ft| !ft.is_dir());
-        let pending_guard = if known_leaf {
-            Some(throttle::pending_meta_permit().await)
-        } else {
-            None
-        };
-        let do_rm = || async move {
-            let _pending_guard = pending_guard;
-            rm_internal(prog_track, &entry_path, &source_root, &settings).await
-        };
-        join_set.spawn(do_rm());
-    }
-    // unfortunately ReadDir is opening file-descriptors and there's not a good way to limit this,
-    // one thing we CAN do however is to drop it as soon as we're done with it
-    drop(entries);
-    let mut rm_summary = Summary {
-        directories_removed: 0,
-        files_skipped: skipped_files,
-        symlinks_skipped: skipped_symlinks,
-        directories_skipped: skipped_dirs,
-        ..Default::default()
-    };
-    while let Some(res) = join_set.join_next().await {
-        match res {
-            Ok(result) => match result {
-                Ok(summary) => rm_summary = rm_summary + summary,
-                Err(error) => {
-                    tracing::error!("remove: {:?} failed with: {:#}", path, &error);
-                    rm_summary = rm_summary + error.summary;
-                    errors.push(error.source);
-                    if settings.fail_early {
-                        break;
-                    }
-                }
+        Ok(DirAction::Descend {
+            dir: Arc::new(dir),
+            child_ctx: (),
+            state: RmDirState {
+                guard,
+                time_metadata,
+                matches_no_include,
             },
-            Err(error) => {
-                errors.push(error.into());
-                if settings.fail_early {
-                    break;
-                }
-            }
-        }
+        })
     }
-    if errors.has_errors() {
-        // unwrap is safe: has_errors() guarantees into_error() returns Some
-        return Err(Error::new(errors.into_error().unwrap(), rm_summary));
-    }
-    tracing::debug!("finally remove the empty directory");
-    let anything_removed = rm_summary.files_removed > 0
-        || rm_summary.symlinks_removed > 0
-        || rm_summary.directories_removed > 0;
-    let anything_skipped = rm_summary.files_skipped > 0
-        || rm_summary.symlinks_skipped > 0
-        || rm_summary.directories_skipped > 0;
-    // a directory is "traversed only" when include filters are active, nothing was removed
-    // from it, and the directory itself doesn't directly match an include pattern. such
-    // directories were only entered to search for matching content inside and should be
-    // left intact. directories that directly match an include pattern (e.g. --include target/)
-    // should be removed even if empty. exclude-only filters never produce traversed-only
-    // directories because directly_matches_include returns true when no includes exist.
-    let relative_path = walk::relative_to_root(path, source_root);
-    let traversed_only = !anything_removed
-        && settings
-            .filter
-            .as_ref()
-            .is_some_and(|f| f.has_includes() && !f.directly_matches_include(relative_path, true));
-    // evaluate the directory's own time filter to decide whether to remove it.
-    // the time filter is an entry filter, not a subtree gate: children are already handled
-    // by their own recursive calls, so this decision only controls the final remove_dir.
-    // returns Ok(true) = proceed, Ok(false) = skip (too new), Err propagates a fail-early.
-    // the src_metadata captured at entry is used so rrm's own mutations during traversal
-    // don't change the answer.
-    let dir_passes_time_filter: bool = if let Some(ref time_filter) = settings.time_filter {
-        match time_filter.matches(&src_metadata) {
-            Ok(result) => match result.as_skip_reason() {
-                Some(reason) => {
-                    if let Some(mode) = settings.dry_run {
-                        crate::dry_run::report_time_skip(path, reason, mode, "dir");
+
+    async fn dir_post(
+        &self,
+        cx: &EntryCx,
+        state: RmDirState,
+        _processed: &ProcessedChildren,
+        child_result: Result<Summary, Error>,
+    ) -> Result<Summary, Error> {
+        let prog_track = self.prog_track;
+        let settings = &self.settings;
+        let path = cx.real_path.as_path();
+        let RmDirState {
+            mut guard,
+            time_metadata,
+            matches_no_include,
+        } = state;
+        // a child failed (keep-going mode — fail-early aborts before `dir_post`). do NOT rmdir:
+        // return the combined error with the partial summary, and let `guard` drop to restore the
+        // relaxed mode (the old code's early-return-on-error left its local guard to do the same).
+        let mut rm_summary = match child_result {
+            Ok(summary) => summary,
+            Err(err) => return Err(err),
+        };
+        tracing::debug!("finally remove the empty directory");
+        let anything_removed = rm_summary.files_removed > 0
+            || rm_summary.symlinks_removed > 0
+            || rm_summary.directories_removed > 0;
+        let anything_skipped = rm_summary.files_skipped > 0
+            || rm_summary.symlinks_skipped > 0
+            || rm_summary.directories_skipped > 0;
+        // directories that directly match an include pattern (e.g. --include target/) should be
+        // removed even if empty; only those merely traversed for matches are left intact.
+        let traversed_only = !anything_removed && matches_no_include;
+        // evaluate the directory's own time filter to decide whether to remove it.
+        // the time filter is an entry filter, not a subtree gate: children are already handled
+        // by their own recursive calls, so this decision only controls the final rmdir.
+        // the metadata SNAPSHOT taken in `dir_pre` — before relaxing the mode or removing any
+        // child — is used so those mutations (which bump the directory's mtime) don't change the
+        // answer. this mirrors the old code's `src_metadata` captured at entry.
+        let dir_passes_time_filter: bool = if let Some(ref time_filter) = settings.time_filter {
+            // unwrap is safe: time_metadata is Some whenever time_filter is Some (both gated on
+            // settings.time_filter.is_some()).
+            let matched = time_metadata.unwrap().and_then(|md| {
+                time_filter.matches(&md).map_err(|err| {
+                    err.context(format!("failed evaluating time filter on {path:?}"))
+                })
+            });
+            match matched {
+                Ok(result) => match result.as_skip_reason() {
+                    Some(reason) => {
+                        if let Some(mode) = settings.dry_run {
+                            crate::dry_run::report_time_skip(path, reason, mode, "dir");
+                        }
+                        false
+                    }
+                    None => true,
+                },
+                Err(err) => {
+                    if settings.fail_early {
+                        return Err(Error::new(err, rm_summary));
+                    }
+                    // log and skip — never remove a directory whose age we cannot verify.
+                    // btime being unsupported on the filesystem is expected noise; downgrade
+                    // to warn. anything else is unexpected and stays at error.
+                    if is_unsupported_io_error(&err) {
+                        tracing::warn!(
+                            "time filter evaluation unsupported for dir {:?}, leaving it intact: {:#}",
+                            &path,
+                            &err
+                        );
+                    } else {
+                        tracing::error!(
+                            "time filter evaluation failed for dir {:?}, leaving it intact: {:#}",
+                            &path,
+                            &err
+                        );
                     }
                     false
                 }
-                None => true,
-            },
-            Err(err) => {
-                let err = err.context(format!("failed evaluating time filter on {:?}", &path));
-                if settings.fail_early {
-                    return Err(Error::new(err, rm_summary));
-                }
-                // log and skip — never remove a directory whose age we cannot verify.
-                // btime being unsupported on the filesystem is expected noise; downgrade
-                // to warn. anything else is unexpected and stays at error.
-                if is_unsupported_io_error(&err) {
-                    tracing::warn!(
-                        "time filter evaluation unsupported for dir {:?}, leaving it intact: {:#}",
-                        &path,
-                        &err
-                    );
-                } else {
-                    tracing::error!(
-                        "time filter evaluation failed for dir {:?}, leaving it intact: {:#}",
-                        &path,
-                        &err
-                    );
-                }
-                false
-            }
-        }
-    } else {
-        true
-    };
-    // handle dry-run mode for directories.
-    // `traversed_only` catches dirs only entered to search for include pattern matches.
-    // `anything_skipped` catches dirs that would still have content after partial removal.
-    // `!dir_passes_time_filter` catches dirs whose own timestamps disqualify removal.
-    // the real-mode path below only needs `traversed_only` and `!dir_passes_time_filter`
-    // because the subsequent `remove_dir` call handles the non-empty case via ENOTEMPTY.
-    if settings.dry_run.is_some() {
-        if traversed_only || anything_skipped || !dir_passes_time_filter {
-            tracing::debug!(
-                "dry-run: directory {:?} would not be removed (removed={}, skipped={}, time_ok={})",
-                &path,
-                anything_removed,
-                anything_skipped,
-                dir_passes_time_filter
-            );
-            if !dir_passes_time_filter {
-                prog_track.directories_skipped.inc();
-                rm_summary.directories_skipped += 1;
             }
         } else {
-            crate::dry_run::report_action("remove", path, None, "dir");
-            rm_summary.directories_removed += 1;
-        }
-        return Ok(rm_summary);
-    }
-    // skip directories that were only traversed to look for include matches.
-    // not needed for exclude-only filters or directly-matched directories.
-    // non-empty directories are handled by the ENOTEMPTY check below.
-    if traversed_only {
-        tracing::debug!(
-            "directory {:?} had nothing removed, leaving it intact",
-            &path
-        );
-        return Ok(rm_summary);
-    }
-    // skip directories whose own timestamps don't satisfy the time filter.
-    // children have already been processed; this only gates the dir's own removal.
-    if !dir_passes_time_filter {
-        tracing::debug!(
-            "directory {:?} skipped by time filter, leaving it intact",
-            &path
-        );
-        prog_track.directories_skipped.inc();
-        rm_summary.directories_skipped += 1;
-        return Ok(rm_summary);
-    }
-    // when filtering is active, directories may not be empty because we only removed
-    // matching files (includes) or skipped excluded files; use remove_dir (not remove_dir_all)
-    // so non-empty directories fail gracefully with ENOTEMPTY
-    let any_filter_active = settings.filter.is_some() || settings.time_filter.is_some();
-    match crate::walk::run_metadata_probed(
-        congestion::Side::Destination,
-        congestion::MetadataOp::RmDir,
-        tokio::fs::remove_dir(path),
-    )
-    .await
-    {
-        Ok(()) => {
-            prog_track.directories_removed.inc();
-            rm_summary.directories_removed += 1;
-            // the directory is gone, so there's nothing to restore on drop.
-            relaxed_guard.defuse();
-        }
-        Err(err) if any_filter_active => {
-            // with filtering, it's expected that directories may not be empty because we only
-            // removed matching files; raw_os_error 39 is ENOTEMPTY on Linux. this is not an
-            // error — surface it at info so users can see which directories survived.
-            if err.kind() == std::io::ErrorKind::DirectoryNotEmpty || err.raw_os_error() == Some(39)
-            {
-                tracing::info!(
-                    "directory {:?} not empty after filtering, leaving it intact",
-                    &path
+            true
+        };
+        // handle dry-run mode for directories.
+        // `traversed_only` catches dirs only entered to search for include pattern matches.
+        // `anything_skipped` catches dirs that would still have content after partial removal.
+        // `!dir_passes_time_filter` catches dirs whose own timestamps disqualify removal.
+        // the real-mode path below only needs `traversed_only` and `!dir_passes_time_filter`
+        // because the subsequent `rmdir_at` call handles the non-empty case via ENOTEMPTY.
+        if settings.dry_run.is_some() {
+            if traversed_only || anything_skipped || !dir_passes_time_filter {
+                tracing::debug!(
+                    "dry-run: directory {:?} would not be removed (removed={}, skipped={}, time_ok={})",
+                    &path,
+                    anything_removed,
+                    anything_skipped,
+                    dir_passes_time_filter
                 );
+                if !dir_passes_time_filter {
+                    prog_track.directories_skipped.inc();
+                    rm_summary.directories_skipped += 1;
+                }
             } else {
+                crate::dry_run::report_action("remove", path, None, "dir");
+                rm_summary.directories_removed += 1;
+            }
+            return Ok(rm_summary);
+        }
+        // skip directories that were only traversed to look for include matches.
+        // not needed for exclude-only filters or directly-matched directories.
+        // non-empty directories are handled by the ENOTEMPTY check below.
+        if traversed_only {
+            tracing::debug!(
+                "directory {:?} had nothing removed, leaving it intact",
+                &path
+            );
+            return Ok(rm_summary);
+        }
+        // skip directories whose own timestamps don't satisfy the time filter.
+        // children have already been processed; this only gates the dir's own removal.
+        if !dir_passes_time_filter {
+            tracing::debug!(
+                "directory {:?} skipped by time filter, leaving it intact",
+                &path
+            );
+            prog_track.directories_skipped.inc();
+            rm_summary.directories_skipped += 1;
+            return Ok(rm_summary);
+        }
+        // when filtering is active, directories may not be empty because we only removed
+        // matching files (includes) or skipped excluded files; use rmdir (not a recursive remove)
+        // so non-empty directories fail gracefully with ENOTEMPTY. the rmdir is fd-relative
+        // (resolved against the parent fd) so it cannot be redirected to a different directory.
+        // gated on the Destination side to match the side the path-based rm used for remove_dir.
+        let any_filter_active = settings.filter.is_some() || settings.time_filter.is_some();
+        match cx
+            .parent
+            .rmdir_at_on(&cx.name, congestion::Side::Destination)
+            .await
+        {
+            Ok(()) => {
+                prog_track.directories_removed.inc();
+                rm_summary.directories_removed += 1;
+                // the directory is gone, so there's nothing to restore on drop.
+                if let Some(guard) = guard.as_mut() {
+                    guard.defuse();
+                }
+            }
+            Err(err) if any_filter_active => {
+                // with filtering, it's expected that directories may not be empty because we only
+                // removed matching files; raw_os_error 39 is ENOTEMPTY on Linux. this is not an
+                // error — surface it at info so users can see which directories survived.
+                if err.kind() == std::io::ErrorKind::DirectoryNotEmpty
+                    || err.raw_os_error() == Some(39)
+                {
+                    tracing::info!(
+                        "directory {:?} not empty after filtering, leaving it intact",
+                        &path
+                    );
+                } else {
+                    return Err(Error::new(
+                        anyhow!(err).context(format!("failed removing directory {:?}", &path)),
+                        rm_summary,
+                    ));
+                }
+            }
+            Err(err) => {
                 return Err(Error::new(
                     anyhow!(err).context(format!("failed removing directory {:?}", &path)),
                     rm_summary,
                 ));
             }
         }
-        Err(err) => {
-            return Err(Error::new(
-                anyhow!(err).context(format!("failed removing directory {:?}", &path)),
-                rm_summary,
-            ));
-        }
+        Ok(rm_summary)
     }
-    Ok(rm_summary)
 }
 
 #[cfg(test)]
@@ -1831,6 +2052,247 @@ mod tests {
             assert!(!known_leaf(Some(dir_ft)), "directory must skip pre-acquire");
             assert!(known_leaf(Some(file_ft)), "regular file must pre-acquire");
             std::fs::remove_dir_all(&tmp).ok();
+            Ok(())
+        }
+
+        /// Regression for the hold-and-wait deadlock when a getdents leaf-hint entry is actually a
+        /// directory (the DT_UNKNOWN edge, or a swap between `getdents` and the authoritative
+        /// `child()`). The walk pre-acquires a `pending_meta` permit for hinted leaves only; if such
+        /// an entry turns out to be a directory, the spawned task must DROP that permit before
+        /// recursing — otherwise it holds the permit AND its children block trying to acquire one,
+        /// and with a saturated pool the whole walk hangs.
+        ///
+        /// This reproduces that exact shape deterministically by driving the `RmVisitor` through the
+        /// driver's [`process_entry`] with the one-and-only permit pre-acquired by the caller
+        /// (mirroring the spawn loop's hinted-leaf pre-acquire). With the bug, the directory branch
+        /// would hold that permit while recursing into the directory, whose child file then blocks
+        /// forever on `pending_meta` (pool size 1, already held by us) — the timeout fires. With the
+        /// fix, the driver's single drop-before-recurse site releases the permit on the directory
+        /// path before recursing, the child acquires it, and removal completes well within the
+        /// timeout.
+        #[tokio::test]
+        #[traced_test]
+        async fn hinted_leaf_that_is_dir_drops_permit_before_recursion() -> anyhow::Result<()> {
+            let root = testutils::create_temp_dir().await?;
+            // `d` is a directory (the authoritative type) holding one child file `c`.
+            let dir_path = root.join("d");
+            tokio::fs::create_dir(&dir_path).await?;
+            tokio::fs::write(dir_path.join("c"), b"x").await?;
+            // size the pending-meta pool to a single permit so a held-across-recursion permit
+            // strands the child's pre-acquire — the saturation the fd-walk must tolerate.
+            throttle::set_max_open_files(1);
+            // open the container of `d` and classify `d` itself: an authoritative directory.
+            let parent = Dir::open_parent_dir(&root, congestion::Side::Source)
+                .await
+                .context("open parent dir")?;
+            let parent = Arc::new(parent.into_tree());
+            let name = std::ffi::OsStr::new("d");
+            let handle = parent.child(name).await.context("classify d")?;
+            assert_eq!(
+                handle.kind(),
+                EntryKind::Dir,
+                "fixture `d` must be a directory"
+            );
+            drop(handle);
+            let settings = Settings {
+                fail_early: true,
+                filter: None,
+                dry_run: None,
+                time_filter: None,
+            };
+            let visitor = Arc::new(RmVisitor {
+                prog_track: &PROGRESS,
+                settings: settings.clone(),
+            });
+            let cx = EntryCx {
+                parent: Arc::clone(&parent),
+                name: name.to_owned(),
+                rel_path: std::path::PathBuf::new(),
+                filter_path: std::path::PathBuf::new(),
+                real_path: dir_path.clone(),
+                dry_run: false,
+                prog_track: &PROGRESS,
+            };
+            // pre-acquire the single permit exactly as the spawn loop does for a hinted leaf, and
+            // hand it to `process_entry`. The fix drops it before recursing into the directory.
+            let permit = crate::walk::preacquire_leaf_permit(
+                PermitKind::PendingMeta,
+                Some(EntryKind::File),
+                |_| true,
+            )
+            .await;
+            assert!(permit.is_some(), "the pre-acquire must take the one permit");
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(20),
+                process_entry(visitor, cx, (), permit),
+            )
+            .await;
+            // restore the default (disabled) pool before asserting so a failure here can't strand
+            // the tiny limit for any concurrent test (the serial group already isolates us, but
+            // this keeps the process-global knob clean on the failure path too).
+            throttle::set_max_open_files(0);
+            let summary = result
+                .context(
+                    "process_entry hung — leaf permit held across directory recursion (deadlock)",
+                )?
+                .map_err(|e| e.source)?;
+            assert_eq!(summary.files_removed, 1, "child file should be removed");
+            assert_eq!(
+                summary.directories_removed, 1,
+                "directory should be removed"
+            );
+            assert!(!dir_path.exists(), "directory `d` should be gone");
+            Ok(())
+        }
+    }
+
+    /// TOCTOU race tests for the fd-based recursive removal.
+    mod race_tests {
+        use super::*;
+
+        static RACE_PROGRESS: std::sync::LazyLock<progress::Progress> =
+            std::sync::LazyLock::new(progress::Progress::new);
+
+        /// Repeatedly swap `tree/sub` between a real directory (holding a real file) and a symlink
+        /// to an OUT-OF-TREE sentinel directory, using rename so each individual state is atomic.
+        /// Two staging names live alongside `sub` and are renamed over it in a tight loop until
+        /// `stop` is set. Runs on a dedicated OS thread so it makes progress regardless of the
+        /// tokio runtime's scheduling. Mirrors copy's `intermediate_dir_swap_never_follows_symlink`
+        /// swapper.
+        fn spawn_dir_symlink_swapper(
+            tree: std::path::PathBuf,
+            sentinel: std::path::PathBuf,
+            stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        ) -> std::thread::JoinHandle<()> {
+            std::thread::spawn(move || {
+                let sub = tree.join("sub");
+                let staged_dir = tree.join("__staged_sub_dir");
+                let staged_link = tree.join("__staged_sub_link");
+                while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    // stage a real directory (with a real file) then swap it in over `sub`.
+                    let _ = std::fs::remove_dir_all(&staged_dir);
+                    if std::fs::create_dir(&staged_dir).is_ok() {
+                        let _ = std::fs::write(staged_dir.join("real.txt"), b"REAL");
+                        // RENAME_EXCHANGE isn't portable here; remove-then-rename. The window where
+                        // `sub` is briefly absent is fine — rm may error, an accepted failed-closed
+                        // outcome. (rm must still never touch the out-of-tree sentinel.)
+                        let _ = std::fs::remove_dir_all(&sub);
+                        let _ = std::fs::remove_file(&sub);
+                        let _ = std::fs::rename(&staged_dir, &sub);
+                    }
+                    // stage a symlink to the out-of-tree sentinel dir, then swap it in over `sub`.
+                    let _ = std::fs::remove_file(&staged_link);
+                    if std::os::unix::fs::symlink(&sentinel, &staged_link).is_ok() {
+                        let _ = std::fs::remove_dir_all(&sub);
+                        let _ = std::fs::remove_file(&sub);
+                        let _ = std::fs::rename(&staged_link, &sub);
+                    }
+                }
+            })
+        }
+
+        /// While `rm` removes a tree, a background thread rapidly flips an intermediate directory
+        /// `tree/sub` between a real directory and a symlink to a SENTINEL directory tree that
+        /// lives OUTSIDE the target, holding files that must never be deleted.
+        ///
+        /// [`RmVisitor::dir_pre`] descends a directory via [`Dir::open_dir`] (`O_NOFOLLOW|O_DIRECTORY`), so if
+        /// `sub` is a symlink at the moment of descent the open fails closed (ELOOP/ENOTDIR) and
+        /// the walk never follows it into the sentinel. If `sub` is a symlink at the moment of
+        /// classification it is treated as a leaf and `unlink_at` removes the LINK, never its
+        /// target. Either way the out-of-tree sentinel files survive — that is the safety
+        /// assertion, checked on every iteration regardless of timing. Also confirms the run
+        /// terminates (per-op timeout) rather than hanging or following the link.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn intermediate_dir_swap_never_deletes_out_of_tree_sentinel() -> anyhow::Result<()> {
+            let tmp = testutils::create_temp_dir().await?;
+            let root = tmp.as_path();
+            // the sentinel tree lives OUTSIDE the rm target, reachable only via the swapped symlink.
+            let sentinel = root.join("sentinel_tree");
+            tokio::fs::create_dir(&sentinel).await?;
+            tokio::fs::write(sentinel.join("secret1.txt"), b"SECRET-1").await?;
+            tokio::fs::create_dir(sentinel.join("subdir")).await?;
+            tokio::fs::write(sentinel.join("subdir").join("secret2.txt"), b"SECRET-2").await?;
+
+            let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let swapper =
+                spawn_dir_symlink_swapper(root.to_path_buf(), sentinel.clone(), stop.clone());
+
+            let settings = Settings {
+                fail_early: false,
+                filter: None,
+                dry_run: None,
+                time_filter: None,
+            };
+            let mut removed = 0usize;
+            let mut errored = 0usize;
+            for i in 0..400 {
+                // (re)create the target tree. To MAXIMIZE the chance rm encounters `tree/sub` while
+                // the background thread has it in the symlink state, give `tree` many sibling
+                // subdirectories with files: rm spends real time enumerating/removing them
+                // concurrently with the swapper's flips, widening the window in which `sub` is
+                // classified/descended mid-swap. On even iterations we additionally seed `sub` as a
+                // symlink-to-sentinel up front, deterministically exercising the "intermediate is a
+                // symlink at classification time → unlink the link, never recurse the target" path.
+                let tree = root.join("tree");
+                let _ = tokio::fs::create_dir(&tree).await;
+                for d in 0..16 {
+                    let sib = tree.join(format!("sib_{d}"));
+                    let _ = tokio::fs::create_dir(&sib).await;
+                    for f in 0..4 {
+                        let _ = tokio::fs::write(sib.join(format!("f{f}.txt")), b"x").await;
+                    }
+                }
+                let sub = tree.join("sub");
+                if i % 2 == 0 {
+                    // deterministically place a symlink-to-sentinel at `sub` (best-effort; the
+                    // swapper may immediately flip it — that's fine, both states are safe).
+                    let _ = tokio::fs::remove_dir_all(&sub).await;
+                    let _ = tokio::fs::remove_file(&sub).await;
+                    let _ = tokio::fs::symlink(&sentinel, &sub).await;
+                } else if tokio::fs::symlink_metadata(&sub).await.is_err() {
+                    let _ = tokio::fs::create_dir(&sub).await;
+                    let _ = tokio::fs::write(sub.join("real.txt"), b"REAL").await;
+                }
+                let result = tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    super::rm(&RACE_PROGRESS, &tree, &settings),
+                )
+                .await
+                .expect("rm must not hang under concurrent dir swapping");
+                match result {
+                    Ok(_) => removed += 1,
+                    Err(_) => errored += 1, // a swap was caught mid-walk (failed closed) — accepted
+                }
+                // CORE SAFETY ASSERTION (holds on every iteration regardless of timing): the
+                // out-of-tree sentinel tree and its files are NEVER deleted by rm — neither by
+                // following a symlinked `sub` (unlink removes the link, not the target) nor by
+                // descending it (open_dir's O_NOFOLLOW fails closed).
+                assert!(
+                    sentinel.exists(),
+                    "iteration {i}: sentinel directory was deleted — rm followed the symlink"
+                );
+                let s1 = tokio::fs::read(sentinel.join("secret1.txt")).await;
+                assert!(
+                    matches!(&s1, Ok(b) if b == b"SECRET-1"),
+                    "iteration {i}: sentinel/secret1.txt was deleted or altered — rm followed the symlink"
+                );
+                let s2 = tokio::fs::read(sentinel.join("subdir").join("secret2.txt")).await;
+                assert!(
+                    matches!(&s2, Ok(b) if b == b"SECRET-2"),
+                    "iteration {i}: sentinel/subdir/secret2.txt was deleted — rm recursed through the symlink"
+                );
+                // clean up any leftover tree before the next iteration (best-effort).
+                let _ = tokio::fs::remove_dir_all(root.join("tree")).await;
+            }
+
+            stop.store(true, std::sync::atomic::Ordering::Relaxed);
+            swapper.join().expect("dir swapper thread panicked");
+            // sanity (not the safety assertion): the run did observable work across the iterations.
+            tracing::info!("intermediate dir swap: removed={removed}, errored={errored}");
+            assert!(
+                removed + errored > 0,
+                "expected at least one observable outcome across the iterations"
+            );
             Ok(())
         }
     }

--- a/common/src/safedir.rs
+++ b/common/src/safedir.rs
@@ -1,0 +1,2522 @@
+//! Safe, race-resistant directory traversal primitives.
+//!
+//! This module provides `O_NOFOLLOW`-based directory and file handle types that
+//! prevent TOCTOU races by using file-descriptor-relative syscalls (`openat`,
+//! `fstatat`) rather than path-based lookups. Every `open_dir`/`child` call
+//! refuses to follow symlinks, so an attacker who races a directory walk cannot
+//! redirect operations outside the intended tree.
+
+use std::ffi::OsStr;
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::sync::Arc;
+
+use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+
+use nix::fcntl::{AT_FDCWD, AtFlags, OFlag, openat, readlinkat};
+use nix::sys::stat::{FileStat, Mode, fchmod, fstat, fstatat, futimens, mkdirat};
+use nix::sys::time::TimeSpec;
+use nix::unistd::{Gid, Uid, UnlinkatFlags, fchown, fchownat, linkat, symlinkat, unlinkat};
+
+use crate::walk::EntryKind;
+
+// ── FileMeta ──────────────────────────────────────────────────────────────────
+
+/// A snapshot of filesystem metadata obtained via `fstat`/`fstatat`.
+///
+/// Implements [`crate::preserve::Metadata`] so callers can apply these fields
+/// to another entry with the existing `set_*_metadata` helpers.
+#[derive(Clone, Debug)]
+pub struct FileMeta {
+    uid: u32,
+    gid: u32,
+    atime: i64,
+    atime_nsec: i64,
+    mtime: i64,
+    mtime_nsec: i64,
+    ctime: i64,
+    ctime_nsec: i64,
+    mode: u32,
+    size: u64,
+}
+
+impl FileMeta {
+    fn from_stat(st: &FileStat) -> Self {
+        Self {
+            uid: st.st_uid,
+            gid: st.st_gid,
+            atime: st.st_atime,
+            atime_nsec: st.st_atime_nsec,
+            mtime: st.st_mtime,
+            mtime_nsec: st.st_mtime_nsec,
+            ctime: st.st_ctime,
+            ctime_nsec: st.st_ctime_nsec,
+            mode: st.st_mode,
+            size: st.st_size as u64,
+        }
+    }
+}
+
+impl crate::preserve::Metadata for FileMeta {
+    fn uid(&self) -> u32 {
+        self.uid
+    }
+    fn gid(&self) -> u32 {
+        self.gid
+    }
+    fn atime(&self) -> i64 {
+        self.atime
+    }
+    fn atime_nsec(&self) -> i64 {
+        self.atime_nsec
+    }
+    fn mtime(&self) -> i64 {
+        self.mtime
+    }
+    fn mtime_nsec(&self) -> i64 {
+        self.mtime_nsec
+    }
+    fn permissions(&self) -> std::fs::Permissions {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::Permissions::from_mode(self.mode)
+    }
+    fn ctime(&self) -> i64 {
+        self.ctime
+    }
+    fn ctime_nsec(&self) -> i64 {
+        self.ctime_nsec
+    }
+    fn size(&self) -> u64 {
+        self.size
+    }
+}
+
+// ── EntryKind classification ───────────────────────────────────────────────────
+
+fn kind_from_stat(st: &FileStat) -> EntryKind {
+    let mode = st.st_mode;
+    // use libc mode-classification macros via their bit patterns (POSIX S_IFMT)
+    // S_IFREG = 0o0100000, S_IFDIR = 0o0040000, S_IFLNK = 0o0120000
+    let ifmt = mode & libc::S_IFMT;
+    match ifmt {
+        libc::S_IFREG => EntryKind::File,
+        libc::S_IFDIR => EntryKind::Dir,
+        libc::S_IFLNK => EntryKind::Symlink,
+        _ => EntryKind::Special,
+    }
+}
+
+// ── Handle ────────────────────────────────────────────────────────────────────
+
+/// An open, classified handle to a filesystem entry obtained via `O_PATH|O_NOFOLLOW`.
+///
+/// The fd is opened with `O_PATH`, so it cannot be used for reading; it exists
+/// solely to identify the entry (for further `openat` calls relative to it) and
+/// to carry the stat snapshot. A symlink entry is never followed: it yields a
+/// `Handle` with `kind() == EntryKind::Symlink`.
+#[derive(Debug)]
+pub struct Handle {
+    fd: OwnedFd,
+    kind: EntryKind,
+    dev: u64,
+    ino: u64,
+    meta: FileMeta,
+}
+
+impl Handle {
+    /// The entry's classification (File / Dir / Symlink / Special).
+    #[must_use]
+    pub fn kind(&self) -> EntryKind {
+        self.kind
+    }
+
+    /// The device number of the entry.
+    #[must_use]
+    pub fn dev(&self) -> u64 {
+        self.dev
+    }
+
+    /// The inode number of the entry.
+    #[must_use]
+    pub fn ino(&self) -> u64 {
+        self.ino
+    }
+
+    /// A snapshot of the entry's metadata at the time the handle was opened.
+    #[must_use]
+    pub fn meta(&self) -> &FileMeta {
+        &self.meta
+    }
+
+    /// Borrow the underlying file descriptor.
+    #[must_use]
+    pub fn as_fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
+    }
+
+    /// Duplicate this handle, sharing the same pinned inode via a `dup`'d
+    /// (`F_DUPFD_CLOEXEC`) `O_PATH` file descriptor and copying the cached
+    /// classification + stat snapshot.
+    ///
+    /// This is a pure fd dup — it opens nothing, follows nothing, and stats
+    /// nothing on the filesystem, so it preserves every TOCTOU property of the
+    /// original `O_PATH|O_NOFOLLOW` handle (the clone pins the exact same inode and
+    /// cannot be redirected by a concurrent rename/symlink swap). It lets a walk
+    /// that classifies an entry once hand an owned handle to a deferred (post-order)
+    /// step without a second `openat`/`fstatat` on the entry.
+    pub fn try_clone(&self) -> std::io::Result<Handle> {
+        Ok(Handle {
+            fd: self.fd.try_clone()?,
+            kind: self.kind,
+            dev: self.dev,
+            ino: self.ino,
+            meta: self.meta.clone(),
+        })
+    }
+
+    /// Read this symlink's target and metadata from the one pinned `O_PATH` fd: the target via the
+    /// empty-path `readlinkat` ([`read_link_handle`]) and the metadata from this handle's `fstat`
+    /// snapshot. Both describe the same pinned inode, so they are a faithful pair (the symlink
+    /// analogue of [`Dir::open_file_read`]'s `(File, FileMeta)`). Errors if the handle is not a
+    /// symlink (the empty-path read requires a symlink fd).
+    pub async fn read_symlink(
+        &self,
+        side: congestion::Side,
+    ) -> std::io::Result<(std::path::PathBuf, FileMeta)> {
+        let target = read_link_handle(self, side).await?;
+        Ok((target, self.meta.clone()))
+    }
+}
+
+// ── Dir ───────────────────────────────────────────────────────────────────────
+
+/// A directory file descriptor opened `O_RDONLY|O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC`.
+///
+/// All entry-level operations are relative to this fd, preventing TOCTOU races
+/// that path-based lookups are vulnerable to.
+///
+/// The fd is held behind an `Arc` so per-entry operations can move an owned
+/// reference into their `spawn_blocking` closure. `spawn_blocking` tasks are
+/// not cancellable: if the surrounding future is dropped (timeout, `fail_early`
+/// abort, Ctrl-C) the closure keeps running detached. Cloning the `Arc` (a
+/// refcount bump, no syscall) keeps the open file description alive for the
+/// closure's full duration even if the originating `Dir` is dropped mid-flight,
+/// preserving the `openat` TOCTOU guarantee. Later fd-relative methods
+/// (`open_file_read`, `create_file`, `make_dir`, `read_entries`, …) must follow
+/// this same clone-Arc-into-closure shape.
+#[derive(Debug)]
+pub struct Dir {
+    fd: Arc<OwnedFd>,
+    /// Which filesystem side this directory lives on, for congestion gating.
+    side: congestion::Side,
+}
+
+impl Dir {
+    /// Which filesystem side this directory lives on (for congestion gating).
+    #[must_use]
+    pub fn side(&self) -> congestion::Side {
+        self.side
+    }
+
+    /// Open `path` as a directory fd.
+    ///
+    /// The final component is always opened with `O_NOFOLLOW`. If `dereference`
+    /// is `false` and the final component is a symlink, the call fails with
+    /// `ELOOP`. If `dereference` is `true` and the final component is a symlink,
+    /// the call is retried without `O_NOFOLLOW` so the symlink is followed.
+    ///
+    /// The parent prefix is resolved normally (it is trusted).
+    pub async fn open_root_dir(
+        path: &Path,
+        dereference: bool,
+        side: congestion::Side,
+    ) -> std::io::Result<Dir> {
+        let path = path.to_owned();
+        // run the blocking openat inside spawn_blocking, gated by the congestion
+        // controller, matching the per-metadata-syscall pattern used across the crate.
+        run_metadata_probed_blocking(side, congestion::MetadataOp::Stat, move || {
+            let flags = OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC;
+            let mode = Mode::empty();
+            match openat(AT_FDCWD, &path, flags, mode) {
+                Ok(fd) => Ok(Dir {
+                    fd: Arc::new(fd),
+                    side,
+                }),
+                Err(nix::errno::Errno::ELOOP) if dereference => {
+                    // final component is a symlink; follow it only when dereference=true
+                    let follow_flags = OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC;
+                    openat(AT_FDCWD, &path, follow_flags, mode)
+                        .map(|fd| Dir {
+                            fd: Arc::new(fd),
+                            side,
+                        })
+                        .map_err(nix_to_io)
+                }
+                Err(e) => Err(nix_to_io(e)),
+            }
+        })
+        .await
+    }
+
+    /// Open a TRUSTED command-line parent-prefix directory, resolving symlinks
+    /// normally (the final component IS followed if it is a symlink).
+    ///
+    /// The trusted-boundary model (design spec §2) trusts the directory named on
+    /// the command line up to and including itself; only entries strictly BELOW
+    /// it are hardened with `O_NOFOLLOW`. The parent prefix that CONTAINS the
+    /// operand is therefore resolved like a normal path open — a symlinked parent
+    /// (e.g. `rcp file symlink_to_dir/out`, where `symlink_to_dir` is a symlink to
+    /// a real directory) must be followed into the real directory, not rejected
+    /// with `ELOOP`/`ENOTDIR`.
+    ///
+    /// This differs from [`Self::open_root_dir`], which `O_NOFOLLOW`s the final
+    /// component (the named operand itself) and only follows it when
+    /// `dereference` is set. Use `open_parent_dir` for the operand's CONTAINER
+    /// directory; use `open_root_dir` for the operand entry. Every descendant
+    /// `openat` during the walk still uses `O_NOFOLLOW`, so the hardening below
+    /// the named root is unaffected.
+    ///
+    /// Returns a [`TrustedDir`]: this is the ONLY constructor of that type, so a
+    /// symlink-following open can be obtained nowhere else. Crossing into the
+    /// hardened tree below the named root is the explicit [`TrustedDir::into_tree`]
+    /// step.
+    pub async fn open_parent_dir(
+        path: &Path,
+        side: congestion::Side,
+    ) -> std::io::Result<TrustedDir> {
+        let path = path.to_owned();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::Stat, move || {
+            // a normal directory open: the kernel resolves the whole path following
+            // symlinks, including the final (trusted parent) component. No O_NOFOLLOW.
+            let flags = OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_CLOEXEC;
+            openat(AT_FDCWD, &path, flags, Mode::empty())
+                .map(|fd| {
+                    TrustedDir(Dir {
+                        fd: Arc::new(fd),
+                        side,
+                    })
+                })
+                .map_err(nix_to_io)
+        })
+        .await
+    }
+
+    /// Open a child directory entry by name, refusing to follow symlinks.
+    ///
+    /// Fails with `ELOOP` if `name` refers to a symlink, or `ENOTDIR` if it
+    /// refers to a non-directory entry. The returned `Dir` carries the same
+    /// congestion side as `self`.
+    pub async fn open_dir(&self, name: &OsStr) -> std::io::Result<Dir> {
+        // `O_NOFOLLOW`/`O_PATH` only guard the final path component, so a `name`
+        // containing `/` could let openat traverse an intermediate symlink. Reject
+        // multi-component names at runtime (debug_assert is compiled out in release).
+        if !is_single_component(name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        // clone the Arc (refcount bump, no syscall) and move it into the blocking
+        // closure so the open file description stays alive for the closure's full
+        // duration even if this Dir is dropped mid-flight (spawn_blocking is not
+        // cancellable). see the Dir doc comment.
+        let dir = self.fd.clone();
+        let side = self.side;
+        let name = name.to_owned();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::Stat, move || {
+            let flags = OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC;
+            openat(dir.as_fd(), name.as_bytes(), flags, Mode::empty())
+                .map(|fd| Dir {
+                    fd: Arc::new(fd),
+                    side,
+                })
+                .map_err(nix_to_io)
+        })
+        .await
+    }
+
+    /// Open a child regular file for reading, refusing to follow symlinks and never
+    /// blocking on a FIFO. Returns the open file plus its metadata snapshot.
+    ///
+    /// `O_NONBLOCK` is included so that if an attacker races the directory entry to
+    /// a FIFO between `getdents` and this `open`, the open returns immediately
+    /// (`O_RDONLY|O_NONBLOCK` on a FIFO never blocks on Linux) rather than blocking
+    /// forever waiting for a writer. `O_NOFOLLOW` prevents symlink following but
+    /// does not catch FIFOs (they are not symlinks); the subsequent `fstat` +
+    /// `S_ISREG` check rejects any non-regular file (FIFO, device, directory) with
+    /// `EINVAL`. `O_NONBLOCK` persists on the returned `File`, which is harmless for
+    /// regular-file I/O on a local fs.
+    ///
+    /// Fails with `EINVAL` if `name` is not a single path component, `ELOOP` if
+    /// `name` is a symlink, or `EINVAL` (after open, via the `fstat`+`S_ISREG`
+    /// check) if the entry is any non-regular type such as a FIFO, device, or
+    /// directory.
+    ///
+    /// This is the canonical regular-file payload+metadata read: the returned `FileMeta` (not the
+    /// classify [`Handle`]'s metadata) is what callers must apply/send, so bytes and metadata come
+    /// from the same fd (read-side fidelity, see docs/tocttou.md).
+    pub async fn open_file_read(&self, name: &OsStr) -> std::io::Result<(std::fs::File, FileMeta)> {
+        if !is_single_component(name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        let dir = self.fd.clone();
+        let side = self.side;
+        let name = name.to_owned();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::Stat, move || {
+            let flags = OFlag::O_RDONLY | OFlag::O_NOFOLLOW | OFlag::O_NONBLOCK | OFlag::O_CLOEXEC;
+            let fd =
+                openat(dir.as_fd(), name.as_bytes(), flags, Mode::empty()).map_err(nix_to_io)?;
+            // fstat the open fd to confirm the entry is a regular file; this is the
+            // safety check — O_NOFOLLOW does not catch FIFOs or other special files.
+            let st = fstat(&fd).map_err(nix_to_io)?;
+            if kind_from_stat(&st) != EntryKind::File {
+                // fd is dropped here, closing it
+                return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+            }
+            let meta = FileMeta::from_stat(&st);
+            let file = std::fs::File::from(fd);
+            Ok((file, meta))
+        })
+        .await
+    }
+
+    /// `fstat` this directory's own held fd, returning its metadata snapshot.
+    ///
+    /// Lets a caller apply/send a directory's metadata from the SAME fd whose `read_entries`
+    /// produced its contents (read-side fidelity, see docs/tocttou.md), rather than from a
+    /// separately-opened classify [`Handle`] that a concurrent swap could desync from the
+    /// enumerated contents. Gated as `Stat`.
+    pub async fn meta(&self) -> std::io::Result<FileMeta> {
+        let dir = self.fd.clone();
+        let side = self.side;
+        run_metadata_probed_blocking(side, congestion::MetadataOp::Stat, move || {
+            let st = fstat(dir.as_fd()).map_err(nix_to_io)?;
+            Ok(FileMeta::from_stat(&st))
+        })
+        .await
+    }
+
+    /// Open a child entry by name, classifying it without following symlinks.
+    ///
+    /// Uses `O_PATH|O_NOFOLLOW`, which yields a valid fd even for symlinks. The
+    /// stat is then obtained via `fstatat` with `AT_EMPTY_PATH` on the resulting
+    /// fd so the classification is always consistent with the opened entry.
+    pub async fn child(&self, name: &OsStr) -> std::io::Result<Handle> {
+        // see open_dir: `O_NOFOLLOW`/`O_PATH` only guard the final component, so a
+        // `name` containing `/` could traverse an intermediate symlink. Reject
+        // multi-component names at runtime (debug_assert is compiled out in release).
+        if !is_single_component(name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        // clone the Arc (refcount bump, no syscall) and move it into the blocking
+        // closure so the open file description stays alive for the closure's full
+        // duration even if this Dir is dropped mid-flight (spawn_blocking is not
+        // cancellable). see the Dir doc comment.
+        let dir = self.fd.clone();
+        let side = self.side;
+        let name = name.to_owned();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::Stat, move || {
+            let flags = OFlag::O_PATH | OFlag::O_NOFOLLOW | OFlag::O_CLOEXEC;
+            let fd =
+                openat(dir.as_fd(), name.as_bytes(), flags, Mode::empty()).map_err(nix_to_io)?;
+            // stat the fd itself (empty path + AT_EMPTY_PATH): works for symlinks too
+            let st = fstatat(&fd, "", AtFlags::AT_EMPTY_PATH).map_err(nix_to_io)?;
+            let kind = kind_from_stat(&st);
+            let dev = st.st_dev;
+            let ino = st.st_ino;
+            let meta = FileMeta::from_stat(&st);
+            Ok(Handle {
+                fd,
+                kind,
+                dev,
+                ino,
+                meta,
+            })
+        })
+        .await
+    }
+
+    /// Re-open `name` and confirm it still refers to the same inode as `expected`
+    /// (same `dev` + `ino`). Returns the fresh [`Handle`] on match.
+    ///
+    /// On mismatch — the directory entry was swapped to a different inode between
+    /// when `expected` was obtained and this call — returns `ESTALE`. Callers fail
+    /// closed: they must not proceed with an operation that assumed a specific identity
+    /// for the entry.
+    ///
+    /// # Soundness
+    ///
+    /// `expected`'s `O_PATH` fd pins the old inode alive for the duration of the
+    /// call: as long as any fd referencing an inode is open, the kernel cannot
+    /// recycle that inode number. A matching `(dev, ino)` therefore genuinely
+    /// proves the two fds refer to the same inode — there is no window in which
+    /// the number could have been reused.
+    pub async fn recheck(&self, name: &OsStr, expected: &Handle) -> std::io::Result<Handle> {
+        if !is_single_component(name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        let fresh = self.child(name).await?;
+        if fresh.dev() == expected.dev() && fresh.ino() == expected.ino() {
+            Ok(fresh)
+        } else {
+            Err(std::io::Error::from_raw_os_error(libc::ESTALE))
+        }
+    }
+
+    /// Create a child directory and return an open `Dir` handle to it (same side as self).
+    ///
+    /// Fails with `EINVAL` if `name` is not a single path component, or `EEXIST` if
+    /// a directory (or any other entry) at `name` already exists.
+    ///
+    /// This is a two-step operation: `mkdirat` (gated as `MkDir`) to create the
+    /// directory, followed by `open_dir` (gated as `Stat`) to open and return it.
+    pub async fn make_dir(&self, name: &OsStr, mode: u32) -> std::io::Result<Dir> {
+        if !is_single_component(name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        let dir = self.fd.clone();
+        let side = self.side;
+        let name_owned = name.to_owned();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::MkDir, move || {
+            mkdirat(
+                dir.as_fd(),
+                name_owned.as_bytes(),
+                Mode::from_bits_truncate(mode),
+            )
+            .map_err(nix_to_io)
+        })
+        .await?;
+        self.open_dir(name).await
+    }
+
+    /// Enumerate the directory's entries (excluding `.` and `..`).
+    ///
+    /// Returns each entry's name and its `getdents` `d_type` as a best-effort
+    /// `EntryKind` hint (`None` when the filesystem reports `DT_UNKNOWN`). The
+    /// hint is advisory only — callers MUST confirm type via `child`/`fstat`
+    /// before acting (TOCTOU safety).
+    ///
+    /// This method acquires only the static ops rate gate (not the congestion
+    /// probe). Directory enumeration is deliberately not probed because buffered
+    /// `getdents` produces bimodal latency (cache hit vs. real kernel call) that
+    /// would pollute the congestion controller's baseline — see
+    /// `walk::next_entry_probed` for the full rationale.
+    pub async fn read_entries(
+        &self,
+    ) -> std::io::Result<Vec<(std::ffi::OsString, Option<EntryKind>)>> {
+        throttle::get_ops_token().await;
+        let dir = self.fd.clone();
+        tokio::task::spawn_blocking(move || {
+            // Dup the fd with FD_CLOEXEC so nix::dir::Dir can consume (and close)
+            // it on drop without touching self's Arc<OwnedFd>. A bare dup(2)
+            // would clear FD_CLOEXEC; F_DUPFD_CLOEXEC atomically sets it.
+            //
+            // Re-entrancy: the dup shares the original's open file description,
+            // and therefore its directory read offset. Reading to EOF advances
+            // that shared offset, so a naive `fdopendir` loop would leave self's
+            // fd at EOF and make a *second* read_entries() on the same Dir
+            // return an empty listing. nix's borrowing `Iter` (from
+            // `nix_dir.iter()`) rewinds the shared description in its `Drop`
+            // (rewinddir(3) → offset 0), and that `Drop` runs on BOTH normal
+            // completion AND the early `?`-return taken on a mid-iteration error
+            // — so the dup is always rewound before it is closed, leaving self's
+            // fd at offset 0 either way. This re-entrancy is load-bearing: the
+            // hardened remote source enumerates a directory in Pass 1 and again
+            // in Pass 2 on the *same* `Arc<Dir>`. (Additionally every caller
+            // treats an enumeration error as terminal and never re-enumerates the
+            // directory, so a partially-advanced offset is never observed
+            // regardless.)
+            let dup_raw: RawFd =
+                nix::fcntl::fcntl(dir.as_fd(), nix::fcntl::FcntlArg::F_DUPFD_CLOEXEC(0))
+                    .map_err(nix_to_io)?;
+            // SAFETY: dup_raw is a freshly-dup'd fd that we own exclusively; no
+            // other reference to it exists.
+            let dup_owned = unsafe { OwnedFd::from_raw_fd(dup_raw) };
+            let mut nix_dir = nix::dir::Dir::from_fd(dup_owned).map_err(nix_to_io)?;
+
+            let mut entries = Vec::new();
+            for entry_result in nix_dir.iter() {
+                let entry = entry_result.map_err(nix_to_io)?;
+                let name_cstr = entry.file_name();
+                // skip "." and ".."
+                if name_cstr == c"." || name_cstr == c".." {
+                    continue;
+                }
+                let name = std::ffi::OsStr::from_bytes(name_cstr.to_bytes()).to_owned();
+                let kind = entry.file_type().map(|t| match t {
+                    nix::dir::Type::Directory => EntryKind::Dir,
+                    nix::dir::Type::Symlink => EntryKind::Symlink,
+                    nix::dir::Type::File => EntryKind::File,
+                    _ => EntryKind::Special,
+                });
+                entries.push((name, kind));
+            }
+            // nix_dir drops here, closing the dup'd fd; self's fd is unaffected
+            Ok(entries)
+        })
+        .await
+        .map_err(std::io::Error::other)?
+    }
+
+    /// Remove a child non-directory entry by name, gated on this directory's own congestion side.
+    ///
+    /// For a symlink, this unlinks the link itself — never its target.
+    ///
+    /// Fails with `EINVAL` if `name` is not a single path component, or `EISDIR`
+    /// if `name` refers to a directory.
+    pub async fn unlink_at(&self, name: &OsStr) -> std::io::Result<()> {
+        self.unlink_at_on(name, self.side).await
+    }
+
+    /// Like [`Self::unlink_at`], but gates the `unlinkat` on an explicitly chosen congestion
+    /// `side` rather than the directory's own side.
+    ///
+    /// `rm` reads its tree on the `Source` side (its `Dir` handles are `Source`-sided, matching
+    /// the old path-based `symlink_metadata`/`read_dir`), but the destructive `unlinkat` must be
+    /// bucketed on `Destination` to match the side the path-based rm used for `remove_file` — so
+    /// it competes for the same metadata cwnd as other destructive work. The fd-relative TOCTOU
+    /// guarantee is unaffected: the syscall is still resolved against this directory's pinned fd.
+    pub(crate) async fn unlink_at_on(
+        &self,
+        name: &OsStr,
+        side: congestion::Side,
+    ) -> std::io::Result<()> {
+        if !is_single_component(name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        let dir = self.fd.clone();
+        let name = name.to_owned();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::Unlink, move || {
+            unlinkat(dir.as_fd(), name.as_bytes(), UnlinkatFlags::NoRemoveDir).map_err(nix_to_io)
+        })
+        .await
+    }
+
+    /// Remove a child empty directory by name, gated on this directory's own congestion side.
+    ///
+    /// Fails with `EINVAL` if `name` is not a single path component, `ENOTEMPTY`
+    /// if the directory is not empty, or `ENOTDIR` if `name` is not a directory.
+    pub async fn rmdir_at(&self, name: &OsStr) -> std::io::Result<()> {
+        self.rmdir_at_on(name, self.side).await
+    }
+
+    /// Like [`Self::rmdir_at`], but gates the `rmdir` on an explicitly chosen congestion `side`
+    /// rather than the directory's own side. See [`Self::unlink_at_on`] for why `rm` needs this
+    /// (`Destination`-sided removal from a `Source`-sided read walk).
+    pub(crate) async fn rmdir_at_on(
+        &self,
+        name: &OsStr,
+        side: congestion::Side,
+    ) -> std::io::Result<()> {
+        if !is_single_component(name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        let dir = self.fd.clone();
+        let name = name.to_owned();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::RmDir, move || {
+            unlinkat(dir.as_fd(), name.as_bytes(), UnlinkatFlags::RemoveDir).map_err(nix_to_io)
+        })
+        .await
+    }
+
+    /// Create a symlink `name` → `target` in this directory, returning a
+    /// fd-pinned `Handle` to the just-created link.
+    ///
+    /// The returned handle has `kind() == EntryKind::Symlink` and can be used to
+    /// apply metadata to the link race-free. `target` is the link contents — it
+    /// is an arbitrary path and is not restricted to a single component.
+    ///
+    /// Fails with `EINVAL` if `name` is not a single path component, or `EEXIST`
+    /// if an entry at `name` already exists.
+    pub async fn symlink_at(&self, name: &OsStr, target: &Path) -> std::io::Result<Handle> {
+        if !is_single_component(name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        let dir = self.fd.clone();
+        let side = self.side;
+        let name = name.to_owned();
+        let target = target.to_owned();
+        // clone `name` so we can call self.child() after the closure consumes it
+        let name_for_child = name.clone();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::Symlink, move || {
+            // symlinkat(target, dirfd, name): creates `name` → `target`
+            symlinkat(target.as_os_str().as_bytes(), dir.as_fd(), name.as_bytes())
+                .map_err(nix_to_io)
+        })
+        .await?;
+        // open the just-created link with O_PATH|O_NOFOLLOW so we get a Handle
+        // that is pinned to the symlink inode itself (not its target).
+        let handle = self.child(&name_for_child).await?;
+        if handle.kind() != EntryKind::Symlink {
+            // should never happen — we just created a symlink; if it somehow
+            // changed underneath us, report ENOENT to signal the caller.
+            return Err(std::io::Error::from_raw_os_error(libc::ENOENT));
+        }
+        Ok(handle)
+    }
+
+    /// Read the target of a child symlink.
+    ///
+    /// Fails with `EINVAL` if `name` is not a single path component, or `EINVAL`
+    /// (from `readlinkat`) if `name` is not a symlink.
+    pub async fn read_link_at(&self, name: &OsStr) -> std::io::Result<std::path::PathBuf> {
+        if !is_single_component(name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        let dir = self.fd.clone();
+        let side = self.side;
+        let name = name.to_owned();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::ReadLink, move || {
+            readlinkat(dir.as_fd(), name.as_bytes())
+                .map(std::path::PathBuf::from)
+                .map_err(nix_to_io)
+        })
+        .await
+    }
+
+    /// Create a hard link at `dst`/`dst_name` pointing to this directory's `name`.
+    ///
+    /// Uses `AtFlags::empty()` (flags=0, no `AT_SYMLINK_FOLLOW`), so if `name` is a
+    /// symlink, the link target is the symlink inode itself — the target file
+    /// gains no new hard link.
+    ///
+    /// Fails with `EINVAL` if either `name` or `dst_name` is not a single path
+    /// component.
+    pub async fn hard_link_at(
+        &self,
+        name: &OsStr,
+        dst: &Dir,
+        dst_name: &OsStr,
+    ) -> std::io::Result<()> {
+        if !is_single_component(name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        if !is_single_component(dst_name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        let src_dir = self.fd.clone();
+        let dst_dir = dst.fd.clone();
+        let side = dst.side;
+        let name = name.to_owned();
+        let dst_name = dst_name.to_owned();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::HardLink, move || {
+            linkat(
+                src_dir.as_fd(),
+                name.as_bytes(),
+                dst_dir.as_fd(),
+                dst_name.as_bytes(),
+                AtFlags::empty(),
+            )
+            .map_err(nix_to_io)
+        })
+        .await
+    }
+
+    /// Create a hard link at `self`/`dst_name` pointing to the EXACT inode that
+    /// `src_handle` pins — never re-resolving the source by name.
+    ///
+    /// `self` is the DESTINATION directory. The source is identified solely by
+    /// `src_handle`'s `O_PATH` file descriptor: the link is made via
+    /// `linkat(AT_FDCWD, "/proc/self/fd/N", dst_fd, dst_name, AT_SYMLINK_FOLLOW)`,
+    /// where `N` is the handle's fd. `AT_SYMLINK_FOLLOW` makes `linkat` follow the
+    /// `/proc` magic symlink to the handle's pinned inode, so the new hard link
+    /// targets that exact inode regardless of any concurrent rename / symlink swap
+    /// of the original directory entry.
+    ///
+    /// # Why /proc and not the source-name `linkat` or `AT_EMPTY_PATH`
+    ///
+    /// `Dir::hard_link_at` re-resolves the source by `name`, which is a TOCTOU
+    /// window: an attacker who controls the source tree can replace `name` with a
+    /// different inode (symlink, FIFO, another file) between classification and the
+    /// `linkat`, so the link would target the replacement. Linking the pinned fd
+    /// closes that window. `linkat(fd, "", .., AT_EMPTY_PATH)` would also be
+    /// inode-exact but requires `CAP_DAC_READ_SEARCH`; the `/proc/self/fd` form does
+    /// not, mirroring `chmod_via_proc_fd`.
+    ///
+    /// # Behavior
+    ///
+    /// - Inode-exact happy path: a stable regular-file handle links exactly as the
+    ///   by-name path did (same inode, same content).
+    /// - Fail-closed under attack: if the pinned inode's last directory entry was
+    ///   removed (link count 0, e.g. the attacker renamed `name` away), the kernel
+    ///   refuses to resurrect it and `linkat` fails with `ENOENT`. It never links a
+    ///   swapped-in replacement.
+    /// - Directories: `linkat` refuses to hard-link a directory (`EPERM`), exactly
+    ///   as the by-name path did. Callers must only pass a regular-file handle.
+    ///
+    /// # Errors
+    ///
+    /// `EINVAL` if `dst_name` is not a single path component; `ENOENT` if the pinned
+    /// inode has no remaining links (fail-closed); `EEXIST` if an entry at
+    /// `dst_name` already exists; `EPERM` if the handle refers to a directory.
+    /// Requires `/proc` mounted (same precondition as `chmod_via_proc_fd`).
+    pub async fn hard_link_handle_at(
+        &self,
+        src_handle: &Handle,
+        dst_name: &OsStr,
+    ) -> std::io::Result<()> {
+        if !is_single_component(dst_name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        // clone the source O_PATH fd into an owned fd the blocking closure can hold,
+        // keeping the pinned inode alive for the syscall's full duration even if the
+        // originating Handle is dropped (spawn_blocking is not cancellable).
+        let src_owned = src_handle.as_fd().try_clone_to_owned()?;
+        let dst_dir = self.fd.clone();
+        let side = self.side;
+        let dst_name = dst_name.to_owned();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::HardLink, move || {
+            let proc_path = format!("/proc/self/fd/{}", src_owned.as_raw_fd());
+            // AT_SYMLINK_FOLLOW: the /proc entry is a magic symlink that must be
+            // dereferenced to reach the pinned inode (without the flag, linkat would
+            // try to hard-link the magic symlink itself, which is not permitted).
+            linkat(
+                AT_FDCWD,
+                proc_path.as_str(),
+                dst_dir.as_fd(),
+                dst_name.as_bytes(),
+                AtFlags::AT_SYMLINK_FOLLOW,
+            )
+            .map_err(nix_to_io)
+        })
+        .await
+    }
+
+    /// Create a new child file, failing if it already exists and never following a symlink.
+    ///
+    /// `mode` is the creation mode (subject to umask); exact permissions are set
+    /// later via fchmod. Returns the open writable `File` on success.
+    ///
+    /// `O_EXCL` is the primary guard: combined with `O_CREAT`, it fails with
+    /// `EEXIST` on any pre-existing entry — including a symlink — without
+    /// following it. `O_NOFOLLOW` is the fallback that would still refuse to
+    /// follow a symlink (with `ELOOP`) should `O_EXCL` ever be bypassed.
+    ///
+    /// Fails with `EINVAL` if `name` is not a single path component, or `EEXIST`
+    /// if a file or symlink at `name` already exists.
+    pub async fn create_file(&self, name: &OsStr, mode: u32) -> std::io::Result<std::fs::File> {
+        if !is_single_component(name) {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        let dir = self.fd.clone();
+        let side = self.side;
+        let name = name.to_owned();
+        run_metadata_probed_blocking(side, congestion::MetadataOp::OpenCreate, move || {
+            let flags = OFlag::O_CREAT
+                | OFlag::O_EXCL
+                | OFlag::O_WRONLY
+                | OFlag::O_NOFOLLOW
+                | OFlag::O_CLOEXEC;
+            let file_mode = Mode::from_bits_truncate(mode);
+            openat(dir.as_fd(), name.as_bytes(), flags, file_mode)
+                .map(std::fs::File::from)
+                .map_err(nix_to_io)
+        })
+        .await
+    }
+}
+
+// ── TrustedDir ──────────────────────────────────────────────────────────────────
+
+/// A directory opened by FOLLOWING symlinks normally — the command-line-named
+/// path's trusted parent prefix.
+///
+/// The trusted-boundary model (design spec §2) trusts the path named on the
+/// command line up to and including its container directory; only entries
+/// strictly BELOW the named root are hardened with `O_NOFOLLOW`. A `TrustedDir`
+/// is that trusted container, and it is the ONLY way in this crate to obtain a
+/// directory fd that was opened following symlinks — its sole constructor is
+/// [`Dir::open_parent_dir`]. Every other directory open ([`Dir::open_dir`],
+/// [`Dir::child`], [`Dir::open_file_read`], [`Dir::create_file`],
+/// [`Dir::make_dir`], …) is `O_NOFOLLOW`.
+///
+/// Because the trusted/hardened distinction is a type rather than a convention,
+/// the compiler enforces it: a parent-prefix slot typed `TrustedDir` can only be
+/// filled by the follow-open, and a hardened `Dir` cannot be used where a trusted
+/// parent is required. Crossing from the trusted prefix into the hardened tree is
+/// the single explicit [`Self::into_tree`] step.
+#[derive(Debug)]
+pub struct TrustedDir(Dir);
+
+impl TrustedDir {
+    /// Cross from the trusted parent prefix into the hardened tree, consuming the `TrustedDir` and
+    /// handing back the owned hardened `Dir` (e.g. to wrap it in an `Arc` for the walk). Every open
+    /// below the returned `Dir` is `O_NOFOLLOW`, so nothing below the named root can be redirected
+    /// by a symlink swap. This is the one explicit trusted→hardened transition.
+    #[must_use]
+    pub fn into_tree(self) -> Dir {
+        self.0
+    }
+}
+
+// ── fd-based metadata application ───────────────────────────────────────────────
+//
+// These primitives apply ownership / mode / timestamps to an entry through a
+// file descriptor we already hold, rather than re-resolving a path. That closes
+// the TOCTOU window a path-based applier would have between opening/creating the
+// entry and re-touching it by name (which is why the fd-based appliers replaced
+// the path-based ones entirely).
+//
+// Every applier follows the chown → chmod → utimens ordering: chown first (it
+// clears setuid/setgid on regular files), chmod second (restores them), utimens
+// last (chown and chmod both touch ctime/mtime). All syscalls are gated through
+// `run_metadata_probed_blocking` with `MetadataOp::Chmod`, bucketing
+// chown/chmod/utimens together.
+
+/// `fchown` on a real (readable/writable) file descriptor.
+///
+/// No-op is the caller's responsibility: this always issues the syscall. Pass
+/// `None` for a component that must not change.
+async fn fchown_fd(
+    fd: BorrowedFd<'_>,
+    side: congestion::Side,
+    uid: Option<u32>,
+    gid: Option<u32>,
+) -> std::io::Result<()> {
+    // BorrowedFd is not 'static, so dup it into an owned fd the closure can hold.
+    let owned = fd.try_clone_to_owned()?;
+    run_metadata_probed_blocking(side, congestion::MetadataOp::Chmod, move || {
+        fchown(
+            owned.as_fd(),
+            uid.map(Uid::from_raw),
+            gid.map(Gid::from_raw),
+        )
+        .map_err(nix_to_io)
+    })
+    .await
+}
+
+/// `fchmod` on a real file descriptor. `mode` is masked to the permission bits
+/// (`0o7777`); file-type bits, if present, are dropped by `from_bits_truncate`.
+///
+/// `fd` must be a real (not `O_PATH`) descriptor — `fchmod` returns `EBADF` on an
+/// `O_PATH` fd. This is used by the copy path, which holds the destination's own
+/// writable file / directory fd. For an `O_PATH` [`Handle`] (e.g. rchm's classified
+/// entry), use [`chmod_via_proc_fd`] instead.
+async fn fchmod_fd(fd: BorrowedFd<'_>, side: congestion::Side, mode: u32) -> std::io::Result<()> {
+    let owned = fd.try_clone_to_owned()?;
+    run_metadata_probed_blocking(side, congestion::MetadataOp::Chmod, move || {
+        fchmod(owned.as_fd(), Mode::from_bits_truncate(mode)).map_err(nix_to_io)
+    })
+    .await
+}
+
+/// `futimens` on a real file descriptor.
+async fn futimens_fd(
+    fd: BorrowedFd<'_>,
+    side: congestion::Side,
+    atime: i64,
+    atime_nsec: i64,
+    mtime: i64,
+    mtime_nsec: i64,
+) -> std::io::Result<()> {
+    let owned = fd.try_clone_to_owned()?;
+    run_metadata_probed_blocking(side, congestion::MetadataOp::Chmod, move || {
+        let atime_spec = TimeSpec::new(atime, atime_nsec);
+        let mtime_spec = TimeSpec::new(mtime, mtime_nsec);
+        futimens(owned.as_fd(), &atime_spec, &mtime_spec).map_err(nix_to_io)
+    })
+    .await
+}
+
+/// Inode-exact `fchownat` on any [`Handle`]'s `O_PATH` fd, operating on the entry
+/// the fd points at — file, directory, or symlink — never following a symlink.
+///
+/// Uses `AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW` so the empty pathname resolves to
+/// the fd's own pinned inode: no path re-resolution by `name` happens, so a
+/// concurrent rename/symlink-swap of the directory entry cannot redirect the
+/// chown to a different target. `AT_SYMLINK_NOFOLLOW` makes a symlink `Handle`
+/// chown the link itself rather than its target. Pass `None` for a component
+/// that must not change (the caller decides when to issue the syscall at all).
+pub(crate) async fn fchown_handle(
+    handle: &Handle,
+    side: congestion::Side,
+    uid: Option<u32>,
+    gid: Option<u32>,
+) -> std::io::Result<()> {
+    let owned = handle.as_fd().try_clone_to_owned()?;
+    run_metadata_probed_blocking(side, congestion::MetadataOp::Chmod, move || {
+        fchownat(
+            owned.as_fd(),
+            "",
+            uid.map(Uid::from_raw),
+            gid.map(Gid::from_raw),
+            AtFlags::AT_EMPTY_PATH | AtFlags::AT_SYMLINK_NOFOLLOW,
+        )
+        .map_err(nix_to_io)
+    })
+    .await
+}
+
+/// `chmod` any non-symlink entry (file, directory, or special) through an `O_PATH`
+/// [`Handle`] by going via the `/proc/self/fd/N` magic symlink, changing the mode
+/// of the EXACT inode the handle pins — never re-resolving the entry by name.
+///
+/// (Symlink mode bits are not settable on Linux, so callers never invoke this on a
+/// symlink handle.)
+///
+/// # Why /proc and not `fchmod`/`fchmodat`
+///
+/// The `Handle` fd is `O_PATH`, which is the only way to pin an arbitrary entry's
+/// inode without read/write/search rights on it. But `O_PATH` rules out the
+/// obvious chmod paths:
+///
+/// - `fchmod(fd, mode)` returns `EBADF` on an `O_PATH` fd (it requires a real
+///   open file description).
+/// - `fchmodat(dirfd, name, mode, AT_SYMLINK_NOFOLLOW)` re-resolves `name`
+///   relative to a directory fd — that re-resolution is exactly the TOCTOU window
+///   we are closing, and the `AT_SYMLINK_NOFOLLOW` flag is only honored on Linux
+///   6.6+ for `fchmodat` (older kernels reject it with `ENOTSUP`).
+///
+/// `chmod("/proc/self/fd/N", mode)` follows the kernel's per-fd magic symlink,
+/// which resolves to the open file description's pinned inode regardless of what
+/// the original `name` now refers to. Because the `O_PATH` handle keeps that
+/// inode alive (the kernel cannot recycle an inode with an open reference), this
+/// is inode-exact and immune to a concurrent rename/symlink swap. It also works
+/// regardless of the file's own permission bits — e.g. a non-root owner's
+/// `0000`-mode file — because the operation authorizes against the caller's
+/// ownership, not the path's mode, and needs no traversal/read rights on the
+/// target. (`fchmodat(.., FollowSymlink)` on the magic symlink is used because
+/// the magic link must be dereferenced to reach the pinned inode.)
+///
+/// # Precondition
+///
+/// Requires `/proc` to be mounted (the standard Linux default). Without `/proc`
+/// the call fails with `ENOENT`; this is a documented operational precondition of
+/// the fd-based chmod path.
+pub(crate) async fn chmod_via_proc_fd(
+    handle: &Handle,
+    side: congestion::Side,
+    mode: u32,
+) -> std::io::Result<()> {
+    // clone the O_PATH fd into an owned fd the blocking closure can hold, keeping
+    // the pinned inode alive for the syscall's full duration even if the
+    // originating Handle is dropped (spawn_blocking is not cancellable).
+    let owned = handle.as_fd().try_clone_to_owned()?;
+    run_metadata_probed_blocking(side, congestion::MetadataOp::Chmod, move || {
+        let proc_path = format!("/proc/self/fd/{}", owned.as_raw_fd());
+        // FollowSymlink: the /proc entry is a magic symlink that must be
+        // dereferenced to reach the pinned inode (NoFollowSymlink would chmod the
+        // magic link itself, a silent no-op).
+        nix::sys::stat::fchmodat(
+            AT_FDCWD,
+            proc_path.as_str(),
+            Mode::from_bits_truncate(mode),
+            nix::sys::stat::FchmodatFlags::FollowSymlink,
+        )
+        .map_err(nix_to_io)
+    })
+    .await
+}
+
+/// Synchronous, ungated chmod of the EXACT inode an `O_PATH` `fd` pins, via its
+/// `/proc/self/fd/N` magic symlink — the blocking-`Drop` counterpart of
+/// [`chmod_via_proc_fd`].
+///
+/// `fd` must reference an `O_PATH` handle (the only fd kind `rm`'s relax path
+/// holds). The same inode-exactness argument applies: the open fd keeps the
+/// pinned inode alive, so `/proc/self/fd/N` resolves to that inode regardless of
+/// any concurrent rename/symlink swap of the original name — there is no path
+/// re-resolution to redirect, so this is race-safe even on a directory whose own
+/// mode is being restored. Works on a `0000`-mode directory we own (it authorizes
+/// against ownership, not the path's mode).
+///
+/// This is deliberately not gated through the congestion controller or the
+/// blocking pool: it runs from a synchronous `Drop` (which cannot `.await`) as a
+/// one-shot best-effort cleanup — a single `fchmodat` whose cost is negligible.
+/// Requires `/proc` mounted (same precondition as [`chmod_via_proc_fd`]).
+pub(crate) fn chmod_via_proc_fd_sync(fd: BorrowedFd<'_>, mode: u32) -> std::io::Result<()> {
+    let proc_path = format!("/proc/self/fd/{}", fd.as_raw_fd());
+    // FollowSymlink: the /proc entry is a magic symlink that must be dereferenced
+    // to reach the pinned inode (NoFollowSymlink would chmod the magic link
+    // itself, a silent no-op).
+    nix::sys::stat::fchmodat(
+        AT_FDCWD,
+        proc_path.as_str(),
+        Mode::from_bits_truncate(mode),
+        nix::sys::stat::FchmodatFlags::FollowSymlink,
+    )
+    .map_err(nix_to_io)
+}
+
+/// Read full [`std::fs::Metadata`] for the exact inode an `O_PATH` [`Handle`] pins,
+/// via the `/proc/self/fd/N` magic symlink.
+///
+/// The fd-pinned [`FileMeta`] snapshot ([`Handle::meta`]) covers uid/gid/mode and
+/// the a/m/ctime timestamps, but NOT the birth time (`btime`) — `fstat` does not
+/// return it. Callers that need `Metadata::created()` (the `--created-before`
+/// time filter) get it here while staying inode-exact: the open `O_PATH` handle
+/// keeps the inode alive, so resolving `/proc/self/fd/N` lands on that same inode
+/// regardless of a concurrent rename/symlink swap of the original name. Gated as
+/// `Stat`. Requires `/proc` mounted (same precondition as [`chmod_via_proc_fd`]).
+pub(crate) async fn stat_meta_via_proc_fd(
+    handle: &Handle,
+    side: congestion::Side,
+) -> std::io::Result<std::fs::Metadata> {
+    let owned = handle.as_fd().try_clone_to_owned()?;
+    run_metadata_probed_blocking(side, congestion::MetadataOp::Stat, move || {
+        let proc_path = format!("/proc/self/fd/{}", owned.as_raw_fd());
+        std::fs::metadata(proc_path)
+    })
+    .await
+}
+
+/// Read the target of a symlink [`Handle`] inode-exact, via `readlinkat(fd, "")` on the pinned
+/// `O_PATH | O_NOFOLLOW` fd.
+///
+/// The empty-pathname form of `readlinkat` (Linux 2.6.39+) operates on the symlink the fd itself
+/// refers to, so the target comes from the *same* pinned inode as [`Handle::meta`] — there is no
+/// path re-resolution by name that a concurrent same-name swap could redirect. This is the symlink
+/// analogue of reading a regular file's bytes and metadata from one [`Dir::open_file_read`] fd: it
+/// lets a caller send/apply a symlink's target and metadata as a faithful pair. Fails if the handle
+/// does not refer to a symlink (the empty-path form requires a symlink fd); callers only invoke it
+/// on a `Symlink`-classified handle. Gated as `ReadLink`.
+///
+/// Raw `libc::readlinkat` is required: nix's wrapper rejects the empty pathname that selects the
+/// fd's own link (the same reason `symlink_utimes_fd` uses raw `utimensat`).
+pub async fn read_link_handle(
+    handle: &Handle,
+    side: congestion::Side,
+) -> std::io::Result<std::path::PathBuf> {
+    use std::os::unix::ffi::OsStringExt;
+    let owned = handle.as_fd().try_clone_to_owned()?;
+    run_metadata_probed_blocking(side, congestion::MetadataOp::ReadLink, move || {
+        // a symlink target is bounded by PATH_MAX, so a single buffer of that size never truncates.
+        let mut buf = vec![0u8; libc::PATH_MAX as usize];
+        // SAFETY: `owned` is a valid open fd for the duration of this call; the empty C string
+        // selects the fd's own symlink (it was opened O_PATH|O_NOFOLLOW); `buf` has `len()` bytes.
+        let n = unsafe {
+            libc::readlinkat(
+                owned.as_raw_fd(),
+                c"".as_ptr(),
+                buf.as_mut_ptr().cast::<libc::c_char>(),
+                buf.len(),
+            )
+        };
+        if n < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        buf.truncate(n as usize);
+        Ok(std::path::PathBuf::from(std::ffi::OsString::from_vec(buf)))
+    })
+    .await
+}
+
+/// Set timestamps on a symlink `Handle`'s `O_PATH` fd, operating on the link
+/// itself, via a raw `utimensat(fd, "", times, AT_EMPTY_PATH)`.
+///
+/// Raw libc is required here: nix's `utimensat` wrapper cannot pass
+/// `AT_EMPTY_PATH`, and `futimens` on an `O_PATH` fd returns `EBADF`. The
+/// `/proc/self/fd` form silently no-ops under `NOFOLLOW`, so it must not be used.
+async fn symlink_utimes_fd(
+    handle: &Handle,
+    side: congestion::Side,
+    atime: i64,
+    atime_nsec: i64,
+    mtime: i64,
+    mtime_nsec: i64,
+) -> std::io::Result<()> {
+    let owned = handle.as_fd().try_clone_to_owned()?;
+    run_metadata_probed_blocking(side, congestion::MetadataOp::Chmod, move || {
+        let times: [libc::timespec; 2] = [
+            libc::timespec {
+                tv_sec: atime,
+                tv_nsec: atime_nsec,
+            },
+            libc::timespec {
+                tv_sec: mtime,
+                tv_nsec: mtime_nsec,
+            },
+        ];
+        // SAFETY: `owned` is a valid open fd for the duration of this call; the
+        // pathname is the empty C string and `times` points to a 2-element array.
+        let res = unsafe {
+            libc::utimensat(
+                owned.as_raw_fd(),
+                c"".as_ptr(),
+                times.as_ptr(),
+                libc::AT_EMPTY_PATH,
+            )
+        };
+        if res == 0 {
+            Ok(())
+        } else {
+            Err(std::io::Error::last_os_error())
+        }
+    })
+    .await
+}
+
+/// Apply file metadata (owner, mode, timestamps) to an already-open writable
+/// file descriptor, following the chown → chmod → utimens ordering.
+///
+/// `fd` must be the destination file's own fd (typically the write fd returned
+/// by [`Dir::create_file`]); this avoids the redundant `File::open` re-open a
+/// path-based applier would need, and closes the TOCTOU window in the process.
+/// Gating on `settings.file`: chown only when uid or gid is requested, chmod
+/// always (the masked
+/// mode honors `mode_mask`), timestamps only when requested.
+pub async fn set_file_metadata_fd<Meta: crate::preserve::Metadata>(
+    settings: &crate::preserve::Settings,
+    meta: &Meta,
+    fd: BorrowedFd<'_>,
+    side: congestion::Side,
+) -> std::io::Result<()> {
+    let ut = &settings.file.user_and_time;
+    if ut.uid || ut.gid {
+        let uid = if ut.uid { Some(meta.uid()) } else { None };
+        let gid = if ut.gid { Some(meta.gid()) } else { None };
+        fchown_fd(fd, side, uid, gid).await?;
+    }
+    let mode = crate::preserve::masked_file_mode(&settings.file, meta);
+    fchmod_fd(fd, side, mode).await?;
+    if ut.time {
+        futimens_fd(
+            fd,
+            side,
+            meta.atime(),
+            meta.atime_nsec(),
+            meta.mtime(),
+            meta.mtime_nsec(),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// Apply directory metadata (owner, mode, timestamps) to an open [`Dir`] fd,
+/// following the chown → chmod → utimens ordering. Gates on `settings.dir` and
+/// uses the directory's own congestion side.
+pub async fn set_dir_metadata_fd<Meta: crate::preserve::Metadata>(
+    settings: &crate::preserve::Settings,
+    meta: &Meta,
+    dir: &Dir,
+) -> std::io::Result<()> {
+    let side = dir.side();
+    let fd = dir.fd.as_fd();
+    let ut = &settings.dir.user_and_time;
+    if ut.uid || ut.gid {
+        let uid = if ut.uid { Some(meta.uid()) } else { None };
+        let gid = if ut.gid { Some(meta.gid()) } else { None };
+        fchown_fd(fd, side, uid, gid).await?;
+    }
+    let mode = crate::preserve::masked_dir_mode(&settings.dir, meta);
+    fchmod_fd(fd, side, mode).await?;
+    if ut.time {
+        futimens_fd(
+            fd,
+            side,
+            meta.atime(),
+            meta.atime_nsec(),
+            meta.mtime(),
+            meta.mtime_nsec(),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// Apply symlink metadata (owner and timestamps only — never mode) to a symlink
+/// [`Handle`], operating on the link itself via `AT_EMPTY_PATH`.
+///
+/// Symlinks have no meaningful permission bits, so there is no chmod step;
+/// ordering is chown → utimens. Gates on `settings.symlink`.
+pub async fn set_symlink_metadata_fd<Meta: crate::preserve::Metadata>(
+    settings: &crate::preserve::Settings,
+    meta: &Meta,
+    handle: &Handle,
+    side: congestion::Side,
+) -> std::io::Result<()> {
+    let ut = &settings.symlink.user_and_time;
+    if ut.uid || ut.gid {
+        let uid = if ut.uid { Some(meta.uid()) } else { None };
+        let gid = if ut.gid { Some(meta.gid()) } else { None };
+        // chown the link itself: fchown_handle already operates inode-exact on the O_PATH handle
+        // via AT_EMPTY_PATH | AT_SYMLINK_NOFOLLOW.
+        fchown_handle(handle, side, uid, gid).await?;
+    }
+    if ut.time {
+        symlink_utimes_fd(
+            handle,
+            side,
+            meta.atime(),
+            meta.atime_nsec(),
+            meta.mtime(),
+            meta.mtime_nsec(),
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Run a blocking metadata syscall closure on the blocking pool, gated by the
+/// congestion controller for the given side and operation kind.
+///
+/// Wraps `spawn_blocking` inside [`crate::walk::run_metadata_probed`] so each
+/// per-entry `openat`/`fstatat` is rate-gated, counted against the cwnd permit,
+/// and feeds the latency probe — the same per-metadata-syscall gating shape used
+/// throughout this crate.
+async fn run_metadata_probed_blocking<F, T>(
+    side: congestion::Side,
+    op: congestion::MetadataOp,
+    f: F,
+) -> std::io::Result<T>
+where
+    F: FnOnce() -> std::io::Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    crate::walk::run_metadata_probed(side, op, async {
+        tokio::task::spawn_blocking(f)
+            .await
+            .map_err(std::io::Error::other)?
+    })
+    .await
+}
+
+/// Convert a `nix::errno::Errno` to `std::io::Error`.
+fn nix_to_io(e: nix::errno::Errno) -> std::io::Error {
+    std::io::Error::from_raw_os_error(e as i32)
+}
+
+/// Return `true` when `name` is a single non-empty path component (no `/`,
+/// not `.` or `..`).
+fn is_single_component(name: &OsStr) -> bool {
+    if name.is_empty() || name == "." || name == ".." {
+        return false;
+    }
+    !name.as_bytes().contains(&b'/')
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::preserve::Metadata;
+    use crate::testutils;
+    use std::io::Read;
+
+    #[tokio::test]
+    async fn child_classifies_file_dir_symlink_and_rejects_nofollow() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        // setup_test_dir() returns the temp dir; the fixture lives at tmp/foo/
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        assert_eq!(
+            root.child(OsStr::new("0.txt")).await?.kind(),
+            EntryKind::File
+        );
+        assert_eq!(root.child(OsStr::new("bar")).await?.kind(), EntryKind::Dir);
+        tokio::fs::symlink("0.txt", tmp.join("foo/lnk")).await?;
+        assert_eq!(
+            root.child(OsStr::new("lnk")).await?.kind(),
+            EntryKind::Symlink
+        );
+        // open_dir on a symlinked "dir" must fail closed (ELOOP/ENOTDIR), never follow
+        tokio::fs::symlink("/etc", tmp.join("foo/evil")).await?;
+        assert!(root.open_dir(OsStr::new("evil")).await.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn open_dir_succeeds_on_real_directory() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        // bar is a real directory; open_dir must succeed and yield a usable Dir
+        let bar = root.open_dir(OsStr::new("bar")).await?;
+        // and the resulting Dir is functional: it can classify its own children
+        assert_eq!(
+            bar.child(OsStr::new("1.txt")).await?.kind(),
+            EntryKind::File
+        );
+        Ok(())
+    }
+
+    // FIX A (PR #247 review): `open_parent_dir` resolves a TRUSTED command-line parent prefix
+    // following symlinks (the final component IS followed), while `open_root_dir` keeps the operand
+    // entry `O_NOFOLLOW` and descendants stay hardened. This pins the parent-prefix-vs-operand
+    // distinction and proves the hardening below the followed prefix is unchanged.
+    #[tokio::test]
+    async fn open_parent_dir_follows_symlinked_prefix_but_descendants_stay_hardened()
+    -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        // a symlink-to-dir standing in for a trusted parent prefix component.
+        tokio::fs::symlink("foo", tmp.join("foo_link")).await?;
+        // open_parent_dir FOLLOWS the symlinked final component into the real `foo` directory,
+        // yielding a TrustedDir; into_tree() crosses into the hardened tree below it.
+        let parent = Dir::open_parent_dir(&tmp.join("foo_link"), congestion::Side::Source).await?;
+        let tree = parent.into_tree();
+        // the followed dir is functional: it sees `foo`'s real children.
+        assert_eq!(
+            tree.child(OsStr::new("0.txt")).await?.kind(),
+            EntryKind::File
+        );
+        // open_root_dir on the SAME symlinked path (dereference=false) must instead fail closed —
+        // it `O_NOFOLLOW`s the final component (the operand-entry contract), proving the two entry
+        // points differ exactly at the final-component follow decision.
+        assert!(
+            Dir::open_root_dir(&tmp.join("foo_link"), false, congestion::Side::Source)
+                .await
+                .is_err()
+        );
+        // hardening below the followed prefix is UNCHANGED: a symlinked child reached via the
+        // followed parent still fails closed (O_NOFOLLOW) rather than being followed.
+        tokio::fs::symlink("/etc", tmp.join("foo/evil_below")).await?;
+        assert!(tree.open_dir(OsStr::new("evil_below")).await.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_multi_component_names() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        // names with a path separator could traverse an intermediate symlink, so
+        // they are rejected with EINVAL before any syscall (release-safe check)
+        for bad in ["bar/1.txt", "..", ".", ""] {
+            let child_err = root.child(OsStr::new(bad)).await.unwrap_err();
+            assert_eq!(child_err.raw_os_error(), Some(libc::EINVAL));
+            let dir_err = root.open_dir(OsStr::new(bad)).await.unwrap_err();
+            assert_eq!(dir_err.raw_os_error(), Some(libc::EINVAL));
+            let file_err = root.open_file_read(OsStr::new(bad)).await.unwrap_err();
+            assert_eq!(file_err.raw_os_error(), Some(libc::EINVAL));
+            let create_err = root.create_file(OsStr::new(bad), 0o644).await.unwrap_err();
+            assert_eq!(create_err.raw_os_error(), Some(libc::EINVAL));
+        }
+        Ok(())
+    }
+
+    // Regression for the spawn_blocking cancellation soundness bug: the Dir's fd
+    // lives behind an Arc that each operation clones into its closure, so an op
+    // stays sound even after the originating Dir is dropped. We model the
+    // detached-closure case by cloning a Dir, dropping the original, and
+    // confirming the clone still opens children correctly.
+    #[tokio::test]
+    async fn operations_remain_valid_after_original_dir_dropped() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        // clone the underlying Arc-held fd into a second Dir, then drop the original
+        let shared = Dir {
+            fd: root.fd.clone(),
+            side: root.side,
+        };
+        drop(root);
+        // the shared handle's open file description is still alive; ops succeed
+        assert_eq!(
+            shared.child(OsStr::new("0.txt")).await?.kind(),
+            EntryKind::File
+        );
+        let bar = shared.open_dir(OsStr::new("bar")).await?;
+        assert_eq!(
+            bar.child(OsStr::new("2.txt")).await?.kind(),
+            EntryKind::File
+        );
+        Ok(())
+    }
+
+    // open_file_read: verify that a regular file can be opened, metadata size is
+    // correct, and the returned File is readable.
+    #[tokio::test]
+    async fn open_file_read_reads_regular_file() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        let (mut file, meta) = root.open_file_read(OsStr::new("0.txt")).await?;
+        // "0.txt" contains the single byte "0"
+        assert_eq!(meta.size(), 1);
+        let mut buf = String::new();
+        file.read_to_string(&mut buf)?;
+        assert_eq!(buf, "0");
+        Ok(())
+    }
+
+    // open_file_read: a FIFO must not cause open to block (O_NONBLOCK) AND the
+    // S_ISREG check must reject it, so the call returns Err without hanging.
+    #[tokio::test]
+    async fn open_file_read_rejects_fifo_without_blocking() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        let fifo_path = tmp.join("foo/test.fifo");
+        nix::unistd::mkfifo(
+            &fifo_path,
+            nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+        )?;
+        // the call must return (not block) within the timeout, and must be an Err
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            root.open_file_read(OsStr::new("test.fifo")),
+        )
+        .await;
+        assert!(result.is_ok(), "open_file_read blocked on FIFO (timed out)");
+        assert!(
+            result.unwrap().is_err(),
+            "open_file_read must reject a FIFO"
+        );
+        Ok(())
+    }
+
+    // open_file_read: a symlink must be rejected (ELOOP from O_NOFOLLOW).
+    #[tokio::test]
+    async fn open_file_read_rejects_symlink() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        // create a symlink pointing to a real file
+        tokio::fs::symlink("0.txt", tmp.join("foo/link_to_0")).await?;
+        let result = root.open_file_read(OsStr::new("link_to_0")).await;
+        assert!(result.is_err(), "open_file_read must reject a symlink");
+        Ok(())
+    }
+
+    // create_file: successfully creates a new writable file.
+    #[tokio::test]
+    async fn create_file_creates_new_writable_file() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        // use a dest-side dir for the write target
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        let mut file = root.create_file(OsStr::new("new.txt"), 0o644).await?;
+        use std::io::Write;
+        file.write_all(b"hello safedir")?;
+        drop(file);
+        // re-open via std and verify the content
+        let content = std::fs::read(tmp.join("foo/new.txt"))?;
+        assert_eq!(content, b"hello safedir");
+        Ok(())
+    }
+
+    // create_file: fails with EEXIST when the file already exists.
+    #[tokio::test]
+    async fn create_file_fails_if_exists() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        // "0.txt" already exists in the fixture
+        let err = root
+            .create_file(OsStr::new("0.txt"), 0o644)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::EEXIST),
+            "expected EEXIST, got {err:#}"
+        );
+        Ok(())
+    }
+
+    // make_dir: creates the directory and returns a usable Dir handle.
+    #[tokio::test]
+    async fn make_dir_creates_and_returns_usable_dir() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        let sub = root.make_dir(OsStr::new("sub"), 0o755).await?;
+        // the returned Dir must be usable: create a file inside it
+        sub.create_file(OsStr::new("child.txt"), 0o644).await?;
+        // and read_entries on the sub dir must show that file
+        let entries = sub.read_entries().await?;
+        let names: Vec<_> = entries
+            .iter()
+            .map(|(n, _)| n.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            names.contains(&"child.txt".to_string()),
+            "child.txt not found in {names:?}"
+        );
+        Ok(())
+    }
+
+    // make_dir: multi-component names must be rejected with EINVAL.
+    #[tokio::test]
+    async fn make_dir_rejects_multi_component_names() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        for bad in ["a/b", "..", ".", ""] {
+            let err = root.make_dir(OsStr::new(bad), 0o755).await.unwrap_err();
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::EINVAL),
+                "expected EINVAL for {:?}, got {err:#}",
+                bad
+            );
+        }
+        Ok(())
+    }
+
+    // read_entries: returns all entries with correct d_type hints.
+    #[tokio::test]
+    async fn read_entries_lists_children_with_dtype_hints() -> anyhow::Result<()> {
+        use std::collections::HashMap;
+        let tmp = testutils::setup_test_dir().await?;
+        // baz contains: 4.txt (file), 5.txt (symlink), 6.txt (symlink)
+        // use bar which has only files; instead build a custom fixture in foo
+        let fixture = tmp.join("foo/fixture_dir");
+        tokio::fs::create_dir(&fixture).await?;
+        tokio::fs::write(fixture.join("afile.txt"), "x").await?;
+        tokio::fs::create_dir(fixture.join("asubdir")).await?;
+        tokio::fs::symlink("afile.txt", fixture.join("alink")).await?;
+
+        let root = Dir::open_root_dir(&fixture, false, congestion::Side::Source).await?;
+        let entries = root.read_entries().await?;
+        let map: HashMap<String, Option<EntryKind>> = entries
+            .into_iter()
+            .map(|(n, k)| (n.to_string_lossy().into_owned(), k))
+            .collect();
+
+        assert_eq!(map.len(), 3, "expected 3 entries, got {map:?}");
+        assert_eq!(
+            map.get("afile.txt"),
+            Some(&Some(EntryKind::File)),
+            "afile.txt wrong"
+        );
+        assert_eq!(
+            map.get("asubdir"),
+            Some(&Some(EntryKind::Dir)),
+            "asubdir wrong"
+        );
+        assert_eq!(
+            map.get("alink"),
+            Some(&Some(EntryKind::Symlink)),
+            "alink wrong"
+        );
+        Ok(())
+    }
+
+    // read_entries: calling it twice on the same Dir must succeed (fd not consumed).
+    #[tokio::test]
+    async fn read_entries_does_not_close_self_fd() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        // first call
+        let first = root.read_entries().await?;
+        assert!(!first.is_empty(), "first read_entries returned empty");
+        // second call on the SAME Dir must yield the identical entry set, not
+        // just an equal count. read_entries dups a fd that shares the directory
+        // read offset, so absent nix's rewinddir-on-completion this second call
+        // would see an empty (or partial) listing. The hardened remote source
+        // depends on exactly this re-entrancy (Pass 1 then Pass 2 enumerate the
+        // same Arc<Dir>).
+        let second = root.read_entries().await?;
+        let mut first_names: Vec<_> = first.iter().map(|(name, _)| name.clone()).collect();
+        let mut second_names: Vec<_> = second.iter().map(|(name, _)| name.clone()).collect();
+        first_names.sort();
+        second_names.sort();
+        assert_eq!(
+            first_names, second_names,
+            "second read_entries differs from first"
+        );
+        // also prove child() still works on the same Dir
+        root.child(OsStr::new("0.txt")).await?;
+        Ok(())
+    }
+
+    // create_file: refuses to follow or clobber an existing symlink.
+    #[tokio::test]
+    async fn create_file_refuses_existing_symlink() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        // plant a symlink pointing at a non-existent target
+        let link_path = tmp.join("foo/evil_link");
+        let target_path = tmp.join("foo/should_not_be_created");
+        tokio::fs::symlink(&target_path, &link_path).await?;
+        // create_file must fail, not follow the symlink and create the target
+        let err = root
+            .create_file(OsStr::new("evil_link"), 0o644)
+            .await
+            .unwrap_err();
+        // O_CREAT|O_EXCL returns EEXIST on an existing symlink without following it
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::EEXIST),
+            "expected EEXIST, got {err:#}"
+        );
+        // the symlink target must NOT have been created
+        assert!(
+            !target_path.exists(),
+            "symlink target was unexpectedly created"
+        );
+        Ok(())
+    }
+
+    // unlink_at: removes a regular file and confirms it is gone.
+    #[tokio::test]
+    async fn unlink_at_removes_file() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        // "0.txt" exists in the fixture
+        root.unlink_at(OsStr::new("0.txt")).await?;
+        // afterwards child() must fail with ENOENT
+        let err = root.child(OsStr::new("0.txt")).await.unwrap_err();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ENOENT),
+            "expected ENOENT after unlink, got {err:#}"
+        );
+        Ok(())
+    }
+
+    // unlink_at: removes the symlink itself, not its target.
+    #[tokio::test]
+    async fn unlink_at_on_symlink_removes_link_not_target() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        // create a sentinel file with content, then symlink to it
+        tokio::fs::write(tmp.join("foo/sentinel.txt"), b"alive").await?;
+        tokio::fs::symlink("sentinel.txt", tmp.join("foo/lnk")).await?;
+        // unlink the link
+        root.unlink_at(OsStr::new("lnk")).await?;
+        // link is gone
+        let err = root.child(OsStr::new("lnk")).await.unwrap_err();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ENOENT),
+            "expected ENOENT for removed link, got {err:#}"
+        );
+        // sentinel target still exists with content
+        let content = tokio::fs::read(tmp.join("foo/sentinel.txt")).await?;
+        assert_eq!(content, b"alive", "sentinel.txt was unexpectedly removed");
+        Ok(())
+    }
+
+    // rmdir_at: removes an empty directory; rejects non-empty (ENOTEMPTY) and a
+    // regular file (ENOTDIR).
+    #[tokio::test]
+    async fn rmdir_at_removes_empty_dir_and_rejects_nonempty() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        // create an empty subdirectory and remove it
+        tokio::fs::create_dir(tmp.join("foo/empty_sub")).await?;
+        root.rmdir_at(OsStr::new("empty_sub")).await?;
+        let err = root.child(OsStr::new("empty_sub")).await.unwrap_err();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ENOENT),
+            "expected ENOENT after rmdir, got {err:#}"
+        );
+        // "bar" is non-empty in the fixture → ENOTEMPTY
+        let err = root.rmdir_at(OsStr::new("bar")).await.unwrap_err();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ENOTEMPTY),
+            "expected ENOTEMPTY for non-empty dir, got {err:#}"
+        );
+        // "0.txt" is a regular file → ENOTDIR
+        let err = root.rmdir_at(OsStr::new("0.txt")).await.unwrap_err();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ENOTDIR),
+            "expected ENOTDIR for regular file, got {err:#}"
+        );
+        Ok(())
+    }
+
+    // symlink_at: creates a symlink and returns a Handle with kind Symlink;
+    // read_link_at then returns the original target path.
+    #[tokio::test]
+    async fn symlink_at_creates_link_and_returns_pinned_handle() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        let target = std::path::Path::new("some/arbitrary/target");
+        let handle = root.symlink_at(OsStr::new("mylink"), target).await?;
+        assert_eq!(
+            handle.kind(),
+            EntryKind::Symlink,
+            "symlink_at must return a Symlink handle"
+        );
+        // read_link_at must return the same target
+        let read_back = root.read_link_at(OsStr::new("mylink")).await?;
+        assert_eq!(
+            read_back, target,
+            "read_link_at returned wrong target: {read_back:?}"
+        );
+        Ok(())
+    }
+
+    // read_link_handle reads the target inode-exact from the pinned O_PATH symlink handle (the
+    // empty-path readlinkat form), so the target pairs with `handle.meta()` from the SAME fd. A
+    // non-symlink handle is rejected (EINVAL).
+    #[tokio::test]
+    async fn read_link_handle_reads_target_from_pinned_handle() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        let target = std::path::Path::new("some/arbitrary/target");
+        tokio::fs::symlink(target, tmp.join("foo/mylink")).await?;
+        // classify the link, then read its target through that same pinned handle.
+        let handle = root.child(OsStr::new("mylink")).await?;
+        assert_eq!(handle.kind(), EntryKind::Symlink);
+        let read_back = read_link_handle(&handle, congestion::Side::Source).await?;
+        assert_eq!(read_back, target, "wrong target: {read_back:?}");
+        // a non-symlink handle (a regular file) is rejected (the empty-path readlinkat form requires
+        // a symlink fd; the kernel returns an error rather than a target). Callers only ever invoke
+        // this on a Symlink-classified handle, so this is the defensive path.
+        let file_handle = root.child(OsStr::new("0.txt")).await?;
+        assert!(
+            read_link_handle(&file_handle, congestion::Side::Source)
+                .await
+                .is_err(),
+            "read_link_handle on a non-symlink must fail"
+        );
+        Ok(())
+    }
+
+    // Handle::read_symlink returns target AND metadata from the one pinned O_PATH fd, so they are a
+    // faithful pair (the symlink analogue of open_file_read).
+    #[tokio::test]
+    async fn read_symlink_returns_target_and_meta_from_one_handle() -> anyhow::Result<()> {
+        use crate::preserve::Metadata as _;
+        let tmp = testutils::setup_test_dir().await?;
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        let target = std::path::Path::new("some/target");
+        tokio::fs::symlink(target, tmp.join("foo/lnk")).await?;
+        let handle = root.child(OsStr::new("lnk")).await?;
+        let (read_target, meta) = handle.read_symlink(congestion::Side::Source).await?;
+        assert_eq!(read_target, target);
+        // metadata is the symlink's own, from the same handle.
+        assert_eq!(meta.uid(), handle.meta().uid());
+        assert_eq!(meta.mtime(), handle.meta().mtime());
+        Ok(())
+    }
+
+    // Dir::meta fstats the directory's own held fd (the fd whose contents we enumerate).
+    #[tokio::test]
+    async fn dir_meta_returns_opened_dir_fstat() -> anyhow::Result<()> {
+        use crate::preserve::Metadata as _;
+        let tmp = testutils::setup_test_dir().await?;
+        let bar = Dir::open_root_dir(&tmp.join("foo/bar"), false, congestion::Side::Source).await?;
+        let meta = bar.meta().await?;
+        let std_meta = std::fs::metadata(tmp.join("foo/bar"))?;
+        // `meta.uid()` resolves via preserve::Metadata (the only trait FileMeta implements);
+        // fully-qualify the std::fs::Metadata side, which implements both that trait and MetadataExt.
+        assert_eq!(meta.uid(), std::os::unix::fs::MetadataExt::uid(&std_meta));
+        assert_eq!(meta.gid(), std::os::unix::fs::MetadataExt::gid(&std_meta));
+        Ok(())
+    }
+
+    // hard_link_at: creates a hard link sharing the same inode.
+    #[tokio::test]
+    async fn hard_link_at_creates_hardlink() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        // use two subdirs as src and dst Dir handles
+        tokio::fs::create_dir(tmp.join("foo/src_sub")).await?;
+        tokio::fs::create_dir(tmp.join("foo/dst_sub")).await?;
+        tokio::fs::write(tmp.join("foo/src_sub/orig.txt"), b"hardlink test").await?;
+
+        let src =
+            Dir::open_root_dir(&tmp.join("foo/src_sub"), false, congestion::Side::Source).await?;
+        let dst = Dir::open_root_dir(
+            &tmp.join("foo/dst_sub"),
+            false,
+            congestion::Side::Destination,
+        )
+        .await?;
+
+        src.hard_link_at(OsStr::new("orig.txt"), &dst, OsStr::new("link.txt"))
+            .await?;
+
+        // both handles must exist and share the same inode
+        let orig_handle = src.child(OsStr::new("orig.txt")).await?;
+        let link_handle = dst.child(OsStr::new("link.txt")).await?;
+        assert_eq!(orig_handle.kind(), EntryKind::File, "orig must be a file");
+        assert_eq!(link_handle.kind(), EntryKind::File, "link must be a file");
+        assert_eq!(
+            orig_handle.ino(),
+            link_handle.ino(),
+            "hard link must share the inode"
+        );
+        Ok(())
+    }
+
+    // hard_link_at: when the source name is a symlink, linkat with flags=0 does
+    // NOT follow it — it links the symlink inode itself, so the new entry is also
+    // a symlink.
+    #[tokio::test]
+    async fn hard_link_at_does_not_follow_source_symlink() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        tokio::fs::create_dir(tmp.join("foo/src_hl")).await?;
+        tokio::fs::create_dir(tmp.join("foo/dst_hl")).await?;
+        // create a real file and a symlink to it in src_hl
+        tokio::fs::write(tmp.join("foo/src_hl/real.txt"), b"target").await?;
+        tokio::fs::symlink("real.txt", tmp.join("foo/src_hl/sym.txt")).await?;
+
+        let src =
+            Dir::open_root_dir(&tmp.join("foo/src_hl"), false, congestion::Side::Source).await?;
+        let dst = Dir::open_root_dir(
+            &tmp.join("foo/dst_hl"),
+            false,
+            congestion::Side::Destination,
+        )
+        .await?;
+
+        // Linux does not allow hard-linking a symlink without AT_EMPTY_PATH or
+        // special capabilities; linkat with flags=0 on a symlink yields EPERM.
+        // Verify that the call does NOT silently follow the symlink into real.txt.
+        let result = src
+            .hard_link_at(OsStr::new("sym.txt"), &dst, OsStr::new("new_link.txt"))
+            .await;
+        match result {
+            Ok(()) => {
+                // If it succeeded (some kernels/configs allow it), the new entry
+                // must be a symlink — NOT a hard link to the underlying file.
+                let new_handle = dst.child(OsStr::new("new_link.txt")).await?;
+                assert_eq!(
+                    new_handle.kind(),
+                    EntryKind::Symlink,
+                    "hard_link_at must link the symlink itself, not its target"
+                );
+                // and real.txt must still have link-count 1 (no new hard link)
+                let real_meta = std::fs::metadata(tmp.join("foo/src_hl/real.txt"))?;
+                use std::os::unix::fs::MetadataExt;
+                assert_eq!(
+                    real_meta.nlink(),
+                    1,
+                    "real.txt must not gain a new hard link"
+                );
+            }
+            Err(ref e) if e.raw_os_error() == Some(libc::EPERM) => {
+                // expected on most Linux configurations; the important thing is
+                // that it did NOT follow the symlink and link real.txt.
+                // real.txt must still have exactly 1 hard link.
+                let real_meta = std::fs::metadata(tmp.join("foo/src_hl/real.txt"))?;
+                use std::os::unix::fs::MetadataExt;
+                assert_eq!(
+                    real_meta.nlink(),
+                    1,
+                    "real.txt must not gain a new hard link"
+                );
+            }
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "unexpected error from hard_link_at on symlink: {e:#}"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    // hard_link_handle_at (FIX 2, PR #247 review): links the EXACT inode the
+    // classified Handle pins, immune to a concurrent swap of the source name. This is
+    // deterministic — the swap happens (in fixed order) AFTER classification but
+    // BEFORE the link — so it directly demonstrates the TOCTOU fix.
+    //
+    // The decoy is a DIFFERENT regular file with different content placed at the same
+    // name. The old by-name `hard_link_at(name, ..)` re-resolves `name` and would link
+    // the decoy inode (this test would fail against it). `hard_link_handle_at` links
+    // the pinned original inode regardless.
+    #[tokio::test]
+    async fn hard_link_handle_at_links_pinned_inode_after_name_swap() -> anyhow::Result<()> {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = testutils::create_temp_dir().await?;
+        tokio::fs::create_dir(tmp.join("src")).await?;
+        tokio::fs::create_dir(tmp.join("dst")).await?;
+        tokio::fs::write(tmp.join("src/entry"), b"ORIGINAL").await?;
+        let orig_ino = tokio::fs::metadata(tmp.join("src/entry")).await?.ino();
+
+        let src = Dir::open_root_dir(&tmp.join("src"), false, congestion::Side::Source).await?;
+        let dst =
+            Dir::open_root_dir(&tmp.join("dst"), false, congestion::Side::Destination).await?;
+        // classify `entry` — pins the ORIGINAL regular-file inode via O_PATH.
+        let handle = src.child(OsStr::new("entry")).await?;
+        assert_eq!(handle.kind(), EntryKind::File);
+
+        // SWAP `entry` to a DIFFERENT regular file (the decoy) before linking. We keep
+        // the original inode alive only through `handle` (its directory entry is gone),
+        // mimicking an attacker renaming a decoy over the source name.
+        tokio::fs::write(tmp.join("src/decoy"), b"DECOY_SECRET").await?;
+        tokio::fs::rename(tmp.join("src/decoy"), tmp.join("src/entry")).await?;
+        let decoy_ino = tokio::fs::metadata(tmp.join("src/entry")).await?.ino();
+        assert_ne!(orig_ino, decoy_ino, "decoy must be a different inode");
+
+        // inode-exact link: either links the ORIGINAL pinned inode, or fails closed.
+        match dst.hard_link_handle_at(&handle, OsStr::new("linked")).await {
+            Ok(()) => {
+                let lm = tokio::fs::symlink_metadata(tmp.join("dst/linked")).await?;
+                assert!(
+                    lm.file_type().is_file(),
+                    "linked entry must be a regular file"
+                );
+                assert_eq!(
+                    lm.ino(),
+                    orig_ino,
+                    "hard_link_handle_at must link the PINNED original inode, never the \
+                     swapped-in decoy (the by-name link would have linked the decoy here)"
+                );
+                let content = tokio::fs::read_to_string(tmp.join("dst/linked")).await?;
+                assert_eq!(
+                    content, "ORIGINAL",
+                    "must reflect the original inode's content"
+                );
+                assert_ne!(content, "DECOY_SECRET");
+            }
+            Err(e) => {
+                // fail-closed is acceptable (e.g. the pinned inode's last link was
+                // already gone). It must NEVER have linked the decoy.
+                assert!(
+                    !tmp.join("dst/linked").exists(),
+                    "no destination entry may exist when the link failed closed (got {e:#})"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    // hard_link_handle_at must refuse to hard-link a DIRECTORY (linkat returns EPERM),
+    // matching the by-name path — a hard link to a directory is never created.
+    #[tokio::test]
+    async fn hard_link_handle_at_refuses_directory() -> anyhow::Result<()> {
+        let tmp = testutils::create_temp_dir().await?;
+        tokio::fs::create_dir(tmp.join("src")).await?;
+        tokio::fs::create_dir(tmp.join("dst")).await?;
+        tokio::fs::create_dir(tmp.join("src/adir")).await?;
+        let src = Dir::open_root_dir(&tmp.join("src"), false, congestion::Side::Source).await?;
+        let dst =
+            Dir::open_root_dir(&tmp.join("dst"), false, congestion::Side::Destination).await?;
+        let dir_handle = src.child(OsStr::new("adir")).await?;
+        assert_eq!(dir_handle.kind(), EntryKind::Dir);
+        let result = dst
+            .hard_link_handle_at(&dir_handle, OsStr::new("linked_dir"))
+            .await;
+        assert!(
+            result.is_err(),
+            "hard_link_handle_at must refuse to hard-link a directory"
+        );
+        assert!(
+            !tmp.join("dst/linked_dir").exists(),
+            "no destination entry may be created for a directory hard link"
+        );
+        Ok(())
+    }
+
+    // hard_link_handle_at (FIX 2, PR #247 review): classify a regular File, then swap the
+    // source name to a FIFO (a special, a different kind AND inode) before linking. The
+    // old by-name `linkat(flags=0)` re-resolves the name and would hard-link the FIFO —
+    // surfacing a special at the destination that rlink would report as a hard-linked
+    // file (specials CAN be hard-linked, unlike directories). The inode-exact link must
+    // instead link the pinned regular file or fail closed: the destination must NEVER be
+    // a special. Deterministic (swap happens between classify and link).
+    #[tokio::test]
+    async fn hard_link_handle_at_never_links_swapped_in_fifo() -> anyhow::Result<()> {
+        use std::os::unix::fs::FileTypeExt;
+        let tmp = testutils::create_temp_dir().await?;
+        tokio::fs::create_dir(tmp.join("src")).await?;
+        tokio::fs::create_dir(tmp.join("dst")).await?;
+        tokio::fs::write(tmp.join("src/entry"), b"REALFILE").await?;
+        let src = Dir::open_root_dir(&tmp.join("src"), false, congestion::Side::Source).await?;
+        let dst =
+            Dir::open_root_dir(&tmp.join("dst"), false, congestion::Side::Destination).await?;
+        // classify `entry` — pins the regular-file inode.
+        let handle = src.child(OsStr::new("entry")).await?;
+        assert_eq!(handle.kind(), EntryKind::File);
+        // swap `entry` to a FIFO (keep the regular inode alive only via the handle).
+        tokio::fs::remove_file(tmp.join("src/entry")).await?;
+        nix::unistd::mkfifo(
+            &tmp.join("src/entry"),
+            nix::sys::stat::Mode::S_IRUSR | nix::sys::stat::Mode::S_IWUSR,
+        )?;
+        match dst.hard_link_handle_at(&handle, OsStr::new("linked")).await {
+            Ok(()) => {
+                let lm = tokio::fs::symlink_metadata(tmp.join("dst/linked")).await?;
+                assert!(
+                    lm.file_type().is_file(),
+                    "linked entry must be the pinned regular file, never the swapped-in FIFO"
+                );
+                assert!(
+                    !lm.file_type().is_fifo(),
+                    "the destination must never be a special (the by-name link would link the FIFO)"
+                );
+                let content = tokio::fs::read_to_string(tmp.join("dst/linked")).await?;
+                assert_eq!(content, "REALFILE");
+            }
+            Err(_) => {
+                // fail-closed is acceptable; nothing may be left at the destination.
+                assert!(
+                    !tmp.join("dst/linked").exists(),
+                    "no destination entry may exist when the link failed closed"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    // hard_link_handle_at on a STABLE regular file links exactly like the by-name path
+    // did (same inode, same content) — the happy path is unchanged.
+    #[tokio::test]
+    async fn hard_link_handle_at_stable_file_happy_path() -> anyhow::Result<()> {
+        let tmp = testutils::create_temp_dir().await?;
+        tokio::fs::create_dir(tmp.join("src")).await?;
+        tokio::fs::create_dir(tmp.join("dst")).await?;
+        tokio::fs::write(tmp.join("src/f"), b"STABLE").await?;
+        let src = Dir::open_root_dir(&tmp.join("src"), false, congestion::Side::Source).await?;
+        let dst =
+            Dir::open_root_dir(&tmp.join("dst"), false, congestion::Side::Destination).await?;
+        let handle = src.child(OsStr::new("f")).await?;
+        dst.hard_link_handle_at(&handle, OsStr::new("f_link"))
+            .await?;
+        let orig = src.child(OsStr::new("f")).await?;
+        let linked = dst.child(OsStr::new("f_link")).await?;
+        assert_eq!(linked.kind(), EntryKind::File);
+        assert_eq!(orig.ino(), linked.ino(), "hard link must share the inode");
+        let content = tokio::fs::read_to_string(tmp.join("dst/f_link")).await?;
+        assert_eq!(content, "STABLE");
+        Ok(())
+    }
+
+    // ── fd-based metadata application ───────────────────────────────────────
+
+    // set_file_metadata_fd: applying owner/mode/time from a source FileMeta to an
+    // already-open destination fd must reflect on the destination file: masked
+    // mode, mtime, and (where testable) uid/gid all match the source.
+    #[tokio::test]
+    async fn set_file_metadata_fd_applies_owner_mode_time() -> anyhow::Result<()> {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = testutils::setup_test_dir().await?;
+        // source file with a distinctive mode and a known, old mtime
+        let src_path = tmp.join("foo/src_meta.txt");
+        tokio::fs::write(&src_path, b"source").await?;
+        std::fs::set_permissions(&src_path, std::fs::Permissions::from_mode(0o741))?;
+        let src_mtime = filetime::FileTime::from_unix_time(1_000_000_000, 123_456_789);
+        filetime::set_file_mtime(&src_path, src_mtime)?;
+        filetime::set_file_atime(
+            &src_path,
+            filetime::FileTime::from_unix_time(1_000_000_500, 0),
+        )?;
+
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        // snapshot the source metadata via a Handle (the realistic source flow)
+        let src_handle = root.child(OsStr::new("src_meta.txt")).await?;
+        let src_meta = src_handle.meta().clone();
+
+        // create the destination file and write some content into it
+        let mut dst_file = root.create_file(OsStr::new("dst_meta.txt"), 0o600).await?;
+        dst_file.write_all(b"destination")?;
+        dst_file.flush()?;
+
+        // apply source metadata to the already-open dst fd; preserve everything
+        let settings = crate::preserve::preserve_all();
+        set_file_metadata_fd(
+            &settings,
+            &src_meta,
+            dst_file.as_fd(),
+            congestion::Side::Destination,
+        )
+        .await?;
+        drop(dst_file);
+
+        // re-stat the destination and assert mode (masked to 0o7777), mtime
+        let dst_md = std::fs::metadata(tmp.join("foo/dst_meta.txt"))?;
+        assert_eq!(
+            dst_md.permissions().mode() & 0o7777,
+            0o741,
+            "destination mode mismatch"
+        );
+        // disambiguate: both preserve::Metadata and std MetadataExt are in scope
+        use std::os::unix::fs::MetadataExt;
+        assert_eq!(
+            MetadataExt::mtime(&dst_md),
+            1_000_000_000,
+            "mtime seconds mismatch"
+        );
+        assert_eq!(
+            MetadataExt::mtime_nsec(&dst_md),
+            123_456_789,
+            "mtime nanos mismatch"
+        );
+        // uid/gid: chown to source's uid/gid (same as current user here) must hold
+        assert_eq!(MetadataExt::uid(&dst_md), src_meta.uid(), "uid mismatch");
+        assert_eq!(MetadataExt::gid(&dst_md), src_meta.gid(), "gid mismatch");
+        Ok(())
+    }
+
+    // set_file_metadata_fd: the chown → chmod ordering must preserve a setuid bit.
+    // An unprivileged fchown (even to the current uid) clears setuid/setgid; doing
+    // chown FIRST and chmod AFTER restores it. This test proves that ordering.
+    #[tokio::test]
+    async fn set_file_metadata_fd_ordering_preserves_setuid() -> anyhow::Result<()> {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = testutils::setup_test_dir().await?;
+        // source file with the setuid bit set (0o4755)
+        let src_path = tmp.join("foo/setuid_src");
+        tokio::fs::write(&src_path, b"x").await?;
+        std::fs::set_permissions(&src_path, std::fs::Permissions::from_mode(0o4755))?;
+
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        let src_handle = root.child(OsStr::new("setuid_src")).await?;
+        let src_meta = src_handle.meta().clone();
+        assert_eq!(
+            src_meta.permissions().mode() & 0o7777,
+            0o4755,
+            "source setuid bit was not set up correctly"
+        );
+
+        // destination starts without the setuid bit
+        let mut dst_file = root.create_file(OsStr::new("setuid_dst"), 0o600).await?;
+        dst_file.write_all(b"x")?;
+        dst_file.flush()?;
+
+        // preserve_all keeps the full mode (mask 0o7777) AND preserves uid/gid, so
+        // the chown runs before the chmod; the setuid bit must survive.
+        let settings = crate::preserve::preserve_all();
+        set_file_metadata_fd(
+            &settings,
+            &src_meta,
+            dst_file.as_fd(),
+            congestion::Side::Destination,
+        )
+        .await?;
+        drop(dst_file);
+
+        let dst_md = std::fs::metadata(tmp.join("foo/setuid_dst"))?;
+        assert_eq!(
+            dst_md.permissions().mode() & 0o7777,
+            0o4755,
+            "setuid bit was lost — chown must run before chmod"
+        );
+        Ok(())
+    }
+
+    // set_dir_metadata_fd: applying mode/time to a freshly made directory via its
+    // Dir fd must reflect on the directory.
+    #[tokio::test]
+    async fn set_dir_metadata_fd_applies() -> anyhow::Result<()> {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let tmp = testutils::setup_test_dir().await?;
+        // source directory with a distinctive mode and known mtime
+        let src_dir_path = tmp.join("foo/src_dir");
+        tokio::fs::create_dir(&src_dir_path).await?;
+        std::fs::set_permissions(&src_dir_path, std::fs::Permissions::from_mode(0o2750))?;
+        filetime::set_file_mtime(
+            &src_dir_path,
+            filetime::FileTime::from_unix_time(1_111_111_111, 222_000_000),
+        )?;
+
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        let src_handle = root.child(OsStr::new("src_dir")).await?;
+        let src_meta = src_handle.meta().clone();
+
+        // create the destination directory and apply metadata via its Dir fd
+        let dst_dir = root.make_dir(OsStr::new("dst_dir"), 0o700).await?;
+        let settings = crate::preserve::preserve_all();
+        set_dir_metadata_fd(&settings, &src_meta, &dst_dir).await?;
+
+        let dst_md = std::fs::metadata(tmp.join("foo/dst_dir"))?;
+        assert_eq!(
+            dst_md.permissions().mode() & 0o7777,
+            0o2750,
+            "destination dir mode mismatch"
+        );
+        assert_eq!(
+            MetadataExt::mtime(&dst_md),
+            1_111_111_111,
+            "dir mtime seconds mismatch"
+        );
+        assert_eq!(
+            MetadataExt::mtime_nsec(&dst_md),
+            222_000_000,
+            "dir mtime nanos mismatch"
+        );
+        Ok(())
+    }
+
+    // set_symlink_metadata_fd: applying time (and owner) to a symlink via its
+    // O_PATH Handle must change the LINK's own atime/mtime — NOT the target's
+    // mtime. This is the key proof that utimensat(AT_EMPTY_PATH) hit the link.
+    #[tokio::test]
+    async fn set_symlink_metadata_fd_changes_link_not_target() -> anyhow::Result<()> {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+
+        // sentinel target file with a known mtime we must NOT disturb
+        let target_path = tmp.join("foo/sentinel_target.txt");
+        tokio::fs::write(&target_path, b"keep my mtime").await?;
+        let target_mtime = filetime::FileTime::from_unix_time(1_500_000_000, 0);
+        filetime::set_file_mtime(&target_path, target_mtime)?;
+        let target_before = std::fs::metadata(&target_path)?;
+
+        // the link to apply metadata to
+        let link = root
+            .symlink_at(
+                OsStr::new("the_link"),
+                std::path::Path::new("sentinel_target.txt"),
+            )
+            .await?;
+
+        // desired link timestamps come from a source FileMeta; build one by
+        // stating a second symlink we set up with a distinctive mtime.
+        let src_link_path = tmp.join("foo/src_link");
+        tokio::fs::symlink("sentinel_target.txt", &src_link_path).await?;
+        let src_link_mtime = filetime::FileTime::from_unix_time(1_234_567_890, 0);
+        // set the LINK's own mtime (symlink=true) — not the target's
+        filetime::set_symlink_file_times(
+            &src_link_path,
+            filetime::FileTime::from_unix_time(1_234_500_000, 0),
+            src_link_mtime,
+        )?;
+        let src_meta = root.child(OsStr::new("src_link")).await?.meta().clone();
+
+        let settings = crate::preserve::preserve_all();
+        set_symlink_metadata_fd(&settings, &src_meta, &link, congestion::Side::Destination).await?;
+
+        // the LINK's own mtime must now equal the source link's mtime
+        let link_md = std::fs::symlink_metadata(tmp.join("foo/the_link"))?;
+        assert_eq!(
+            MetadataExt::mtime(&link_md),
+            1_234_567_890,
+            "link's own mtime was not applied"
+        );
+        // the TARGET file's mtime must be UNCHANGED
+        let target_after = std::fs::metadata(&target_path)?;
+        assert_eq!(
+            MetadataExt::mtime(&target_after),
+            MetadataExt::mtime(&target_before),
+            "target mtime changed — utimensat followed the symlink!"
+        );
+        assert_eq!(
+            MetadataExt::mtime_nsec(&target_after),
+            MetadataExt::mtime_nsec(&target_before),
+            "target mtime_nsec changed — utimensat followed the symlink!"
+        );
+        Ok(())
+    }
+
+    // recheck: returns a fresh Handle with the same dev/ino when the entry is unchanged.
+    #[tokio::test]
+    async fn recheck_succeeds_when_unchanged() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        let h = root.child(OsStr::new("0.txt")).await?;
+        let fresh = root.recheck(OsStr::new("0.txt"), &h).await?;
+        assert_eq!(
+            fresh.dev(),
+            h.dev(),
+            "recheck: dev mismatch on unchanged entry"
+        );
+        assert_eq!(
+            fresh.ino(),
+            h.ino(),
+            "recheck: ino mismatch on unchanged entry"
+        );
+        Ok(())
+    }
+
+    // recheck: returns ESTALE when the entry's inode has been replaced.
+    #[tokio::test]
+    async fn recheck_fails_when_swapped_to_different_inode() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        // create a file whose Handle we will hold
+        tokio::fs::write(tmp.join("foo/f"), b"original").await?;
+        let h = root.child(OsStr::new("f")).await?;
+        let original_ino = h.ino();
+        // replace f with a completely new file (different inode)
+        root.unlink_at(OsStr::new("f")).await?;
+        root.create_file(OsStr::new("f"), 0o644).await?;
+        // verify the replacement has a different inode
+        let fresh_via_child = root.child(OsStr::new("f")).await?;
+        assert_ne!(
+            fresh_via_child.ino(),
+            original_ino,
+            "test setup error: new file has same inode as old one"
+        );
+        // recheck must detect the swap and return ESTALE
+        let err = root.recheck(OsStr::new("f"), &h).await.unwrap_err();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ESTALE),
+            "expected ESTALE on inode swap, got {err:#}"
+        );
+        Ok(())
+    }
+
+    // recheck: returns ESTALE when the entry has been swapped to a symlink.
+    #[tokio::test]
+    async fn recheck_fails_when_swapped_to_symlink() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        // create a regular file g
+        tokio::fs::write(tmp.join("foo/g"), b"regular").await?;
+        let h = root.child(OsStr::new("g")).await?;
+        // replace g with a symlink (different inode and kind)
+        root.unlink_at(OsStr::new("g")).await?;
+        root.symlink_at(OsStr::new("g"), std::path::Path::new("0.txt"))
+            .await?;
+        // recheck must detect the mismatch (different inode) and return ESTALE
+        let err = root.recheck(OsStr::new("g"), &h).await.unwrap_err();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ESTALE),
+            "expected ESTALE on symlink swap, got {err:#}"
+        );
+        Ok(())
+    }
+
+    // rejects_multi_component_names: extend to cover the five new methods.
+    #[tokio::test]
+    async fn new_methods_reject_multi_component_names() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        // a second Dir for hard_link_at's dst parameter
+        let dst =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        // a valid Handle to satisfy recheck's `expected` parameter; the bad `name`
+        // must be rejected before any dev/ino comparison is attempted.
+        let any_handle = root.child(OsStr::new("0.txt")).await?;
+
+        for bad in ["a/b", "..", ".", ""] {
+            let bad_os = OsStr::new(bad);
+
+            let err = root.unlink_at(bad_os).await.unwrap_err();
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::EINVAL),
+                "unlink_at: expected EINVAL for {bad:?}, got {err:#}"
+            );
+
+            let err = root.rmdir_at(bad_os).await.unwrap_err();
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::EINVAL),
+                "rmdir_at: expected EINVAL for {bad:?}, got {err:#}"
+            );
+
+            // symlink_at: only `name` is guarded; target is arbitrary
+            let err = root
+                .symlink_at(bad_os, std::path::Path::new("irrelevant"))
+                .await
+                .unwrap_err();
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::EINVAL),
+                "symlink_at(name): expected EINVAL for {bad:?}, got {err:#}"
+            );
+
+            let err = root.read_link_at(bad_os).await.unwrap_err();
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::EINVAL),
+                "read_link_at: expected EINVAL for {bad:?}, got {err:#}"
+            );
+
+            // hard_link_at: both `name` and `dst_name` are guarded
+            let err = root
+                .hard_link_at(bad_os, &dst, OsStr::new("good"))
+                .await
+                .unwrap_err();
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::EINVAL),
+                "hard_link_at(name): expected EINVAL for {bad:?}, got {err:#}"
+            );
+
+            let err = root
+                .hard_link_at(OsStr::new("good"), &dst, bad_os)
+                .await
+                .unwrap_err();
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::EINVAL),
+                "hard_link_at(dst_name): expected EINVAL for {bad:?}, got {err:#}"
+            );
+
+            // recheck: bad `name` must be rejected before dev/ino comparison
+            let err = root.recheck(bad_os, &any_handle).await.unwrap_err();
+            assert_eq!(
+                err.raw_os_error(),
+                Some(libc::EINVAL),
+                "recheck(name): expected EINVAL for {bad:?}, got {err:#}"
+            );
+        }
+        Ok(())
+    }
+
+    // chmod_via_proc_fd: changing the mode of a 0000-mode file through its O_PATH
+    // handle must succeed (the /proc magic-symlink path does not need any rights on
+    // the target itself) and the new mode must be observable on disk. This is the
+    // case `fchmod` (EBADF on O_PATH) and a bare path chmod under restrictive modes
+    // would struggle with; the pinned inode makes it inode-exact and permission-free.
+    #[tokio::test]
+    async fn chmod_via_proc_fd_changes_mode_of_zero_mode_file() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = testutils::setup_test_dir().await?;
+        let root =
+            Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Destination).await?;
+        // a file with no permission bits at all (0000).
+        let path = tmp.join("foo/locked.txt");
+        tokio::fs::write(&path, b"locked").await?;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o000))?;
+        // O_PATH handle pins the inode even though the file is 0000.
+        let handle = root.child(OsStr::new("locked.txt")).await?;
+        assert_eq!(handle.kind(), EntryKind::File, "fixture must be a file");
+        // chmod it to 0o640 via the /proc magic symlink.
+        chmod_via_proc_fd(&handle, congestion::Side::Destination, 0o640).await?;
+        // the mode change must be visible on disk.
+        let md = std::fs::symlink_metadata(&path)?;
+        assert_eq!(
+            md.permissions().mode() & 0o7777,
+            0o640,
+            "chmod_via_proc_fd must change the mode of a 0000-mode file"
+        );
+        Ok(())
+    }
+
+    // stat_meta_via_proc_fd: on a symlink Handle (opened O_PATH|O_NOFOLLOW), resolving
+    // /proc/self/fd/N must land on the LINK's own inode — never the target's. This is
+    // load-bearing for symlink time-filtering (rm/rrm reads a symlink's own mtime/btime to
+    // decide removal). We give the link and its target DISTINCT mtimes and assert the metadata
+    // returned is the link's (is_symlink + the link's mtime), proving the magic-symlink resolve
+    // is pinned to the O_PATH inode and does not follow the link to the target.
+    #[tokio::test]
+    async fn stat_meta_via_proc_fd_on_symlink_resolves_link_not_target() -> anyhow::Result<()> {
+        use std::os::unix::fs::MetadataExt;
+        let tmp = testutils::setup_test_dir().await?;
+        let root = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+
+        // target file with one mtime ...
+        let target_path = tmp.join("foo/stat_target.txt");
+        tokio::fs::write(&target_path, b"target body").await?;
+        filetime::set_file_mtime(
+            &target_path,
+            filetime::FileTime::from_unix_time(1_700_000_000, 0),
+        )?;
+
+        // ... and a symlink to it with a DISTINCT mtime set on the LINK itself (not the target).
+        let link_path = tmp.join("foo/stat_link");
+        tokio::fs::symlink("stat_target.txt", &link_path).await?;
+        filetime::set_symlink_file_times(
+            &link_path,
+            filetime::FileTime::from_unix_time(1_600_000_000, 0),
+            filetime::FileTime::from_unix_time(1_600_000_123, 0),
+        )?;
+
+        // open the symlink via child() — an O_PATH|O_NOFOLLOW handle pinned to the link inode.
+        let handle = root.child(OsStr::new("stat_link")).await?;
+        assert_eq!(
+            handle.kind(),
+            EntryKind::Symlink,
+            "fixture must classify as a symlink"
+        );
+
+        let md = stat_meta_via_proc_fd(&handle, congestion::Side::Source).await?;
+        // the returned metadata must be the LINK's, not the dereferenced target's.
+        assert!(
+            md.file_type().is_symlink(),
+            "stat_meta_via_proc_fd followed the symlink to its target (got a non-symlink)"
+        );
+        assert_eq!(
+            MetadataExt::mtime(&md),
+            1_600_000_123,
+            "expected the LINK's own mtime; a target-following stat would return 1_700_000_000"
+        );
+        Ok(())
+    }
+}

--- a/common/src/toctou_check.rs
+++ b/common/src/toctou_check.rs
@@ -1,0 +1,267 @@
+//! TOCTOU-safety verdict logic for `--toctou-check` and `--require-toctou-safe`.
+//!
+//! This module provides the [`toctou_verdict`] function used by `--toctou-check` and
+//! `--require-toctou-safe` on every RCP tool. The verdict reflects whether the
+//! invocation uses the TOCTOU-hardened walk: `safe = !dereference && linux`.
+//!
+//! The tools do NOT verify the trust of the operand path's prefix (the directories
+//! above the named root) — that is the caller's responsibility (the sudo policy or a
+//! vetted wrapper passes resolved, trusted operands). See the "Scope of TOCTOU safety"
+//! section of `docs/tocttou.md` for the authoritative definition of the boundary.
+
+/// Normalized inputs used to compute a TOCTOU-safety verdict.
+///
+/// Each tool populates this from its parsed CLI flags. Tools without a
+/// `--dereference` flag (rchm, rrm) always pass `dereference: false`.
+#[derive(Debug, Clone)]
+pub struct VerdictInputs {
+    /// Whether `--dereference` / `-L` was requested (following symlinks).
+    pub dereference: bool,
+}
+
+/// The result of a TOCTOU-safety analysis.
+#[derive(Debug, Clone)]
+pub struct Verdict {
+    /// Whether the invocation is considered TOCTOU-safe.
+    pub safe: bool,
+    /// Human-readable reasons why the invocation is NOT safe (empty when `safe == true`).
+    pub reasons: Vec<String>,
+    /// Caveats that apply even when `safe == true` (trusted-boundary statements).
+    pub caveats: Vec<String>,
+}
+
+impl Verdict {
+    /// Render a human-readable summary of this verdict.
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        if self.safe {
+            out.push_str("TOCTOU status: SAFE\n");
+        } else {
+            out.push_str("TOCTOU status: NOT SAFE\n");
+            for reason in &self.reasons {
+                out.push_str(&format!("  Reason: {}\n", reason));
+            }
+        }
+        for caveat in &self.caveats {
+            out.push_str(&format!("  Note: {}\n", caveat));
+        }
+        out
+    }
+}
+
+/// Compute the TOCTOU-safety verdict for an invocation described by `inputs`.
+///
+/// An invocation is NOT safe only when:
+/// - `dereference` is true (`--dereference`/`-L` follows symlinks by request), or
+/// - the build target is non-Linux (the hardened path is Linux-only).
+///
+/// All other flags (`--delete`, remote, filtering) are now hardened and do NOT
+/// affect the verdict.
+///
+/// The verdict reflects only whether the hardened walk is in use. It does NOT — and
+/// cannot — vouch for the trust of the operand path's prefix; that is the caller's
+/// responsibility (see the "Scope of TOCTOU safety" section of `docs/tocttou.md`).
+/// The "safe" verdict therefore always carries a caveat stating the trusted-boundary
+/// assumption the caller must ensure.
+pub fn toctou_verdict(inputs: &VerdictInputs) -> Verdict {
+    let linux_build = cfg!(target_os = "linux");
+    let safe = !inputs.dereference && linux_build;
+
+    let mut reasons = Vec::new();
+    if inputs.dereference {
+        reasons.push(
+            "--dereference/-L follows symlinks by request, so a swapped link is followed \
+            — not hardened under privilege asymmetry"
+                .to_string(),
+        );
+    }
+    if !linux_build {
+        reasons
+            .push("the TOCTOU-hardened path is Linux-only; this build does not use it".to_string());
+    }
+
+    let caveats = vec![
+        "Hardening assumes the directory named on the command line (and the path components \
+        above it) are not modifiable by a less-privileged actor; it protects everything at or \
+        below the named root. Also assumes fs.protected_hardlinks=1 (Linux default)."
+            .to_string(),
+    ];
+
+    Verdict {
+        safe,
+        reasons,
+        caveats,
+    }
+}
+
+/// Result of the CLI linter check, indicating whether the caller should proceed.
+///
+/// When this is `Exit { code }`, the caller must print `output` and exit with
+/// `code` WITHOUT starting the operation. When this is `Proceed`, the caller
+/// continues normally.
+#[derive(Debug)]
+pub enum LinterAction {
+    /// Caller should print the message and exit with this code.
+    Exit { output: String, code: i32 },
+    /// Caller should proceed with the normal operation.
+    Proceed,
+}
+
+/// Run the TOCTOU CLI linter checks.
+///
+/// Call this in each tool's `main()` after argument parsing, before starting
+/// the async runtime / operation. Returns [`LinterAction::Exit`] when either
+/// `toctou_check` or `require_toctou_safe` demands early exit, or
+/// [`LinterAction::Proceed`] when the tool should run normally.
+///
+/// The linter operates purely on the verdict (`!dereference && linux`). It does NOT
+/// inspect the operand paths: the trust of a path's prefix is the caller's
+/// responsibility (see the "Scope of TOCTOU safety" section of `docs/tocttou.md`).
+/// `--require-toctou-safe` is the tool's half of that contract — it refuses to run
+/// unless the hardened walk is in use (rejecting `--dereference`/`-L` and non-Linux
+/// builds) — but it does not, and cannot, vouch for prefix trust.
+///
+/// # Parameters
+///
+/// - `dereference`: whether `--dereference`/`-L` is set (false for rchm/rrm).
+/// - `toctou_check`: whether `--toctou-check` was passed.
+/// - `require_toctou_safe`: whether `--require-toctou-safe` was passed.
+pub fn run_linter(
+    dereference: bool,
+    toctou_check: bool,
+    require_toctou_safe: bool,
+) -> LinterAction {
+    if !toctou_check && !require_toctou_safe {
+        return LinterAction::Proceed;
+    }
+
+    let inputs = VerdictInputs { dereference };
+    let verdict = toctou_verdict(&inputs);
+
+    if toctou_check {
+        // print verdict and exit — no operation performed
+        let code = if verdict.safe { 0 } else { 1 };
+        return LinterAction::Exit {
+            output: verdict.render(),
+            code,
+        };
+    }
+
+    // --require-toctou-safe mode: refuse only when the hardened walk is not in use.
+    if !verdict.safe {
+        let mut msg = "Refusing to run: invocation is not TOCTOU-safe.\n".to_string();
+        for reason in &verdict.reasons {
+            msg.push_str(&format!("  Reason: {}\n", reason));
+        }
+        return LinterAction::Exit {
+            output: msg,
+            code: 1,
+        };
+    }
+
+    LinterAction::Proceed
+}
+
+/// Run the TOCTOU CLI linter and act on its verdict: print the message and exit the process when
+/// the linter demands it ([`LinterAction::Exit`]), or return so the caller proceeds
+/// ([`LinterAction::Proceed`]).
+///
+/// This is the print-and-exit half of [`run_linter`], shared verbatim by every tool's `main()` so
+/// the print/exit policy lives in one place (the testable verdict core stays in [`run_linter`] /
+/// [`toctou_verdict`]). Call it immediately after argument parsing, before the async runtime / any
+/// filesystem operation. `dereference` is `false` for tools without a `--dereference` flag
+/// (rchm/rrm/rlink).
+pub fn enforce_or_exit(dereference: bool, toctou_check: bool, require_toctou_safe: bool) {
+    match run_linter(dereference, toctou_check, require_toctou_safe) {
+        LinterAction::Exit { output, code } => {
+            print!("{}", output);
+            std::process::exit(code);
+        }
+        LinterAction::Proceed => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------------------
+    // Verdict tests
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn no_dereference_is_safe() {
+        let v = toctou_verdict(&VerdictInputs { dereference: false });
+        if cfg!(target_os = "linux") {
+            assert!(v.safe, "no-dereference on Linux should be safe");
+            assert!(v.reasons.is_empty(), "no reasons expected for safe verdict");
+        } else {
+            // non-Linux: not safe due to platform
+            assert!(!v.safe);
+        }
+        assert!(
+            !v.caveats.is_empty(),
+            "caveats must be present even when safe"
+        );
+    }
+
+    #[test]
+    fn dereference_is_not_safe() {
+        let v = toctou_verdict(&VerdictInputs { dereference: true });
+        assert!(!v.safe, "dereference must make the verdict not-safe");
+        assert!(
+            !v.reasons.is_empty(),
+            "at least one reason must be present when not safe"
+        );
+        // the dereference reason must be in the list
+        assert!(
+            v.reasons
+                .iter()
+                .any(|r| r.contains("dereference") || r.contains("-L")),
+            "reason must mention dereference/-L, got: {:?}",
+            v.reasons
+        );
+    }
+
+    #[test]
+    fn caveats_always_present() {
+        for deref in [false, true] {
+            let v = toctou_verdict(&VerdictInputs { dereference: deref });
+            assert!(
+                !v.caveats.is_empty(),
+                "caveats must be present regardless of verdict (deref={})",
+                deref
+            );
+            // the trusted-boundary caveat must be there
+            assert!(
+                v.caveats
+                    .iter()
+                    .any(|c| c.contains("named on the command line")),
+                "trusted-boundary caveat must be present, got: {:?}",
+                v.caveats
+            );
+        }
+    }
+
+    #[test]
+    fn render_safe_contains_safe() {
+        let v = toctou_verdict(&VerdictInputs { dereference: false });
+        let rendered = v.render();
+        if cfg!(target_os = "linux") {
+            assert!(
+                rendered.contains("SAFE"),
+                "rendered output must contain SAFE: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn render_not_safe_contains_not_safe() {
+        let v = toctou_verdict(&VerdictInputs { dereference: true });
+        let rendered = v.render();
+        assert!(
+            rendered.contains("NOT SAFE"),
+            "rendered output must contain NOT SAFE: {rendered}"
+        );
+    }
+}

--- a/common/src/walk.rs
+++ b/common/src/walk.rs
@@ -91,6 +91,87 @@ impl EntryKind {
     }
 }
 
+/// Which backpressure pool a leaf's pre-acquired permit comes from.
+///
+/// The two pools are deliberately distinct (see [`LeafPermit`]) — this enum
+/// selects between them per tool, plus a `None` variant for metadata-only
+/// walks (e.g. rcmp-style traversals) that take no leaf permit at all.
+///
+/// Unifying the *choice* of pool here — alongside [`LeafPermit`] and
+/// [`preacquire_leaf_permit`] — is what lets the traversal driver own the
+/// "drop the leaf permit before recursing into a directory" invariant in a
+/// single place. Hand-coding that drop at every per-tool branch is the root
+/// cause of the hold-and-wait deadlock class this lifecycle eliminates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PermitKind {
+    /// File-descriptor backpressure ([`throttle::open_file_permit`]) — for
+    /// tools that hold an open fd across leaf work (copy, link).
+    OpenFile,
+    /// Task-spawn backpressure ([`throttle::pending_meta_permit`]) — for
+    /// recursive metadata-only walks that don't hold an fd (chmod, rm).
+    PendingMeta,
+    /// The tool takes no leaf permit (it doesn't gate at the leaf).
+    None,
+}
+
+/// A pre-acquired leaf permit, type-erased over the two distinct backpressure
+/// pools so a single caller (the traversal driver) can hold either uniformly
+/// and drop it in exactly one place before recursing into a directory.
+///
+/// The two pools must stay distinct: [`throttle::OpenFileGuard`] gates open
+/// file descriptors while [`throttle::PendingMetaGuard`] gates in-flight
+/// metadata-only tasks. They are sized independently so a path that composes
+/// the two operations (e.g. `copy_file → rm` when overwriting a directory
+/// destination) cannot self-deadlock against a saturated open-files pool.
+/// This enum unifies only the *lifecycle*, never the pools themselves.
+///
+/// Neither guard is `Clone`; dropping a `LeafPermit` releases exactly the
+/// underlying permit it wraps. The driver drops it before descending so a
+/// directory entry never holds a leaf permit across its recursive walk —
+/// the single home for the invariant that previously lived at 4/7/1/1
+/// per-tool branch sites and shipped as a deadlock when a single-site tool
+/// forgot it.
+pub enum LeafPermit {
+    /// A permit from the open-files pool.
+    OpenFile(throttle::OpenFileGuard),
+    /// A permit from the pending-metadata pool.
+    PendingMeta(throttle::PendingMetaGuard),
+}
+
+/// Pre-acquire a leaf permit for a child about to be spawned, per the tool's
+/// policy.
+///
+/// Returns `None` when `kind == PermitKind::None` or when `!want(hint)` — the
+/// latter lets a tool opt out based on the cheap `getdents` `d_type` hint. The
+/// key case: when the hint says "directory", the tool passes a `want` that
+/// returns `false`, so no leaf permit is taken. That matters because a hinted
+/// directory must NOT hold a leaf permit across recursion (the hold-and-wait
+/// deadlock). Otherwise this acquires from the pool selected by `kind` and
+/// wraps it in [`LeafPermit`].
+///
+/// `want` receives the raw hint (`None` for `DT_UNKNOWN`); the authoritative
+/// type is only resolved later by the per-entry worker. A hint of `None`
+/// therefore takes a permit when the tool's `want` admits it (matching the
+/// historical "treat unknown as a leaf" behavior), and the worker re-classifies
+/// and drops it if the entry turns out to be a directory.
+pub async fn preacquire_leaf_permit(
+    kind: PermitKind,
+    hint: Option<EntryKind>,
+    want: impl Fn(Option<EntryKind>) -> bool,
+) -> Option<LeafPermit> {
+    if kind == PermitKind::None || !want(hint) {
+        return None;
+    }
+    match kind {
+        PermitKind::OpenFile => Some(LeafPermit::OpenFile(throttle::open_file_permit().await)),
+        PermitKind::PendingMeta => Some(LeafPermit::PendingMeta(
+            throttle::pending_meta_permit().await,
+        )),
+        // unreachable: the early return above already handled `None`.
+        PermitKind::None => None,
+    }
+}
+
 /// Resolve the `throttle::Side` from the matching `congestion::Side`.
 ///
 /// The two crates carry independent enum definitions to keep `throttle`
@@ -229,12 +310,70 @@ where
     result
 }
 
+/// Determine the `is_dir` value to feed an include/exclude FILTER decision for a
+/// directory entry, using the authoritative `fstat` type when the cheap
+/// `getdents` `d_type` hint is unavailable.
+///
+/// `read_entries` returns each entry's `d_type` as a best-effort hint; on
+/// filesystems that don't populate it (NFS, some FUSE mounts) the hint is `None`
+/// (`DT_UNKNOWN`). Treating `None` as "not a directory" for an `is_dir`-dependent
+/// filter (e.g. `--include '/sub/**'`) would wrongly EXCLUDE a real directory and
+/// omit its entire subtree. To match the old path-based walk (which fell back to
+/// an `lstat` via `DirEntry::file_type()`), this resolves the type
+/// AUTHORITATIVELY via `dir.child(name)`'s `fstat` — but ONLY when the hint is
+/// `None` AND the type is actually needed: either a filter is active, or the
+/// caller passes `force_authoritative` because its own control flow depends on
+/// the result (e.g. a dry-run recurse-vs-leaf decision). When the hint is
+/// reliable, or the type is unneeded, the cheap hint is used directly (no extra
+/// syscall), preserving the optimization.
+///
+/// `child(name)` uses `O_PATH|O_NOFOLLOW`, so this never follows a symlink (a
+/// symlink entry classifies as `Symlink`, not `Dir`) and never blocks: the
+/// hardening of the walk below the named root is unaffected. On a `child` error
+/// (e.g. the entry vanished mid-walk) the hint-derived value is used as a
+/// fallback — the entry's own per-entry worker will then surface the error
+/// authoritatively.
+pub async fn filter_is_dir(
+    filter: Option<&FilterSettings>,
+    dir: &crate::safedir::Dir,
+    name: &std::ffi::OsStr,
+    hint: Option<EntryKind>,
+    force_authoritative: bool,
+) -> bool {
+    match hint {
+        Some(kind) => kind == EntryKind::Dir,
+        // DT_UNKNOWN: only pay for the authoritative fstat when the type is actually
+        // needed — a filter needs it, or the caller's control flow depends on it
+        // (`force_authoritative`, e.g. a dry-run recurse-vs-leaf decision). Otherwise
+        // the value is unused, so default cheaply.
+        None if filter.is_some() || force_authoritative => match dir.child(name).await {
+            Ok(handle) => handle.kind() == EntryKind::Dir,
+            // entry changed/vanished: fall back to the historical non-dir default;
+            // the per-entry worker re-classifies and reports any real error.
+            Err(_) => false,
+        },
+        None => false,
+    }
+}
+
 /// Decide whether an entry should be skipped by the filter, returning the
 /// `FilterResult` that caused the skip. Returns `None` if there is no filter
 /// or the entry is included.
 #[must_use]
 pub fn should_skip_entry(
     filter: &Option<FilterSettings>,
+    relative_path: &std::path::Path,
+    is_dir: bool,
+) -> Option<FilterResult> {
+    should_skip_entry_ref(filter.as_ref(), relative_path, is_dir)
+}
+
+/// [`should_skip_entry`] taking the filter by `Option<&_>` rather than
+/// `&Option<_>`, so callers that already hold an `Option<&FilterSettings>` (the
+/// traversal driver) don't have to clone it. Identical semantics otherwise.
+#[must_use]
+pub fn should_skip_entry_ref(
+    filter: Option<&FilterSettings>,
     relative_path: &std::path::Path,
     is_dir: bool,
 ) -> Option<FilterResult> {
@@ -264,4 +403,254 @@ pub fn relative_to_root<'a>(
     root: &std::path::Path,
 ) -> &'a std::path::Path {
     entry.strip_prefix(root).unwrap_or(entry)
+}
+
+/// Strip trailing path separators from a root operand. A trailing slash forces the OS to resolve
+/// the final component as a directory, which would dereference a symlink root like `link/`
+/// (following it to its target). Stripping makes `link/` behave like `link` (the symlink itself),
+/// which is then classified/operated on `O_NOFOLLOW` relative to its parent fd.
+#[must_use]
+pub fn without_trailing_separators(path: &std::path::Path) -> std::path::PathBuf {
+    use std::os::unix::ffi::OsStrExt;
+    let bytes = path.as_os_str().as_bytes();
+    let mut end = bytes.len();
+    while end > 1 && bytes[end - 1] == b'/' {
+        end -= 1;
+    }
+    std::path::PathBuf::from(std::ffi::OsStr::from_bytes(&bytes[..end]))
+}
+
+/// A root operand decomposed for the fd-relative walk entry point.
+pub struct RootOperand {
+    /// The operand's parent directory — opened TRUSTED (follows symlinks) via
+    /// [`crate::safedir::Dir::open_parent_dir`].
+    pub parent: std::path::PathBuf,
+    /// The operand's final component — classified `O_NOFOLLOW` via `child(name)` below the parent.
+    pub name: std::ffi::OsString,
+    /// The operand path for diagnostics / `real_path` reconstruction: the operand as typed (with
+    /// trailing slashes stripped) for a normal operand, or the canonicalized path for a `.`/`..`
+    /// operand that had to be resolved.
+    pub display: std::path::PathBuf,
+}
+
+/// Decompose a root operand into the `(parent, final_component)` the fd-relative walk needs (see
+/// [`RootOperand`]): the parent prefix is opened with [`crate::safedir::Dir::open_parent_dir`]
+/// (trusted, follows symlinks) and the final component is then classified `O_NOFOLLOW` via
+/// `child(name)` below it.
+///
+/// Most operands split directly via `parent()` / `file_name()` (an empty parent meaning the current
+/// directory). An operand whose final component is `.` or `..` (e.g. `.`, `tree/..`) has no
+/// `file_name()`, so it is first canonicalized to a concrete path — `.` becomes the current
+/// directory, `tree/..` its grandparent — restoring the behavior of the pre-fd-walk path code,
+/// where `rrm .` / `rchm -R … .` operated on the current tree. (Canonicalizing only this branch
+/// never touches a normal operand, so a symlinked final component on the normal path is still
+/// opened `O_NOFOLLOW`; `.`/`..` are themselves never symlinks.) The filesystem root `/` has no
+/// parent and cannot be expressed as parent + component, so it is rejected with a clear error.
+pub async fn split_root_operand(path: &std::path::Path) -> anyhow::Result<RootOperand> {
+    let stripped = without_trailing_separators(path);
+    if let Some(name) = stripped.file_name() {
+        let parent = match stripped.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+            // empty parent (a single-component relative path) means the current directory.
+            _ => std::path::PathBuf::from("."),
+        };
+        let name = name.to_owned();
+        return Ok(RootOperand {
+            parent,
+            name,
+            display: stripped,
+        });
+    }
+    // final component is `.`/`..` (or the operand is `/`): canonicalize to a concrete path so it can
+    // be split into parent + component.
+    let canonical = tokio::fs::canonicalize(&stripped)
+        .await
+        .with_context(|| format!("cannot resolve operand {stripped:?}"))?;
+    let name = canonical.file_name().map(std::ffi::OsStr::to_owned);
+    let parent = canonical.parent().map(std::path::Path::to_path_buf);
+    let (Some(parent), Some(name)) = (parent, name) else {
+        anyhow::bail!("cannot operate on the filesystem root {canonical:?}");
+    };
+    Ok(RootOperand {
+        parent,
+        name,
+        display: canonical,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::safedir::Dir;
+    use crate::testutils;
+    use std::ffi::OsStr;
+
+    fn include_filter(pattern: &str) -> Option<FilterSettings> {
+        let mut f = FilterSettings::new();
+        f.add_include(pattern).unwrap();
+        Some(f)
+    }
+
+    // FIX B (PR #247 review): when the getdents `d_type` hint is unavailable (DT_UNKNOWN -> None)
+    // AND a filter is active, the filter `is_dir` decision must come from the AUTHORITATIVE fstat,
+    // not default to non-dir. Otherwise a real directory reported as DT_UNKNOWN would be wrongly
+    // excluded by an is_dir-dependent include filter, omitting its whole subtree. We can't force
+    // DT_UNKNOWN on a normal local fs, so we drive `filter_is_dir` with `hint = None` directly —
+    // exactly the value `read_entries` would yield on NFS/FUSE — to exercise the authoritative path.
+    #[tokio::test]
+    async fn filter_is_dir_authoritatively_classifies_dt_unknown_directory() -> anyhow::Result<()> {
+        let tmp = testutils::setup_test_dir().await?;
+        // fixture: tmp/foo holds `bar` (a real directory) and `0.txt` (a real file).
+        let dir = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        let filter = include_filter("/bar/**");
+        // DT_UNKNOWN + active filter on a real DIRECTORY -> must resolve to `true` via fstat, so an
+        // include filter does NOT omit its subtree (the regression this fix closes).
+        assert!(
+            filter_is_dir(filter.as_ref(), &dir, OsStr::new("bar"), None, false).await,
+            "a real directory reported as DT_UNKNOWN must classify as a directory for the filter"
+        );
+        // DT_UNKNOWN + active filter on a real FILE -> resolves to `false` authoritatively.
+        assert!(
+            !filter_is_dir(filter.as_ref(), &dir, OsStr::new("0.txt"), None, false).await,
+            "a real file reported as DT_UNKNOWN must classify as a non-directory"
+        );
+        Ok(())
+    }
+
+    // FIX B: a reliable hint is used directly (no fstat), and with no filter active the value is
+    // the cheap default — the optimization is preserved (we never pay an fstat we don't need).
+    #[tokio::test]
+    async fn filter_is_dir_uses_hint_when_available_and_skips_when_no_filter() -> anyhow::Result<()>
+    {
+        let tmp = testutils::setup_test_dir().await?;
+        let dir = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        let filter = include_filter("/bar/**");
+        // reliable Dir hint -> true regardless of fstat.
+        assert!(
+            filter_is_dir(
+                filter.as_ref(),
+                &dir,
+                OsStr::new("bar"),
+                Some(EntryKind::Dir),
+                false
+            )
+            .await
+        );
+        // reliable File hint -> false.
+        assert!(
+            !filter_is_dir(
+                filter.as_ref(),
+                &dir,
+                OsStr::new("0.txt"),
+                Some(EntryKind::File),
+                false
+            )
+            .await
+        );
+        // DT_UNKNOWN, NO filter, and not forced -> cheap non-dir default (no authoritative fstat
+        // needed); the `name` is never resolved, so it need not even exist.
+        assert!(!filter_is_dir(None, &dir, OsStr::new("does_not_exist"), None, false).await);
+        Ok(())
+    }
+
+    // force_authoritative (e.g. rlink --dry-run, which uses is_dir for its recurse-vs-leaf
+    // branch): a DT_UNKNOWN hint with NO filter must still classify AUTHORITATIVELY when the
+    // caller's control flow depends on the result, so a dry-run on NFS/FUSE doesn't preview a
+    // real directory as a leaf and skip its subtree.
+    #[tokio::test]
+    async fn filter_is_dir_forces_authoritative_classification_when_requested() -> anyhow::Result<()>
+    {
+        let tmp = testutils::setup_test_dir().await?;
+        let dir = Dir::open_root_dir(&tmp.join("foo"), false, congestion::Side::Source).await?;
+        // DT_UNKNOWN + NO filter, but force_authoritative -> a real directory must classify as dir.
+        assert!(
+            filter_is_dir(None, &dir, OsStr::new("bar"), None, true).await,
+            "force_authoritative must fstat a DT_UNKNOWN directory even with no filter"
+        );
+        // ...and a real file as non-dir.
+        assert!(
+            !filter_is_dir(None, &dir, OsStr::new("0.txt"), None, true).await,
+            "force_authoritative must fstat a DT_UNKNOWN file even with no filter"
+        );
+        Ok(())
+    }
+
+    // The leaf-permit lifecycle: `PermitKind::None` and a rejecting `want` both opt
+    // out (the basis for "a hinted directory takes no permit, so it can't deadlock
+    // by holding one across recursion"); a matching `want` acquires from the
+    // requested pool. The pools are process-global; configure a small cap so the
+    // OpenFile case exercises a real acquire rather than the disabled-pool no-op.
+    #[tokio::test]
+    async fn preacquire_leaf_permit_respects_kind_and_want() {
+        throttle::set_max_open_files(4);
+        // `None` kind never takes a permit, regardless of hint/want.
+        assert!(
+            preacquire_leaf_permit(PermitKind::None, Some(EntryKind::File), |_| true)
+                .await
+                .is_none()
+        );
+        // matching want on the OpenFile pool yields an OpenFile permit.
+        let permit = preacquire_leaf_permit(PermitKind::OpenFile, Some(EntryKind::File), |h| {
+            h == Some(EntryKind::File)
+        })
+        .await;
+        assert!(matches!(permit, Some(LeafPermit::OpenFile(_))));
+        drop(permit);
+        // a rejecting want (e.g. the hint says "directory") opts out even though the
+        // pool is configured — the hinted-dir-takes-no-permit case.
+        assert!(
+            preacquire_leaf_permit(PermitKind::OpenFile, Some(EntryKind::Dir), |_| false)
+                .await
+                .is_none()
+        );
+    }
+
+    // split_root_operand: a normal operand splits via parent()/file_name() (single component ->
+    // parent "."), a trailing slash is stripped, a trailing `/.` names the directory itself, and —
+    // the regression fix — a bare `.` or an operand ending in `..` (no file_name()) is canonicalized
+    // so it still names a directory instead of being rejected. The filesystem root `/` is rejected.
+    #[tokio::test]
+    async fn split_root_operand_handles_dot_and_normal_operands() -> anyhow::Result<()> {
+        use std::ffi::OsStr;
+        use std::path::Path;
+        // normal nested operand: split verbatim.
+        let op = split_root_operand(Path::new("a/b")).await?;
+        assert_eq!(op.parent, Path::new("a"));
+        assert_eq!(op.name, OsStr::new("b"));
+        assert_eq!(op.display, Path::new("a/b"));
+        // single component: parent defaults to the current directory.
+        let op = split_root_operand(Path::new("foo")).await?;
+        assert_eq!(op.parent, Path::new("."));
+        assert_eq!(op.name, OsStr::new("foo"));
+        // trailing slash stripped (so a symlink root is classified O_NOFOLLOW, not dereferenced).
+        let op = split_root_operand(Path::new("foo/")).await?;
+        assert_eq!(op.name, OsStr::new("foo"));
+        // trailing `/.` names the directory itself: `file_name()` normalizes the `.` away, so it
+        // splits verbatim (no canonicalize) — `dir/.` -> parent ".", name "dir"; `a/b/.` -> "a","b".
+        let op = split_root_operand(Path::new("dir/.")).await?;
+        assert_eq!(op.parent, Path::new("."));
+        assert_eq!(op.name, OsStr::new("dir"));
+        let op = split_root_operand(Path::new("a/b/.")).await?;
+        assert_eq!(op.parent, Path::new("a"));
+        assert_eq!(op.name, OsStr::new("b"));
+        // bare `.` (no file_name): canonicalized to the current directory.
+        let cwd = tokio::fs::canonicalize(".").await?;
+        let op = split_root_operand(Path::new(".")).await?;
+        assert_eq!(op.parent, cwd.parent().unwrap());
+        assert_eq!(op.name, cwd.file_name().unwrap());
+        assert_eq!(op.display, cwd);
+        // operand ending in `..` (no file_name): canonicalized so it still names a directory.
+        // tmp/sub/.. resolves to tmp — the `rrm .` / `rchm -R … .` regression this fix closes.
+        let tmp = testutils::create_temp_dir().await?;
+        let sub = tmp.join("sub");
+        tokio::fs::create_dir(&sub).await?;
+        let canonical_tmp = tokio::fs::canonicalize(&tmp).await?;
+        let op = split_root_operand(&sub.join("..")).await?;
+        assert_eq!(op.parent, canonical_tmp.parent().unwrap());
+        assert_eq!(op.name, canonical_tmp.file_name().unwrap());
+        assert_eq!(op.display, canonical_tmp);
+        // the filesystem root has no parent and is rejected with a clear error.
+        assert!(split_root_operand(Path::new("/")).await.is_err());
+        Ok(())
+    }
 }

--- a/common/src/walk_driver.rs
+++ b/common/src/walk_driver.rs
@@ -1,0 +1,854 @@
+//! Generic single-tree safe-walk driver.
+//!
+//! This module owns the recursive directory-walk *skeleton* that copy, chmod, and
+//! rm previously each hand-coded. A tool supplies a [`WalkVisitor`]; the driver
+//! drives the traversal:
+//!
+//! 1. gated `read_entries` on the open hardened directory,
+//! 2. per child: authoritative-or-hinted [`walk::filter_is_dir`] +
+//!    [`walk::should_skip_entry`] filter decision (against the child's
+//!    [`EntryCx::filter_path`]), then [`walk::preacquire_leaf_permit`] per the
+//!    visitor's policy,
+//! 3. acquire-then-spawn one task per non-skipped child, joining/folding via
+//!    [`join_and_fold`] (NOT batched: see [`walk_dir_contents`] for why the permit
+//!    is acquired and the task spawned in the same loop step),
+//! 4. in each task: authoritative [`Dir::child`] classification, then either
+//!    [`WalkVisitor::visit_leaf`] (holding the permit) or — for a directory —
+//!    **drop the permit**, [`WalkVisitor::dir_pre`], recurse, [`WalkVisitor::dir_post`].
+//!
+//! ## The single invariant home
+//!
+//! The "drop the leaf permit before recursing into a directory" invariant — the
+//! root cause of the hold-and-wait deadlock class (see [`walk::LeafPermit`]) —
+//! lives in **exactly one place**: the directory branch of [`process_entry`].
+//! Leaves hold their permit across [`WalkVisitor::visit_leaf`]; the directory
+//! branch `drop`s it before any further work. No visitor ever hand-drops a leaf
+//! permit, so the invariant cannot silently migrate back to N parallel sites.
+//!
+//! ## Cancellation safety
+//!
+//! Spawned tasks must be `'static`, and `spawn_blocking` work is not cancellable,
+//! so every per-entry context is **owned**: [`EntryCx`] clones `Arc<Dir>` plus
+//! owned `OsString`/`PathBuf` rather than borrowing, exactly as the existing
+//! per-tool walks do. A dropped surrounding future (timeout, `fail_early` abort,
+//! Ctrl-C) therefore can never leave a spawned task holding a dangling borrow.
+//!
+//! ## How copy will map onto this trait (Phase D validation)
+//!
+//! `copy` is the reference single-tree visitor (implemented in `rcp::copy` as
+//! `CopyVisitor`); its mapping both validated the trait and shaped this module.
+//! `CopyVisitor` holds the run-constant state (`dst_root`, `filter_base`,
+//! `Settings`, `preserve::Settings`, the opened top-level destination parent — the
+//! *source* root needs no field, since each entry's source path is its
+//! [`EntryCx::real_path`]) and:
+//!
+//! - **`type Summary`** = `copy::Summary`.
+//! - **`type DirContext`** = the *destination* parent for one level:
+//!   `{ dst_dir: Option<Arc<Dir>>, is_fresh: bool }` (`None` dst = dry-run). This
+//!   is how the single-tree driver carries copy's second tree — each child reads
+//!   its destination parent from `parent_ctx` rather than the driver modeling two
+//!   trees. [`WalkVisitor::root_dir_context`] returns the opened top-level
+//!   destination (`Some(dst)`/`None`) with the initial `is_fresh`.
+//! - **`type DirState`** = `{ dst_dir, dst_parent, dst_name, we_created, src_meta,
+//!   is_root, base }` — what `dir_post` needs to apply directory metadata
+//!   (`src_meta` is taken from `dir_pre`'s classification `Handle`, no extra stat),
+//!   run empty-dir cleanup (`dst_parent.rmdir_at(dst_name)`), and `--delete`-prune,
+//!   plus the `base` create/unchanged contribution it folds with the children.
+//! - **`visit_leaf`** dispatches on `kind`: `File` → `copy_file_fd`, `Symlink` →
+//!   `copy_symlink_fd`, `Special` → skip-or-error. The pre-acquired `permit` is
+//!   the open-files guard `copy_file_fd` needs; it is dropped for symlink/special.
+//!   `--dereference` of a symlink-to-dir stays inside `visit_leaf`: it drops the
+//!   permit and calls the path-based `copy()` recursively (the one deliberately
+//!   non-fd path), which the trait expresses fine — `visit_leaf` is a plain async
+//!   fn that may itself recurse without going through the driver.
+//! - **`dir_pre`** runs `resolve_dst_dir`: `DirResolution::Skip` →
+//!   [`DirAction::Skip`] (`--ignore-existing` hit a non-dir); `Proceed{dir,..}` →
+//!   [`DirAction::Descend`] whose `dir` is the *source* dir (opened via
+//!   `src_parent.open_dir(name)`), `child_ctx` carries the resolved `dst_dir` +
+//!   child `is_fresh`, and `state` carries the `DirState`.
+//! - **`dir_post`** receives the children's folded `Result`: on `Ok` it runs the
+//!   `--delete` prune (keep-set = `processed.names()`), empty-dir cleanup, and
+//!   `set_dir_metadata_fd` (post-order); on `Err` (a non-fail-early child failure)
+//!   it skips the destructive prune, still applies directory metadata, and returns
+//!   the combined error — exactly as `copy_dir_contents`'s tail did.
+//! - **`on_skip`** mirrors copy's inline filter-skip: `report_skip` in dry-run +
+//!   `skipped_summary_for(kind)`.
+//! - **`permit_kind`** = `OpenFile`; **`want_permit`** = "hint is `File`" (copy
+//!   only pre-acquires for a regular-file hint — symlinks may deref to dirs, and
+//!   DT_UNKNOWN might be a dir).
+//!
+//! The delegated-subtree case (rlink handing copy an update-only/type-changed
+//! subtree rooted below the original filter root) is carried by seeding the root
+//! [`EntryCx::filter_path`] with the subtree's logical base, so the filter still
+//! matches at the entry's true path while `rel_path`/`real_path` stay relative to
+//! the delegated root.
+//!
+//! The dry-run "directory" path (no destination dir, contents still traversed for
+//! reporting) is just `DirContext.dst_dir == None` threaded through — the same
+//! branch copy already has. No part of copy needs a trait shape this module does
+//! not provide, which is why the trait stops here (no second-tree concept leaks
+//! into the driver — that asymmetry is what keeps rlink on the substrate, not the
+//! visitor, per the design spec §4).
+
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_recursion::async_recursion;
+
+use crate::error::OperationError;
+use crate::progress::Progress;
+use crate::safedir::{Dir, Handle};
+use crate::walk::{self, EntryKind, LeafPermit, PermitKind};
+
+/// A per-run summary accumulated by the walk.
+///
+/// Every tool's `Summary` (copy/chmod/rm/link) already satisfies these bounds
+/// (`Default + Add + Send + 'static`); requiring exactly them keeps the driver
+/// generic over the tool without depending on any tool's concrete counters.
+pub trait WalkSummary: Default + std::ops::Add<Output = Self> + Send + Sized + 'static {}
+
+impl<T> WalkSummary for T where T: Default + std::ops::Add<Output = T> + Send + Sized + 'static {}
+
+/// Owned per-entry context handed to every [`WalkVisitor`] method.
+///
+/// All fields are owned so the whole context can move into a spawned task (tasks
+/// are `'static`). It carries the hardened parent [`Dir`] (an `Arc`, cloned, never
+/// borrowed) and the entry's accumulated paths.
+#[derive(Clone)]
+pub struct EntryCx {
+    /// The hardened directory that contains this entry. Cloned into each child
+    /// task; every open below it is `O_NOFOLLOW`.
+    pub parent: Arc<Dir>,
+    /// This entry's name within `parent`.
+    pub name: OsString,
+    /// Path accumulated from the walk root to this entry (empty for the root
+    /// entry). Joined onto the tool's root it reconstructs the real path; used for
+    /// diagnostics and path reconstruction.
+    pub rel_path: PathBuf,
+    /// The path the driver feeds to the include/exclude filter for this entry: the
+    /// entry's **logical** path relative to the filter root. Usually equals
+    /// `rel_path`, but a tool processing a *delegated subtree* (rlink handing an
+    /// update-only or type-changed subtree to copy, which is rooted below the
+    /// original filter root) seeds the root entry's `filter_path` with that subtree's
+    /// logical base so the filter still matches at the entry's true path (e.g.
+    /// `cache/keep.txt`, not the bare `keep.txt` relative to the delegated root). The
+    /// driver extends it by one component per level alongside `rel_path`.
+    pub filter_path: PathBuf,
+    /// `root.join(rel_path)` — the reconstructed real filesystem path, for
+    /// diagnostics and the deliberately-path-based features (`-L`/`--delete`).
+    pub real_path: PathBuf,
+    /// Whether this is a dry run (no filesystem mutation).
+    pub dry_run: bool,
+    /// The process-global progress tracker.
+    pub prog_track: &'static Progress,
+}
+
+impl EntryCx {
+    /// Build the child context for `child_name` within `child_dir`, extending the
+    /// accumulated `rel_path`/`filter_path`/`real_path` by one component. `child_dir`
+    /// is the hardened directory the child lives in (for a directory entry's
+    /// contents, the opened directory itself; for the root, the root directory).
+    #[must_use]
+    pub fn child(&self, child_dir: Arc<Dir>, child_name: &OsStr) -> EntryCx {
+        EntryCx {
+            parent: child_dir,
+            name: child_name.to_owned(),
+            rel_path: self.rel_path.join(child_name),
+            filter_path: self.filter_path.join(child_name),
+            real_path: self.real_path.join(child_name),
+            dry_run: self.dry_run,
+            prog_track: self.prog_track,
+        }
+    }
+}
+
+/// What a [`WalkVisitor::dir_pre`] decided to do with a directory entry.
+///
+/// Generic over the tool's summary `Sum` (carried by [`Self::Skip`]), the
+/// per-directory inherited `Ctx` (carried by [`Self::Descend`] to this
+/// directory's children), and the per-directory `State` (carried by
+/// [`Self::Descend`] to [`WalkVisitor::dir_post`]).
+pub enum DirAction<Sum, Ctx, State> {
+    /// Do not descend; the whole subtree contributes `Sum` and nothing else
+    /// (e.g. `--ignore-existing` hit a non-directory destination, or a
+    /// filtered-out directory).
+    Skip(Sum),
+    /// Descend into `dir`; `child_ctx` is the inherited context handed to *this
+    /// directory's children* (copy's destination dir + freshness; chmod/rm: `()`),
+    /// and `state` is carried, in the same task, to [`WalkVisitor::dir_post`].
+    Descend {
+        /// The hardened directory whose contents to walk. For copy this is the
+        /// *source* directory being read; the destination travels in `child_ctx`.
+        dir: Arc<Dir>,
+        /// The inherited context the driver clones into each child task and hands
+        /// to the child's [`WalkVisitor::visit_leaf`] / [`WalkVisitor::dir_pre`].
+        /// This is how copy threads the destination parent directory down one
+        /// level without the driver knowing a second tree exists.
+        child_ctx: Ctx,
+        /// Tool state threaded from `dir_pre` to `dir_post` in the same task
+        /// (copy's `we_created` + dst handle for metadata; rm's `RelaxedDirGuard` +
+        /// snapshot; chmod's `()`).
+        state: State,
+    },
+}
+
+/// The names of the non-skipped children the driver actually spawned for a
+/// directory, in enumeration order.
+///
+/// Handed to [`WalkVisitor::dir_post`] so a visitor can build a `--delete`
+/// keep-set (the set of destination names with a source counterpart) without
+/// re-reading the directory.
+#[derive(Debug, Default)]
+pub struct ProcessedChildren {
+    names: Vec<OsString>,
+}
+
+impl ProcessedChildren {
+    /// The spawned children's names, in enumeration order.
+    #[must_use]
+    pub fn names(&self) -> &[OsString] {
+        &self.names
+    }
+
+    /// Move the names out (e.g. straight into a `--delete` keep-set).
+    #[must_use]
+    pub fn into_names(self) -> Vec<OsString> {
+        self.names
+    }
+}
+
+/// The `Result` a [`WalkVisitor::dir_pre`] produces: a [`DirAction`] over the
+/// visitor's three associated types, or its [`OperationError`]. A named alias so
+/// the trait method's signature stays readable.
+pub type DirPreResult<V> = Result<
+    DirAction<
+        <V as WalkVisitor>::Summary,
+        <V as WalkVisitor>::DirContext,
+        <V as WalkVisitor>::DirState,
+    >,
+    OperationError<<V as WalkVisitor>::Summary>,
+>;
+
+/// A tool's policy for a single-tree safe walk.
+///
+/// The driver calls these to make the per-entry decisions it cannot know itself;
+/// it owns everything else (enumeration, permit lifecycle, spawning, the
+/// drop-before-recurse invariant, error fold). All futures are `+ Send` (RPITIT)
+/// so the driver can spawn them; the visitor is shared as `Arc<V>`.
+pub trait WalkVisitor: Send + Sync + 'static {
+    /// Per-run summary type (the tool's `Summary`).
+    type Summary: WalkSummary;
+    /// Inherited per-directory context: what a directory's children need *from
+    /// that directory* (an "inherited attribute" of the tree walk). The driver
+    /// clones it into each child task and hands it to the child's
+    /// [`Self::visit_leaf`] / [`Self::dir_pre`].
+    ///
+    /// This is the single-tree driver's bridge to copy's second (destination)
+    /// tree: copy puts the open destination directory handle (plus its freshness)
+    /// here, so each child can create/overwrite its own destination entry without
+    /// the driver ever modeling a second tree. chmod and rm — which only ever
+    /// need the source parent the driver already provides — use `()`.
+    type DirContext: Clone + Send + Sync + 'static;
+    /// State threaded from [`Self::dir_pre`] to [`Self::dir_post`] within one
+    /// task (so it need not be `Send` across the per-child spawn boundary —
+    /// `dir_pre`/recurse/`dir_post` all run in the same task).
+    type DirState: Send;
+
+    /// The inherited context for the walk *root's* children — the seed of the
+    /// `DirContext` chain. copy returns its top-level destination directory here;
+    /// chmod/rm return `()`. (The root entry itself is processed with this same
+    /// context as its "parent" context.)
+    fn root_dir_context(&self) -> Self::DirContext;
+
+    /// Which backpressure pool a leaf permit comes from for this tool.
+    fn permit_kind(&self) -> PermitKind;
+
+    /// Whether to pre-acquire a leaf permit for a child with this `getdents`
+    /// `d_type` `hint`. Must return `false` for a hinted directory (it would
+    /// recurse and a held permit could deadlock); the canonical policy is
+    /// "known non-directory only". `hint == None` (DT_UNKNOWN) is a tool choice.
+    fn want_permit(&self, hint: Option<EntryKind>) -> bool;
+
+    /// Whether the walk stops at the first error (`--fail-early`).
+    fn fail_early(&self) -> bool;
+
+    /// The active filter, if any (drives [`walk::filter_is_dir`] /
+    /// [`walk::should_skip_entry_ref`]).
+    fn filter(&self) -> Option<&crate::filter::FilterSettings>;
+
+    /// Account for an entry the filter excluded, returning its summary
+    /// contribution. Called by the driver for each filtered-out child *instead of*
+    /// spawning it, so the tool's `*_skipped` counters and dry-run skip reporting
+    /// stay tool-owned (the driver is generic over the summary and dry-run mode).
+    ///
+    /// `kind` is the cheap `getdents`-hint classification (DT_UNKNOWN treated as a
+    /// file), matching the per-tool walks' skip dispatch; `skip_result` is the
+    /// `FilterResult` that caused the exclusion. The driver still increments the
+    /// shared progress counter via [`EntryKind::inc_skipped`] — override only to
+    /// add the summary counters and the `--dry-run` "skip …" line.
+    ///
+    /// The default does nothing (returns `Default`), which suits metadata-only
+    /// walks and the smoke tests; copy/chmod/rm override it to mirror their
+    /// existing `skipped_summary_for` + `report_skip` behavior.
+    fn on_skip(
+        &self,
+        _cx: &EntryCx,
+        _kind: EntryKind,
+        _skip_result: &crate::filter::FilterResult,
+    ) -> Self::Summary {
+        Self::Summary::default()
+    }
+
+    /// Process a non-directory entry (file / symlink / special). `parent_ctx` is
+    /// the inherited context of the directory containing this entry (copy's
+    /// destination parent + freshness). The pre-acquired `permit` (if any) is held
+    /// for the duration and dropped on return.
+    fn visit_leaf(
+        &self,
+        cx: &EntryCx,
+        parent_ctx: &Self::DirContext,
+        handle: Handle,
+        kind: EntryKind,
+        permit: Option<LeafPermit>,
+    ) -> impl std::future::Future<Output = Result<Self::Summary, OperationError<Self::Summary>>> + Send;
+
+    /// Pre-order step for a directory entry, run *after* the leaf permit has been
+    /// dropped and *before* the contents are walked. `parent_ctx` is the inherited
+    /// context of the *containing* directory. Returns [`DirAction::Skip`] to prune
+    /// the subtree or [`DirAction::Descend`] to walk it (supplying the child
+    /// context for this directory's own children, and the `dir_post` state).
+    ///
+    /// chmod applies the pre-order mode change here (unless deferred) and opens
+    /// the dir; copy resolves the destination directory (mkdir/overwrite/skip) and
+    /// puts it in the child context; rm snapshots metadata and arms its
+    /// `RelaxedDirGuard`.
+    fn dir_pre(
+        &self,
+        cx: &EntryCx,
+        parent_ctx: &Self::DirContext,
+        handle: &Handle,
+    ) -> impl std::future::Future<Output = DirPreResult<Self>> + Send;
+
+    /// Post-order step for a directory entry, run *after* its contents are walked,
+    /// in the same task as `dir_pre`. `state` is the [`DirAction::Descend`] state;
+    /// `processed` lists the spawned children; `child_result` is the contents' folded
+    /// outcome — `Ok(summary)` when every child succeeded, or `Err` carrying the
+    /// combined child error and the partial summary when one or more children failed
+    /// **without** `fail_early`. (Neither has `dir_pre`'s own contribution folded in
+    /// — the visitor carries that in `state` and folds it here.)
+    ///
+    /// `dir_post` is **not** called when `fail_early` is set and a child failed: that
+    /// case aborts the subtree immediately (the surrounding `JoinSet` drops, aborting
+    /// siblings) and the error is returned without any post-order work — so a
+    /// fail-early abort never applies post-order finalization (copy's directory
+    /// metadata / `--delete` prune). When `fail_early` is unset, `dir_post` IS called
+    /// with `Err(..)` so the visitor can still apply safe post-order finalization
+    /// (copy applies directory metadata even after a partial failure, but skips the
+    /// destructive `--delete` prune) and then return the combined error.
+    ///
+    /// copy applies directory metadata, empty-dir cleanup, and `--delete` prune;
+    /// chmod applies the deferred post-order change; rm runs the time filter, the
+    /// `rmdir`, and defuses its guard. A visitor that wants the historical
+    /// "finalize only on full success" behavior simply propagates the `Err`.
+    fn dir_post(
+        &self,
+        cx: &EntryCx,
+        state: Self::DirState,
+        processed: &ProcessedChildren,
+        child_result: Result<Self::Summary, OperationError<Self::Summary>>,
+    ) -> impl std::future::Future<Output = Result<Self::Summary, OperationError<Self::Summary>>> + Send;
+}
+
+/// Process one already-located entry: classify it authoritatively via
+/// [`Dir::child`], then dispatch.
+///
+/// - **Non-directory:** call [`WalkVisitor::visit_leaf`] holding `permit`.
+/// - **Directory:** `drop(permit)` — **the one and only drop-before-recurse
+///   site** — then [`WalkVisitor::dir_pre`]; on [`DirAction::Descend`], walk the
+///   contents via [`walk_dir_contents`] (threading the child context) and finish
+///   with [`WalkVisitor::dir_post`].
+///
+/// `parent_ctx` is the inherited context of the directory that contains this
+/// entry. `cx.parent` must be that (hardened) directory. On a classification
+/// error the entry's own error is surfaced — the same fail-closed behavior the
+/// per-tool walks have.
+#[async_recursion]
+pub async fn process_entry<V>(
+    visitor: Arc<V>,
+    cx: EntryCx,
+    parent_ctx: V::DirContext,
+    permit: Option<LeafPermit>,
+) -> Result<V::Summary, OperationError<V::Summary>>
+where
+    V: WalkVisitor,
+{
+    let _ops_guard = cx.prog_track.ops.guard();
+    // authoritative classification: one fstat, in one place. a symlink swap between
+    // the getdents hint and here is caught (O_NOFOLLOW) and classified as Symlink.
+    let handle = match cx.parent.child(&cx.name).await {
+        Ok(handle) => handle,
+        Err(err) => {
+            let err = anyhow::Error::new(err)
+                .context(format!("failed reading metadata from {:?}", &cx.real_path));
+            return Err(OperationError::new(err, Default::default()));
+        }
+    };
+    let kind = handle.kind();
+    if kind != EntryKind::Dir {
+        // leaf: the permit is held across the (non-recursive) leaf work and dropped
+        // when `visit_leaf` returns. nothing below this can recurse.
+        return visitor
+            .visit_leaf(&cx, &parent_ctx, handle, kind, permit)
+            .await;
+    }
+    // ── the single drop-before-recurse site ──────────────────────────────────
+    // an authoritative directory recurses; its children acquire their own permits.
+    // releasing the (only ever pre-acquired for a hinted leaf) permit now is what
+    // makes the hold-and-wait deadlock structurally impossible.
+    drop(permit);
+    match visitor.dir_pre(&cx, &parent_ctx, &handle).await? {
+        DirAction::Skip(summary) => Ok(summary),
+        DirAction::Descend {
+            dir,
+            child_ctx,
+            state,
+        } => {
+            match walk_dir_contents(Arc::clone(&visitor), dir, &cx, &child_ctx).await {
+                Ok((child_summary, processed)) => {
+                    visitor
+                        .dir_post(&cx, state, &processed, Ok(child_summary))
+                        .await
+                }
+                // a child failed. with `fail_early` the subtree is aborted immediately and NO
+                // post-order work runs (siblings were aborted when the `JoinSet` dropped) — the
+                // error propagates as-is. without `fail_early`, `dir_post` IS still invoked, with
+                // the combined error, so the visitor can apply safe post-order finalization (copy's
+                // directory metadata) while skipping destructive work (copy's `--delete` prune) and
+                // then return the combined error. `processed` is not recoverable on the error path,
+                // so an empty list is passed — the only consumer (a `--delete` keep-set) is skipped
+                // on error anyway.
+                Err(walk_err) => {
+                    if visitor.fail_early() {
+                        Err(walk_err)
+                    } else {
+                        visitor
+                            .dir_post(&cx, state, &ProcessedChildren::default(), Err(walk_err))
+                            .await
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Walk the contents of an open hardened directory.
+///
+/// Enumerates `dir` (gated `read_entries`), applies the visitor's filter to each
+/// child, pre-acquires a leaf permit per the visitor's policy, and spawns one
+/// [`process_entry`] task per non-skipped child. Joins them with a fold +
+/// fail-early via [`join_and_fold`].
+///
+/// Returns the folded child summary (filter-skip contributions included) and the
+/// [`ProcessedChildren`] list of the names that were spawned. `parent_cx`
+/// describes the directory entry itself (its `rel_path`/`real_path` are the base
+/// the children extend). `dir_ctx` is the inherited context of `dir` (the context
+/// its children receive) — for the root walk this is
+/// [`WalkVisitor::root_dir_context`].
+///
+/// ## Acquire-then-spawn ordering
+///
+/// Each leaf permit is acquired and the child task is spawned **in the same loop
+/// iteration**, before the next child's permit is acquired. This is load-bearing
+/// for backpressure correctness: a directory may have more permit-taking leaf
+/// children than the pool has permits. If permits for *every* child were acquired
+/// before *any* task was spawned (batch-acquire-then-spawn), the acquire loop would
+/// block on permit `N+1` while the first `N` permits are held by not-yet-running
+/// tasks — a self-deadlock against a saturated pool. Spawning each task as soon as
+/// its permit is taken lets running tasks release permits the loop is waiting on.
+#[async_recursion]
+pub async fn walk_dir_contents<V>(
+    visitor: Arc<V>,
+    dir: Arc<Dir>,
+    parent_cx: &EntryCx,
+    dir_ctx: &V::DirContext,
+) -> Result<(V::Summary, ProcessedChildren), OperationError<V::Summary>>
+where
+    V: WalkVisitor,
+{
+    let entries = match dir.read_entries().await {
+        Ok(entries) => entries,
+        Err(err) => {
+            let err = anyhow::Error::new(err)
+                .context(format!("cannot read directory {:?}", &parent_cx.real_path));
+            return Err(OperationError::new(err, Default::default()));
+        }
+    };
+    let mut skipped_summary = V::Summary::default();
+    let mut processed = ProcessedChildren::default();
+    let mut join_set = tokio::task::JoinSet::new();
+    for (entry_name, hint) in entries {
+        // the FILTER `is_dir` decision uses the AUTHORITATIVE type when the getdents
+        // hint is DT_UNKNOWN and a filter is active (one extra fstat only then, never
+        // follows a symlink) — the single classification path that closes the
+        // DT_UNKNOWN-omits-a-subtree bug class.
+        // used only for the FILTER decision; the recurse-vs-leaf choice is made later from the
+        // AUTHORITATIVE `child()` handle in `process_entry`, so there is no control-flow
+        // dependence here that would need `force_authoritative`.
+        let entry_is_dir =
+            walk::filter_is_dir(visitor.filter(), &dir, &entry_name, hint, false).await;
+        // build the child's owned context once; reused whether it is skipped or spawned.
+        let child_cx = parent_cx.child(Arc::clone(&dir), &entry_name);
+        if let Some(skip_result) =
+            walk::should_skip_entry_ref(visitor.filter(), &child_cx.filter_path, entry_is_dir)
+        {
+            // classification for the skipped-counter dispatch and the visitor's skip accounting
+            // uses the getdents hint, but for DT_UNKNOWN (`None`) falls back to the AUTHORITATIVE
+            // dir/non-dir decision already computed above for the filter. this branch only runs
+            // with an active filter, so `entry_is_dir` is the fstat-resolved value (no extra
+            // syscall) — matching the per-tool walks, which dispatched on the authoritative
+            // `file_type()`, so a real directory reported as DT_UNKNOWN is counted as
+            // `directories_skipped`, not `files_skipped`. (A DT_UNKNOWN symlink still counts as a
+            // file here; the subtree-scale dir mis-count is the one that matters.) The driver does
+            // the shared progress increment; the visitor's `on_skip` does the tool-specific summary
+            // + dry-run reporting.
+            let entry_kind = hint.unwrap_or(if entry_is_dir {
+                EntryKind::Dir
+            } else {
+                EntryKind::File
+            });
+            tracing::debug!("skipping {:?} due to filter", &child_cx.real_path);
+            entry_kind.inc_skipped(parent_cx.prog_track);
+            skipped_summary =
+                skipped_summary + visitor.on_skip(&child_cx, entry_kind, &skip_result);
+            continue;
+        }
+        // pre-acquire the leaf permit per the visitor's policy, then IMMEDIATELY spawn the task so
+        // the held permit can be released by the running task (see the acquire-then-spawn note
+        // above). a hinted directory takes none (it recurses); `process_entry` re-classifies and
+        // drops it for a hinted leaf that turns out to be a directory.
+        let permit =
+            walk::preacquire_leaf_permit(visitor.permit_kind(), hint, |h| visitor.want_permit(h))
+                .await;
+        // own everything moved into the task (cancellation safety): the child context
+        // (source parent Arc + owned name/paths), the visitor handle, and a clone of
+        // the inherited context (copy's destination parent dir).
+        let task_visitor = Arc::clone(&visitor);
+        let task_ctx = dir_ctx.clone();
+        processed.names.push(entry_name);
+        join_set
+            .spawn(async move { process_entry(task_visitor, child_cx, task_ctx, permit).await });
+    }
+    let folded =
+        join_and_fold::<V::Summary>(join_set, visitor.fail_early(), skipped_summary).await?;
+    Ok((folded, processed))
+}
+
+/// Join an already-populated `JoinSet` of per-child tasks and fold their summaries
+/// with fail-early / error-collection semantics — the shared join engine behind
+/// the directory walk.
+///
+/// The directory walk spawns into the `JoinSet` incrementally (acquire-then-spawn,
+/// see [`walk_dir_contents`]) and hands it here so the held leaf permits are
+/// released by running tasks rather than all held before the first task runs.
+/// `base` seeds the fold (the walk passes the filter-skip contributions). On
+/// `fail_early`, the first task error returns immediately, carrying the summary
+/// accumulated so far; the remaining tasks are aborted when the `JoinSet` is
+/// dropped. Otherwise all errors are collected and deduplicated, and the single
+/// combined error (if any) is returned with the full folded summary.
+pub async fn join_and_fold<S>(
+    mut join_set: tokio::task::JoinSet<Result<S, OperationError<S>>>,
+    fail_early: bool,
+    base: S,
+) -> Result<S, OperationError<S>>
+where
+    S: WalkSummary,
+{
+    let mut summary = base;
+    let errors = crate::error_collector::ErrorCollector::default();
+    while let Some(res) = join_set.join_next().await {
+        match res {
+            Ok(Ok(child_summary)) => summary = summary + child_summary,
+            Ok(Err(error)) => {
+                tracing::error!("walk child failed with: {:#}", &error);
+                summary = summary + error.summary;
+                if fail_early {
+                    // dropping `join_set` here aborts the still-running children.
+                    return Err(OperationError::new(error.source, summary));
+                }
+                errors.push(error.source);
+            }
+            Err(join_error) => {
+                if fail_early {
+                    return Err(OperationError::new(join_error.into(), summary));
+                }
+                errors.push(join_error.into());
+            }
+        }
+    }
+    if let Some(error) = errors.into_error() {
+        return Err(OperationError::new(error, summary));
+    }
+    Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filter::FilterSettings;
+    use crate::progress::Progress;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    static PROGRESS: std::sync::LazyLock<Progress> = std::sync::LazyLock::new(Progress::new);
+
+    /// A minimal `Summary` for the driver tests: counts files, dirs, and symlinks.
+    #[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
+    struct CountSummary {
+        files: usize,
+        dirs: usize,
+        symlinks: usize,
+    }
+
+    impl std::ops::Add for CountSummary {
+        type Output = Self;
+        fn add(self, other: Self) -> Self {
+            Self {
+                files: self.files + other.files,
+                dirs: self.dirs + other.dirs,
+                symlinks: self.symlinks + other.symlinks,
+            }
+        }
+    }
+
+    /// A trivial visitor that just counts entries by kind. Exercises RPITIT +
+    /// `Send` + recursion (compile and run). `DirState = ()`; leaf permit comes
+    /// from the pending-meta pool, taken for known non-directory hints only.
+    struct CountingVisitor {
+        /// counts every spawned leaf, to prove `visit_leaf` ran under backpressure.
+        leaves_seen: Arc<AtomicUsize>,
+    }
+
+    impl WalkVisitor for CountingVisitor {
+        type Summary = CountSummary;
+        type DirContext = ();
+        type DirState = ();
+
+        fn root_dir_context(&self) {}
+
+        fn permit_kind(&self) -> PermitKind {
+            PermitKind::PendingMeta
+        }
+        fn want_permit(&self, hint: Option<EntryKind>) -> bool {
+            // known non-directory only; a hinted dir (or DT_UNKNOWN) takes none.
+            hint.is_some_and(|k| k != EntryKind::Dir)
+        }
+        fn fail_early(&self) -> bool {
+            false
+        }
+        fn filter(&self) -> Option<&FilterSettings> {
+            None
+        }
+
+        async fn visit_leaf(
+            &self,
+            _cx: &EntryCx,
+            _parent_ctx: &(),
+            _handle: Handle,
+            kind: EntryKind,
+            permit: Option<LeafPermit>,
+        ) -> Result<CountSummary, OperationError<CountSummary>> {
+            self.leaves_seen.fetch_add(1, Ordering::SeqCst);
+            // hold the permit across the leaf work, then drop it (mirrors real tools).
+            drop(permit);
+            Ok(match kind {
+                EntryKind::Symlink => CountSummary {
+                    symlinks: 1,
+                    ..Default::default()
+                },
+                _ => CountSummary {
+                    files: 1,
+                    ..Default::default()
+                },
+            })
+        }
+
+        async fn dir_pre(
+            &self,
+            cx: &EntryCx,
+            _parent_ctx: &(),
+            _handle: &Handle,
+        ) -> Result<DirAction<CountSummary, (), ()>, OperationError<CountSummary>> {
+            // open the directory's contents fd (O_NOFOLLOW) and descend.
+            let dir = cx.parent.open_dir(&cx.name).await.map_err(|err| {
+                OperationError::new(
+                    anyhow::Error::new(err)
+                        .context(format!("cannot open directory {:?}", &cx.real_path)),
+                    Default::default(),
+                )
+            })?;
+            Ok(DirAction::Descend {
+                dir: Arc::new(dir),
+                child_ctx: (),
+                state: (),
+            })
+        }
+
+        async fn dir_post(
+            &self,
+            _cx: &EntryCx,
+            _state: (),
+            _processed: &ProcessedChildren,
+            child_result: Result<CountSummary, OperationError<CountSummary>>,
+        ) -> Result<CountSummary, OperationError<CountSummary>> {
+            // count this directory itself, post-order. a child error propagates (this test visitor
+            // has `fail_early == false` but never errors, so the `Ok` arm is what runs).
+            let child_summary = child_result?;
+            Ok(child_summary
+                + CountSummary {
+                    dirs: 1,
+                    ..Default::default()
+                })
+        }
+    }
+
+    /// Build an `EntryCx` for the root directory `name` under `parent`.
+    fn root_cx(parent: Arc<Dir>, name: &OsStr, real_path: PathBuf) -> EntryCx {
+        EntryCx {
+            parent,
+            name: name.to_owned(),
+            rel_path: PathBuf::new(),
+            filter_path: PathBuf::new(),
+            real_path,
+            dry_run: false,
+            prog_track: &PROGRESS,
+        }
+    }
+
+    // The driver compiles and runs end-to-end (RPITIT + Send + recursion) and counts
+    // a real tree correctly. `setup_test_dir` builds foo/{0.txt, bar/{1,2,3.txt},
+    // baz/{4.txt, 5.txt->sym, 6.txt->sym}}: under `foo` there are 5 files, 2
+    // subdirectories, and 2 symlinks.
+    #[tokio::test]
+    async fn counts_entries_in_a_tree() -> anyhow::Result<()> {
+        let tmp = crate::testutils::setup_test_dir().await?;
+        let foo = tmp.join("foo");
+        // open the foo directory as the hardened root to walk its contents.
+        let root = Arc::new(Dir::open_root_dir(&foo, false, congestion::Side::Source).await?);
+        let leaves_seen = Arc::new(AtomicUsize::new(0));
+        let visitor = Arc::new(CountingVisitor {
+            leaves_seen: Arc::clone(&leaves_seen),
+        });
+        let cx = root_cx(Arc::clone(&root), std::ffi::OsStr::new("foo"), foo.clone());
+        let (summary, processed) = walk_dir_contents(visitor, root, &cx, &()).await?;
+        assert_eq!(
+            summary,
+            CountSummary {
+                files: 5,
+                dirs: 2,
+                symlinks: 2,
+            },
+            "the walk must count every entry once, by kind"
+        );
+        // the top-level processed list is foo's direct children: 0.txt, bar, baz.
+        assert_eq!(processed.names().len(), 3, "foo has three direct children");
+        assert_eq!(
+            leaves_seen.load(Ordering::SeqCst),
+            7,
+            "every non-directory leaf (5 files + 2 symlinks) was visited"
+        );
+        Ok(())
+    }
+
+    /// Driver-level deadlock regression. The module name carries the
+    /// `max_open_files` substring so nextest's serial test-group isolates this
+    /// process-wide throttle mutation (see `.config/nextest.toml`).
+    mod max_open_files_tests {
+        use super::*;
+
+        /// Driver-level regression for the drop-before-recurse invariant.
+        ///
+        /// With the pending-meta pool sized to a single permit, we pre-acquire that
+        /// one permit and hand it to `process_entry` for an entry that is
+        /// AUTHORITATIVELY a directory (mirroring the spawn loop's hinted-leaf
+        /// pre-acquire when getdents mis-hints, or a swap between getdents and
+        /// `child()`). The directory's child file then needs its own pending-meta
+        /// permit to be visited.
+        ///
+        /// WITHOUT the fix, `process_entry` would hold that one permit across the
+        /// recursion and the child's `preacquire_leaf_permit` would block forever
+        /// (pool size 1, already held) — the timeout fires. WITH the fix, the
+        /// directory branch drops the permit before recursing, the child acquires it,
+        /// and the walk completes well within the timeout.
+        #[tokio::test]
+        async fn hinted_leaf_that_is_dir_drops_permit_before_recursion() -> anyhow::Result<()> {
+            let root = crate::testutils::create_temp_dir().await?;
+            // `d` is a real directory holding one child file `c`.
+            let dir_path = root.join("d");
+            tokio::fs::create_dir(&dir_path).await?;
+            tokio::fs::write(dir_path.join("c"), b"x").await?;
+            // size the pending-meta pool to a single permit (the `set_max_open_files`
+            // knob sizes both pools).
+            throttle::set_max_open_files(1);
+            // open the container of `d` and classify `d`: an authoritative directory.
+            let parent = Arc::new(
+                Dir::open_parent_dir(&root, congestion::Side::Source)
+                    .await?
+                    .into_tree(),
+            );
+            let name = std::ffi::OsStr::new("d");
+            let handle = parent.child(name).await?;
+            assert_eq!(
+                handle.kind(),
+                EntryKind::Dir,
+                "fixture `d` must be a directory"
+            );
+            drop(handle);
+            let leaves_seen = Arc::new(AtomicUsize::new(0));
+            let visitor = Arc::new(CountingVisitor {
+                leaves_seen: Arc::clone(&leaves_seen),
+            });
+            let cx = root_cx(Arc::clone(&parent), name, dir_path.clone());
+            // pre-acquire the single permit exactly as the spawn loop does for a
+            // hinted leaf, and hand it to `process_entry`. the fix drops it before
+            // recursing.
+            let permit = walk::preacquire_leaf_permit(
+                PermitKind::PendingMeta,
+                Some(EntryKind::File),
+                |_| true,
+            )
+            .await;
+            assert!(permit.is_some(), "the pre-acquire must take the one permit");
+            let result = tokio::time::timeout(
+                Duration::from_secs(20),
+                process_entry(visitor, cx, (), permit),
+            )
+            .await;
+            // restore the default (disabled) pool before asserting so a failure can't
+            // strand the tiny limit for a concurrent test.
+            throttle::set_max_open_files(0);
+            let summary = result
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "process_entry hung — leaf permit held across directory recursion (deadlock)"
+                    )
+                })?
+                .map_err(|e| e.source)?;
+            assert_eq!(
+                summary,
+                CountSummary {
+                    files: 1,
+                    dirs: 1,
+                    symlinks: 0,
+                },
+                "the directory and its one child file are both counted"
+            );
+            assert_eq!(
+                leaves_seen.load(Ordering::SeqCst),
+                1,
+                "the child file was visited (its permit was acquired after the drop)"
+            );
+            Ok(())
+        }
+    }
+}

--- a/common/tests/probe_metadata.rs
+++ b/common/tests/probe_metadata.rs
@@ -117,21 +117,32 @@ async fn copy_emits_one_metadata_sample_per_tree_entry() {
     .await
     .expect("copy succeeds");
     congestion::clear_sample_sink();
-    // Source-side metadata: one symlink_metadata per copy_internal call —
-    // 6 entries (root + a + b + 3 .txt files) = 6 src probes.
+    // The local copy walk is fd-based (`common::safedir`), so the probe counts reflect
+    // fd-relative `openat`/`fstatat`/`mkdirat` syscalls rather than the old path-based
+    // `symlink_metadata`/`create_dir`/`File::open`. The data copy (`copy_file_range`) stays
+    // unprobed, like the `tokio::fs::copy` it replaced.
+    //
+    // Source-side metadata (16 total):
+    //   - 1 open_root_dir(src parent)                                          = 1
+    //   - root dir:  child(stat) + open_dir(stat) + meta(fstat)                = 3
+    //   - 2 subdirs: child(stat) + open_dir(stat) + meta(fstat)    × 2         = 6
+    //   - 3 files:   child(stat) + open_file_read(fstat)           × 3         = 6
+    //   (read_entries / getdents is deliberately unprobed; each directory's applied metadata is
+    //    read from its own opened fd via `Dir::meta` — read-side fidelity, one fstat per dir)
     assert_eq!(
         sink.metadata_count_for(congestion::Side::Source),
-        6,
-        "expected 6 src metadata probes (one symlink_metadata per entry)",
+        16,
+        "expected 16 src metadata probes for the fd-based walk",
     );
-    // Destination-side metadata for the 6 entries:
-    //   - 3 dirs:  1 create_dir + 3 preserve (chown + chmod + utimens) = 4 each
-    //   - 3 files: 4 preserve (chown + open + chmod + utimens)         = 4 each
-    // tokio::fs::copy itself is unprobed (data-path), so 6 × 4 = 24 dst.
+    // Destination-side metadata (28 total):
+    //   - 1 open_root_dir(dst parent)                                          = 1
+    //   - 3 dirs:  make_dir(mkdir + open_dir) + 3 preserve (chown/chmod/utimens) = 5 each = 15
+    //   - 3 files: create_file + 3 preserve (chown/chmod/utimens)              = 4 each = 12
+    //   (copy_file_range is the data path, unprobed)
     assert_eq!(
         sink.metadata_count_for(congestion::Side::Destination),
-        24,
-        "expected 24 dst metadata probes (4 per entry × 6 entries)",
+        28,
+        "expected 28 dst metadata probes for the fd-based walk",
     );
 }
 
@@ -342,25 +353,38 @@ async fn link_update_path_emits_probes_for_update_tree() {
     .await
     .expect("link succeeds");
     congestion::clear_sample_sink();
-    // Source-side: 6 link_internal symlink_metadata(src) calls (root + a +
-    // b + 3 .txt) + 1 top-level symlink_metadata(update) (succeeds, dirs
-    // only at top level — recursive update lookups for src/{a,b,*.txt}
-    // are NotFound, so their probes are discarded) + 3 copy_internal
-    // symlink_metadata calls (one per u*.txt under update) = 10.
+    // The link walk is fd-based, and update-only entries are delegated to the fd-based
+    // `copy::copy_child` using the HELD update/destination parent `Dir`s (so the delegation opens
+    // no root dir of its own). read_entries/getdents is unprobed; failed (NotFound) probes are
+    // discarded by `run_metadata_probed`.
+    //
+    // Source-side (22 total):
+    //   - open_root_dir(src parent) + open_root_dir(update parent)               = 2
+    //   - root dir: src child + src open_dir + update child + update open_dir
+    //               + meta(fstat, from the update dir)                            = 5
+    //   - a/, b/:   src child + src open_dir + meta(fstat, from src dir) (× 2); the update
+    //               lookups are NotFound and discarded                            = 6
+    //   - 3 src .txt files: src child only (hard link reads src via linkat)       = 3
+    //   - 3 update-only files via copy_child: child + open_file_read (× 3)        = 6
+    //   2 + 5 + 6 + 3 + 6 = 22. (Drops if the update-walk path stops spawning copies for u*.txt.)
+    //   (each directory's applied metadata is read from its own opened fd via `Dir::meta`.)
     assert_eq!(
         sink.metadata_count_for(congestion::Side::Source),
-        10,
-        "expected 10 src metadata probes — drops to 7 if the update-walk \
-         path stops spawning copies for u*.txt",
+        22,
+        "expected 22 src metadata probes — drops if the update-walk path stops spawning copies \
+         for u*.txt",
     );
-    // Destination-side: 15 from the small-tree link (see
-    // link_emits_one_metadata_sample_per_tree_entry) + 12 for the 3
-    // update-only files (4 preserve probes per file via copy_file) = 27.
+    // Destination-side (31 total):
+    //   - open_root_dir(dst parent)                                              = 1
+    //   - 3 dirs (root + a + b): make_dir(mkdir + open_dir) + 3 preserve         = 5 each = 15
+    //   - 3 src .txt files hard-linked: linkat only (no metadata)                = 1 each = 3
+    //   - 3 update-only files via copy_child: create_file + 3 preserve           = 4 each = 12
+    //   1 + 15 + 3 + 12 = 31. (Drops if the update-walk path stops spawning copies for u*.txt.)
     assert_eq!(
         sink.metadata_count_for(congestion::Side::Destination),
-        27,
-        "expected 27 dst metadata probes — drops to 15 if the update-walk \
-         path stops spawning copies for u*.txt",
+        31,
+        "expected 31 dst metadata probes — drops if the update-walk path stops spawning copies \
+         for u*.txt",
     );
 }
 
@@ -391,20 +415,29 @@ async fn link_emits_one_metadata_sample_per_tree_entry() {
     .await
     .expect("link succeeds");
     congestion::clear_sample_sink();
-    // Source-side metadata: one symlink_metadata per link_internal call —
-    // 6 entries (root + a + b + 3 .txt files) = 6 src probes.
+    // The link walk is now fd-based (`common::safedir`), so the probe counts reflect fd-relative
+    // `openat`/`fstatat`/`mkdirat`/`linkat` syscalls rather than the old path-based
+    // `symlink_metadata`/`create_dir`/`hard_link`. read_entries/getdents is deliberately unprobed.
+    //
+    // Source-side metadata (13 total):
+    //   - 1 open_root_dir(src parent)                                  = 1
+    //   - root dir:  child(stat) + open_dir(stat) + meta(fstat)        = 3
+    //   - 2 subdirs: child(stat) + open_dir(stat) + meta(fstat) × 2    = 6
+    //   - 3 files:   child(stat) only — a hard link reads the src via `linkat` (no open_file_read)
+    //                                                  × 3             = 3
+    //   (each directory's applied metadata is read from its own opened fd via `Dir::meta`)
     assert_eq!(
         sink.metadata_count_for(congestion::Side::Source),
-        6,
-        "expected 6 src metadata probes (one symlink_metadata per entry)",
+        13,
+        "expected 13 src metadata probes for the fd-based link walk",
     );
-    // Destination-side metadata for the 6 entries:
-    //   - 3 dirs:  1 create_dir + 3 preserve (chown + chmod + utimens) = 4 each
-    //   - 3 files: 1 hard_link (no preserve in hard_link_helper)       = 1 each
-    // Total: 12 + 3 = 15 dst.
+    // Destination-side metadata (19 total):
+    //   - 1 open_root_dir(dst parent)                                            = 1
+    //   - 3 dirs:  make_dir(mkdir + open_dir) + 3 preserve (chown/chmod/utimens) = 5 each = 15
+    //   - 3 files: hard_link_at (linkat) only — a hard link copies no metadata   = 1 each = 3
     assert_eq!(
         sink.metadata_count_for(congestion::Side::Destination),
-        15,
-        "expected 15 dst metadata probes (4 per dir × 3 + 1 per file × 3)",
+        19,
+        "expected 19 dst metadata probes for the fd-based link walk",
     );
 }

--- a/docs/remote_protocol.md
+++ b/docs/remote_protocol.md
@@ -110,12 +110,12 @@ All TCP connections are encrypted and authenticated using TLS 1.3 with self-sign
 ### 2.2 Source → Destination Messages (Control Stream)
 
 **`Directory`**
-- **Purpose**: Create directory, store metadata, and declare entry counts for completion tracking
-- **Fields**: `src`, `dst`, `metadata`, `is_root`, `entry_count`, `file_count`, `keep_if_empty`
-- **Usage**: Sent during directory tree traversal in depth-first order. Source pre-reads the directory children before sending this message, so `entry_count` and `file_count` are known at send time. Destination creates the directory, stores metadata, and uses the entry counts for completion tracking.
+- **Purpose**: Create directory, store metadata, and declare the entry count for completion tracking
+- **Fields**: `src`, `dst`, `metadata`, `is_root`, `entry_count`, `keep_if_empty`
+- **Usage**: Sent during directory tree traversal in depth-first order. Source pre-reads the directory children before sending this message, so `entry_count` is known at send time. Destination creates the directory, stores metadata, and uses the entry count for completion tracking.
 - **`entry_count`**: Total number of child entries (files + directories + symlinks) that will be sent for this directory. Used by DirectoryTracker to know when all children have been processed.
-- **`file_count`**: Number of child files in this directory. Sent back to source via `DirectoryCreated` so source knows how many files to send (round-trip mechanism).
 - **`keep_if_empty`**: Whether to keep the directory if it ends up empty after filtering. `true` when no filter is active, when it is the root, or when the directory directly matches an include pattern. `false` when the directory was only traversed to look for potential matches and should be removed if it ends up empty on disk.
+- **No `file_count`**: the source retains the child-file count it computed during the pre-read (in its fd-map entry under hardened reads, or in a path→count map under `-L`), so it is not sent on the wire and not echoed back. See §7.1.
 
 **`Symlink`**
 - **Purpose**: Create symlink with metadata
@@ -141,8 +141,13 @@ All TCP connections are encrypted and authenticated using TLS 1.3 with self-sign
 
 **`DirectoryCreated`**
 - **Purpose**: Confirm directory created, request file transfers
-- **Fields**: `src`, `dst`, `file_count`
-- **Usage**: Sent after successfully creating directory. The `file_count` field is echoed back from the `Directory` message so source knows how many files to send from this directory. Triggers source to send files.
+- **Fields**: `src`, `dst`
+- **Usage**: Sent after successfully creating directory. This is purely the Pass-2 trigger: it tells the source the destination created the directory and is ready to receive its files. The source already retains the authoritative child-file count it computed during the Pass-1 pre-read (hardened: in the fd-map entry; `-L`: in a path→count map), so no count is echoed back. Triggers source to send files. See §7.1.
+
+**`DirectorySkipped`**
+- **Purpose**: Acknowledge a `Directory` message the destination did NOT create (create failed, ancestor failed, or `--ignore-existing` skipped a non-directory), so no files will be requested for it.
+- **Fields**: `src`, `dst`
+- **Usage**: The destination sends **exactly one** of `DirectoryCreated` / `DirectorySkipped` per `Directory` message. The source uses this to release the directory's held fd in its source-side fd-map (the TOCTOU-safe-read dir-fd budget). Without this nack a skipped directory's fd permit would never be released, so a no-ack subtree larger than the budget would block the source's Pass-1 walk and hang the copy. Does not affect completion accounting: skipped directories were never added to `pending_directories`.
 
 **`DestinationDone`**
 - **Purpose**: Signal destination has finished all operations
@@ -168,15 +173,20 @@ The protocol uses asymmetric error communication between source and destination:
 - Without these notifications, destination would hang waiting for entries that will never arrive
 - **Note**: `FileSkipped` is only sent for file open failures. Transport failures (send errors after connection established) are fatal and abort the entire transfer
 
-**Destination → Source: Does NOT communicate failures**
+**Destination → Source: Does NOT communicate failures (one exception: directory acks)**
 - Destination handles its own failures locally (logging, error flags)
-- Source doesn't need to know if destination failed to create a directory, write a file, etc.
 - Source continues sending the complete directory structure regardless of destination failures
 - This simplifies the protocol and reduces round-trips
 - Destination metadata errors (file, directory, symlink) are handled locally: logged with
   `tracing::error!`, `error_occurred` flag set, and processing continues unless `--fail-early`
   is set. This applies to both file metadata (via `DataConsumed` stream state) and directory
   metadata (in `DirectoryTracker::complete_directory_single`)
+- **Exception — directory acks:** the destination DOES tell the source the outcome of every
+  `Directory` message, sending exactly one of `DirectoryCreated` (success/reuse) or
+  `DirectorySkipped` (not created). This is not failure reporting for its own sake — the source
+  needs it to release the directory's held fd from its source-side fd-map (TOCTOU-safe reads).
+  It does not change what the source sends next (a skipped directory's children still arrive and
+  are skipped via `failed_directories`).
 
 ### 3.2 Rationale
 
@@ -186,9 +196,11 @@ This asymmetry reflects the producer-consumer relationship:
 
 If destination fails to create a directory:
 - It tracks this locally in `failed_directories`
-- It does NOT send `DirectoryCreated`, so source won't send files for it
+- It sends `DirectorySkipped` (not `DirectoryCreated`), so source won't send files for it but
+  does release the directory's held fd (fd-map). The same `DirectorySkipped` is sent when a
+  directory is skipped because an ancestor failed, or `--ignore-existing` skips a non-directory.
 - It skips any descendant directories/symlinks that arrive (checking `failed_directories`)
-- Source is unaware and continues sending the full structure
+- Source continues sending the full structure (it only releases the skipped dir's fd)
 
 ### 3.3 Root Item Failure Invariant
 
@@ -215,24 +227,25 @@ can eventually return true and `DestinationDone` can be sent.
 Source                              Destination
   |                                      |
   |  (pre-read root: 2 files, 1 symlink, 1 dir = 4 entries)
+  |  (retain root file_count=2 source-side)
   |  ---- Directory(root, entries=4,  -> |  Create root, store metadata
-  |         files=2, meta) ----------->  |  entries_expected=4
-  |  (pre-read child1: 1 file = 1 entry)
+  |         meta) -------------------->  |  entries_expected=4
+  |  (pre-read child1: 1 file = 1 entry; retain child1 file_count=1)
   |  ---- Directory(child1, entries=1,-> |  Create child1, store metadata
-  |         files=1, meta) ----------->  |  entries_expected=1
+  |         meta) -------------------->  |  entries_expected=1
   |                                      |  (child1 does NOT count for root yet)
   |  ---- Symlink(root/link, meta) ----> |  Create symlink
   |                                      |  root: entries_processed++ (1/4)
-  |  (pre-read child2: 0 entries)        |
+  |  (pre-read child2: 0 entries; retain child2 file_count=0)
   |  ---- Directory(child2, entries=0,-> |  Create child2, entries_expected=0
-  |         files=0, meta) ----------->  |  child2 complete → apply metadata
+  |         meta) -------------------->  |  child2 complete → apply metadata
   |                                      |  child2 notifies root: entries_processed++ (2/4)
   |  ---- DirStructureComplete --------> |  Structure complete
   |                                      |
-  |  <--- DirectoryCreated(root, fc=2) - |
-  |  <--- DirectoryCreated(child1,fc=1)  |
+  |  <--- DirectoryCreated(root) ------- |  (trigger only; no count echoed)
+  |  <--- DirectoryCreated(child1) ----- |
   |                                      |
-  |  (send 2 files from root)           |
+  |  (look up retained file_count=2; send 2 files from root) |
   |  ~~~~ File(root/f1) ~~~~~~~~~~~~~~~~>|  Write file
   |                                      |  root: entries_processed++ (3/4)
   |  ~~~~ File(root/f2) ~~~~~~~~~~~~~~~~>|  Write file
@@ -292,11 +305,13 @@ is called even for skipped entries to ensure the parent can complete.
 Source                              Destination
   |                                      |
   |  ---- Directory(dir1, entries=2,  -> |  mkdir dir1 → FAILS
-  |         files=1, meta) ----------->  |  Add to failed_directories
-  |                                      |  DO NOT send DirectoryCreated
+  |         meta) -------------------->  |  Add to failed_directories
+  |  <--- DirectorySkipped(dir1) ------- |  Nack (not created)
+  |  (release dir1 fd, no Pass 2)        |
   |                                      |
   |  ---- Directory(dir1/dir2, ...) ---> |  Ancestor failed, skip (log warning)
-  |                                      |  parent(dir1) process_child_entry (skipped)
+  |  <--- DirectorySkipped(dir1/dir2) -- |  Nack; parent(dir1) process_child_entry
+  |  (release dir1/dir2 fd, no Pass 2)   |
   |  ---- Symlink(dir1/link, meta) ----> |  Ancestor failed, skip (log warning)
   |                                      |  parent(dir1) process_child_entry (skipped)
   |  ---- DirStructureComplete --------> |  Structure complete
@@ -358,7 +373,7 @@ during the copy (see Section 7.1 for handling of source modifications).
 **On `Directory` message:**
 - If ancestor in `failed_directories`: skip, log warning; call `process_child_entry(parent)` to count this entry (directory won't have children to process)
 - Try to create directory (see directory creation semantics below)
-- If success: add to `pending_directories` with `entries_expected` from message, `entries_processed = 0`, store metadata, send `DirectoryCreated { file_count }` back to source. Do NOT notify parent yet — parent is notified when this directory completes (via `complete_directory`), ensuring bottom-up completion order.
+- If success: add to `pending_directories` with `entries_expected` from message, `entries_processed = 0`, store metadata, send `DirectoryCreated { src, dst }` back to source (the Pass-2 trigger; no count is echoed — the source retains its own file count). Do NOT notify parent yet — parent is notified when this directory completes (via `complete_directory`), ensuring bottom-up completion order.
 - If failure: add to `failed_directories`; if `is_root`, set `root_complete = true` to avoid hang; if not root, call `process_child_entry(parent)` (directory won't go through `complete_directory`)
 
 **Directory creation semantics:**
@@ -460,7 +475,7 @@ Destination                          Source
 
 ## 7. Design Rationale
 
-### 7.1 Unified Entry Counting and Round-Trip File Count
+### 7.1 Unified Entry Counting and Source-Retained File Count
 
 The protocol uses a two-layer counting scheme for directory completion:
 
@@ -471,12 +486,40 @@ traversal time and used by DirectoryTracker to determine when all children have 
 processed. Since directories, symlinks, and files all count, a parent directory only
 completes after all its children are done — preventing premature metadata application.
 
-**File count (round-trip, source → destination → source):**
-The `file_count` in the `Directory` message tells destination how many files exist in this
-directory. Destination echoes it back in `DirectoryCreated { file_count }` so that source
-knows how many files to send. This round-trip mechanism decouples the traversal from file
-sending — source pre-reads children during traversal but only sends files after receiving
-the `DirectoryCreated` confirmation.
+**File count (source-retained, no round-trip):**
+The number of child files in a directory is computed by the source during the Pass-1
+pre-read and **retained on the source side** — it is not sent on the wire and not echoed
+back. The destination only signals readiness:
+
+- **Hardened reads (default):** the count is stored in the directory's source-side fd-map
+  entry (alongside the held `O_NOFOLLOW` directory fd) keyed by source path.
+- **`-L`/`--dereference`:** the source holds no fd-map, so the count is stored in a separate
+  `path → file_count` map.
+
+`DirectoryCreated { src, dst }` is purely the **Pass-2 trigger**: when it arrives the source
+looks up the directory's retained count and begins sending its files. This still decouples
+traversal (Pass 1) from file sending (Pass 2) — the source pre-reads children during
+traversal but only sends files after the `DirectoryCreated` confirmation — but without a
+file-count round-trip. Under hardened reads a `DirectoryCreated` whose directory has no
+retained entry is a TOCTOU-safety / protocol-invariant violation and **fails closed** (the
+source refuses to re-resolve the directory by path); under `-L` a missing count defaults to
+0 with a debug log (that path is not hardened, so a miss is not a fail-closed condition).
+
+**Committed-but-unreadable directory (tombstone):**
+When the source commits a directory to the wire (the `is_dir` pre-check passed) but then
+cannot open or enumerate it, it sends a 0-entry `Directory` so the destination creates an
+empty directory and completes its tracking. To keep the fail-closed rule from mis-firing on
+this legitimate case, the source registers a matching retained entry before sending:
+
+- If the directory fd is held (only enumeration failed): a real 0-file fd-map entry.
+- If the directory could not be opened at all: a **tombstone** (no held fd, no fd-budget
+  permit, file_count 0).
+
+Either way the destination's `DirectoryCreated` ack consumes a real entry instead of hitting
+the fail-closed miss path, and Pass 2 sends zero files. This preserves the
+"unreadable directory → continue as an empty directory unless `--fail-early`" behavior for
+both root and non-root directories. (A *true* miss — a directory that was never committed,
+or whose entry was already consumed — still fails closed.)
 
 **Handling source modifications during copy:**
 Directory contents may change between the source's pre-read (during traversal) and the
@@ -484,10 +527,11 @@ actual file sending (after receiving `DirectoryCreated`):
 
 - **Files disappeared:** source sends synthetic `FileSkipped` for missing files, so
   destination's `entries_processed` still reaches `entries_expected`
-- **Extra files appeared:** source ignores them (only sends up to `file_count`), logs warning
+- **Extra files appeared:** source ignores them (only sends up to the retained file count),
+  logs warning
 - **Extra directories/symlinks appeared:** source ignores them (already sent during traversal)
-- **Directory unreadable at send time:** source sends `file_count` synthetic `FileSkipped`
-  messages so destination can still complete
+- **Directory unreadable at send time:** source sends one synthetic `FileSkipped` per retained
+  expected file so destination can still complete
 - With `--fail-early`: abort on any discrepancy
 
 The destination uses `>=` comparison (`entries_processed >= entries_expected`) rather than
@@ -508,7 +552,8 @@ Failed directories are tracked in a simple set:
 - Descendants are detected via ancestor lookup and skipped
 - Skipped descendants still call `process_child_entry(parent)` so the parent's entry count
   is correctly maintained — even when a child directory fails, it counts as a processed entry
-- Failed directories are not added to `pending_directories` since no `DirectoryCreated` is sent
+- Failed directories are not added to `pending_directories`; a `DirectorySkipped` nack is sent in
+  place of `DirectoryCreated` (exactly one of the two is sent per `Directory`)
 
 ### 7.4 Message Batching
 
@@ -519,7 +564,7 @@ The protocol uses two sending primitives:
 - Benefit: Multiple messages batched in single network packet
 
 **`send_control_message()`:** Serializes and flushes.
-- Used for: `DirStructureComplete`, `DestinationDone`, `DirectoryCreated`
+- Used for: `DirStructureComplete`, `DestinationDone`, `DirectoryCreated`, `DirectorySkipped`
 - Critical for correctness at synchronization points
 
 ### 7.5 Data Connection Pooling

--- a/docs/security.md
+++ b/docs/security.md
@@ -175,8 +175,24 @@ User
 - **Compromised local machine**: Master machine is fully trusted
 - **Compromised remote hosts**: If host is compromised, attacker controls rcpd
 - **Side-channel attacks**: No specific mitigations for timing attacks, etc.
-- **Local TOCTTOU attacks**: See [TOCTTOU Vulnerabilities](tocttou.md) for details on
-  race condition attacks when rcp runs with elevated privileges
+- **TOCTTOU attacks with `--dereference`/`-L`**: Following symlinks is requested behavior
+  and cannot be hardened. See [TOCTTOU Vulnerabilities](tocttou.md) for details.
+- **TOCTTOU on non-Linux**: The hardened path is Linux-only; non-Linux builds use
+  path-based operations. See [TOCTTOU Vulnerabilities](tocttou.md).
+- **Trust of the operand path's prefix**: The hardening protects everything at or below the
+  named root, but the tools do not verify that the directories *above* it are free of
+  less-privileged control. `--require-toctou-safe` enforces the hardened walk (refusing
+  `-L`/non-Linux); the prefix trust is the caller's responsibility — see the
+  [Scope of TOCTOU safety](tocttou.md#scope-of-toctou-safety) section.
+
+On Linux, the default (non-`-L`) local hardening is implemented through a single shared
+safe-walk driver (`common/src/walk_driver.rs`): `rcp` (copy), `rchm`, and `rrm` are
+`WalkVisitor` implementations, so the recursive walk — and in particular the leaf-permit
+"drop before recursion" deadlock invariant — lives in one place rather than being
+hand-maintained per tool. The trusted/hardened boundary is type-enforced via `TrustedDir`,
+and `DT_UNKNOWN` filter classification goes through the single `filter_is_dir` path. `rlink`
+remains dual-tree (source plus `--update`) but shares the same substrate. See
+[TOCTTOU Vulnerabilities](tocttou.md) for the full mechanism.
 
 ## Threat Model
 
@@ -313,7 +329,13 @@ The rcp security model provides:
 
 **Limitations**:
 
-- ⚠️ **TOCTTOU**: No protection against local race conditions when running with elevated
-  privileges. See [TOCTTOU Vulnerabilities](tocttou.md) for details and mitigations.
+- ⚠️ **TOCTTOU with `--dereference`/`-L`**: Following symlinks is requested behavior and
+  is not hardened. On Linux, all other default paths (local copy/link/chmod/rm/delete,
+  remote copy source+destination) are fully TOCTOU-hardened. Non-Linux builds are not
+  hardened. Use `--require-toctou-safe` in sudo rules to enforce the hardened walk (it
+  refuses `-L`/non-Linux). The trust of the destination path's prefix is the caller's
+  responsibility, not verified in-tool — see the
+  [Scope of TOCTOU safety](tocttou.md#scope-of-toctou-safety) section of
+  [TOCTTOU Vulnerabilities](tocttou.md) for details.
 
 Use `--no-encryption` only on trusted networks where performance is critical.

--- a/docs/tocttou.md
+++ b/docs/tocttou.md
@@ -1,20 +1,21 @@
 # TOCTTOU Vulnerabilities in the RCP tools
 
 This document describes Time-of-Check-Time-of-Use (TOCTTOU) race condition vulnerabilities
-that affect the RCP tools (`rcp`, `rchm`, `rrm`, `rlink`) when used with elevated
-privileges, and discusses potential mitigations. The examples below use `rcp`, but the
-same check-then-path-operate pattern applies to the other tools — e.g. `rchm` performs a
-path-based `chmod` after an `lstat`-based type check, so a concurrent symlink swap could
-redirect the mode change despite `rchm`'s otherwise non-dereferencing behavior.
+that affect the RCP tools when used with elevated privileges, and documents the hardening
+that is now implemented on Linux. The examples below use `rcp`, but the attack pattern
+applies to the other tools as well.
 
 ## Table of Contents
 
 - [Overview](#overview)
+- [Scope of TOCTOU safety](#scope-of-toctou-safety)
 - [What is TOCTTOU?](#what-is-tocttou)
 - [Attack Scenarios](#attack-scenarios)
-- [Current State](#current-state)
-- [Mitigation Options](#mitigation-options)
-- [Recommendations](#recommendations)
+- [Implemented Hardening](#implemented-hardening)
+- [What Is Not Hardened](#what-is-not-hardened)
+- [Residual Preconditions](#residual-preconditions)
+- [The Linter: --toctou-check and --require-toctou-safe](#the-linter---toctou-check-and---require-toctou-safe)
+- [Summary](#summary)
 
 ## Overview
 
@@ -33,6 +34,105 @@ vulnerabilities directly.
 privilege than an actor who can modify the paths being traversed.* Root operating on
 trusted, root-owned trees is outside this threat; the risk arises specifically when a
 more-privileged run traverses a tree that a less-privileged actor can write to.
+
+On Linux, the local and remote default paths are now TOCTOU-hardened (see
+[Implemented Hardening](#implemented-hardening) below) — for everything *at or below the
+named root*. The trust of the path *above* the named root is the caller's responsibility.
+The next section defines the guarantee precisely; read it before relying on TOCTOU safety
+under elevated privilege.
+
+## Scope of TOCTOU safety
+
+TOCTOU safety in the RCP tools rests on **two guarantees** and **one delegated
+responsibility**. The scope is deliberately narrow, because a general-purpose copy/chmod/rm
+tool can neither freeze the filesystem while it works nor vouch for the paths it is handed. So
+it guarantees only what is both achievable and security-relevant, and leans on the caller for
+the rest.
+
+### In scope — the two guarantees
+
+On the default (non-`-L`) path, on Linux, given the operand paths as written:
+
+**1. Containment.** No symlink or path-component swap _at or below a named root_ — anywhere in
+the tree the tool traverses — can redirect a read, write, chmod, chown, or delete to an object
+**outside that root's subtree.** This is the property that matters when a privileged process
+operates on a tree a less-privileged actor can write *into* (the classic "root copies, chmods,
+or removes over an attacker-controlled directory" hazard). It is delivered by the fd-based
+safe walk described below: the named root and every entry beneath it are opened `O_NOFOLLOW`,
+classified by `fstat` of the held fd, and operated on via fd-relative syscalls — and for
+chmod/chown/hard-link, via the entry's pinned `O_PATH` fd through `/proc/self/fd` — so a
+swapped-in symlink is never followed out of the subtree.
+
+**2. Permission and ownership fidelity.** The destination (`rcp`/`rlink`) or the modified
+entry (`rchm`) receives exactly the permissions and ownership of the source object that was
+actually read; a concurrent swap can never make the tool **widen** permissions or attach the
+wrong owner — e.g. it cannot write a `0600` root-owned file's contents out as world-readable.
+Mode and bytes are taken from the *same* fd, and metadata is applied through the destination's
+own held fd, never re-resolved by path.
+
+**"The named root"** is the final component of the operand path — the file or directory you
+name. It is opened `O_NOFOLLOW` and classified by the `fstat` of that held fd, so a swap of
+the root *entry itself* (within its parent) is caught at open, and everything reachable
+beneath it is the hardened tree. (Corollary: the root's immediate parent need not be
+non-writable for the guarantee to hold — a swap of the root entry there is caught at open.)
+
+### Out of scope — what we deliberately do not promise
+
+**Freezing the tree, or pinning _which_ object is operated on.** The tree may change
+concurrently; the tool operates on whatever is validly reachable within the subtree at access
+time. Each child is reached with a single-component `openat(parent_fd, name, O_NOFOLLOW)`,
+which re-resolves `name` — it is **not** pinned to the exact inode first classified, so a
+same-name swap to *another regular file in the same hardened directory* is possible and
+accepted. This is deliberate, not a gap, because it is not a security boundary: an actor who
+can swap entries inside the subtree already controls that subtree's contents, so operating on
+the swapped-in file grants them nothing they did not already have. Both guarantees above still
+hold across such a swap — you cannot escape the subtree (Containment), and permissions are
+never widened because mode and bytes come from the *same* fd (Fidelity). We do not attempt to
+detect or prevent concurrent modification beyond that.
+
+**Whether the operand path _itself_ is trustworthy.** The directories *above* the named root —
+the prefix the tool follows to reach it — are resolved normally (following symlinks). The
+tools do **not** verify that this prefix is free of less-privileged control, or free of
+symlinks that resolve somewhere unexpected. A general-purpose tool has no way to decide
+whether a given path is an acceptable privileged target: *"is `/home/alice` a legitimate place
+for root to write?"* depends entirely on policy the tool does not — and cannot — know. Any
+in-tool "is this prefix trusted" heuristic is either unsound (it cannot anticipate every
+symlink, `..`, ownership, and mount-namespace case) or so conservative it refuses almost every
+real privileged copy. So the tools do not attempt it. **The caller must pass operands it has
+resolved and whose prefix it trusts.**
+
+The guarantees are *additionally* bounded by separately-documented exceptions:
+`--dereference`/`-L` and non-Linux builds (see [What Is Not Hardened](#what-is-not-hardened)),
+`rcmp` (read-only; out of scope), and the kernel preconditions `fs.protected_hardlinks=1` and
+no attacker-controlled bind mounts (see [Residual Preconditions](#residual-preconditions)). A
+hardlink alias planted at or below the root, for instance, is a *non-swap* redirect covered by
+the `protected_hardlinks` precondition rather than by the Containment guarantee.
+
+### The contract for safe privileged (sudo) use
+
+Safe TOCTOU use under elevated privilege is a two-layer arrangement:
+
+1. **A layer above the RCP tools** — the `sudo` policy, or a thin vetted wrapper — decides
+   which operand paths are acceptable and ensures they are fully resolved and that the
+   directories above each named root are not under a less-privileged actor's control. The
+   "is this path safe?" judgment lives here, because this is where the policy context exists.
+2. **The RCP tool** guarantees the hardened walk for everything at and below those named
+   roots (the in-scope property above).
+
+`--require-toctou-safe` is the tool's half of this contract: it refuses to run unless the
+invocation uses the hardened walk — rejecting `--dereference`/`-L` (which follows symlinks by
+design) and non-Linux builds. It does **not**, and cannot, vouch for the trust of the operand
+paths; that is the caller's responsibility per (1).
+
+```bash
+# The sudo policy constrains operands to vetted, resolved, trusted paths;
+# --require-toctou-safe guarantees the hardened walk for what is at/below them.
+user ALL=(root) NOPASSWD: /usr/bin/rcp --require-toctou-safe /vetted/source/* /vetted/dest/
+```
+
+A wildcard rule (`... --require-toctou-safe *`) enforces only the tool's half — hardened
+walk, no `-L`. It does **not** make an arbitrary destination safe. Lock the paths down in the
+policy.
 
 ## What is TOCTTOU?
 
@@ -58,6 +158,9 @@ write to destination → leaks /etc/shadow
 
 ## Attack Scenarios
 
+These scenarios explain the classes of attack the hardening defends against. Each is now
+defeated on Linux for the default (non-`-L`) path.
+
 ### Scenario 1: Symlink Race Attack (Privileged Source Read)
 
 **Setup**: A user has a sudo rule allowing them to copy files from `/backup`:
@@ -76,6 +179,10 @@ user ALL=(root) NOPASSWD: /usr/bin/rcp /backup/* /home/user/restore/
 4. If the timing is right, rcp checks when it's a regular file, but opens when it's a symlink
 5. Result: `/etc/shadow` is copied to `/home/user/restore/myfile`
 
+**Hardening**: The source open uses `openat(parent_fd, "myfile", O_RDONLY|O_NOFOLLOW|O_NONBLOCK)`.
+A swapped-in symlink fails with `ELOOP`. A swapped-in FIFO is caught by the subsequent
+`fstat`+`S_ISREG` check (the process never blocks waiting for a writer).
+
 ### Scenario 2: Destination Escape Attack
 
 **Setup**: A user can copy to a specific destination via sudo:
@@ -92,6 +199,10 @@ user ALL=(root) NOPASSWD: /usr/bin/rcp /home/user/upload/* /var/www/html/
 4. rcp continues writing into what it thinks is the destination directory
 5. Result: Files written to `/etc/` instead of `/var/www/html/innocent/`
 
+**Hardening**: Destination directories are opened `O_NOFOLLOW|O_DIRECTORY` relative to the
+parent's held fd. If the entry has been swapped to a symlink, `openat` fails with `ELOOP`.
+All file writes are relative to that held fd — never re-resolving the path.
+
 ### Scenario 3: Directory Traversal via Symlink
 
 **Setup**: rcp is copying a directory tree:
@@ -106,6 +217,11 @@ sudo rcp /shared/project /backup/
 2. During directory traversal, attacker replaces `subdir/file` with a symlink to `/etc/passwd`
 3. rcp (running as root) reads `/etc/passwd` instead of the intended file
 4. Result: Sensitive file contents copied to attacker-accessible backup
+
+**Hardening**: Every entry name is opened with `openat(parent_dir_fd, name, O_NOFOLLOW)`,
+where `parent_dir_fd` is the already-held directory fd opened the same way. A swapped
+symlink anywhere in the tree causes a fail-closed `ELOOP` or `ENOTDIR` — never a
+redirect.
 
 ### Scenario 4: Metadata Preservation Attack
 
@@ -122,218 +238,257 @@ sudo rcp --preserve=ownership /data/files /backup/
 3. rcp applies metadata (ownership) to the symlink target
 4. Result: Attacker potentially modifies ownership of system binaries
 
-## Current State
+**Hardening**: All metadata operations (chown, chmod, utimes) use fd-based syscalls
+(`fchown`, `fchmod`, fd-relative `utimensat`) on the held destination fd rather than
+path-based calls. There is no path re-resolution after the file is created.
 
-rcp currently has **no specific TOCTTOU mitigations**. File operations follow this pattern:
+## Implemented Hardening
 
-```rust
-// common/src/copy.rs - simplified
-let src_metadata = tokio::fs::symlink_metadata(&src).await?;  // CHECK
-// ... time passes, file can change ...
-if src_metadata.is_file() {
-    tokio::fs::copy(&src, &dst).await?;  // USE
-}
-```
+### Mechanism: fd-based safe walk
 
-**Behaviors that expose TOCTTOU windows**:
+The core principle is **never re-resolve a path**. The implementation (in
+`common/src/safedir.rs`) holds each directory as an open fd (`Dir`, opened
+`O_RDONLY|O_DIRECTORY|O_NOFOLLOW|O_CLOEXEC`) and derives each child via a
+single-component `openat(parent_fd, name, O_NOFOLLOW)`. The type of every entry is
+determined by `fstat`-ing that fd — not from the `getdents` `d_type` field alone
+(which is only a hint). Every operation on the child is performed on the held fd or via
+fd-relative `*at()` syscalls.
 
-1. **Metadata check before open**: `symlink_metadata()` followed by `copy()` or `read_dir()`
-2. **Path-based operations**: All operations use path strings, not file descriptors
-3. **No O_NOFOLLOW enforcement**: Standard `tokio::fs` doesn't provide this control
-4. **Destination checks**: Existence and metadata checks before writing
-5. **Permission preservation**: `fchownat()`/`utimensat()` applied after file creation
+Specific invariants enforced:
 
-**What rcp does do**:
+- Every `openat` of a non-dereferenced entry uses `O_NOFOLLOW`. A swapped-in symlink
+  fails with `ELOOP` (fail closed).
+- File opens include `O_NONBLOCK` to avoid blocking on a FIFO that an attacker swapped
+  in. The subsequent `fstat`+`S_ISREG` check rejects any non-regular entry (FIFO,
+  device, directory) with `EINVAL`.
+- Metadata operations (chown, chmod, utimes, and critically symlink timestamps) use
+  fd-based syscalls. File data is copied via `copy_file_range` between held fds.
+- On overwrite paths, a `recheck` verifies that the `(dev, ino)` of the entry matches
+  the originally classified handle before performing the unlink.
+- Directory names passed to any `*at()` call are validated to be single path
+  components (no `/`, `.`, `..`).
+- **Source payload and metadata come from the same fd (read-side fidelity).** For each copied or
+  sent source object, the data and the metadata applied/sent for it are read from one open file
+  description, so a same-name swap cannot pair one inode's bytes/target with another inode's
+  mode/owner/timestamps: a regular file via `open_file_read` → `(File, FileMeta)`; a symlink via the
+  `O_PATH` handle's `read_symlink` (target + metadata off the one fd); a directory via the
+  enumerated `Dir` fd (`read_entries` + `meta`). The remote *destination* is fidelity-safe by
+  construction — it writes the received bytes and applies the received metadata to its single
+  created fd, so there are no two source fds to mismatch. `scripts/check-source-read-fidelity.sh`
+  (run in CI) backstops this by forbidding by-name source-payload reads (`read_link_at`,
+  `File::open`) in the hardened modules, outside the `-L`/`--dereference` path.
 
-- Uses `symlink_metadata()` (lstat) instead of `metadata()` (stat) to not follow symlinks
-  during checks
-- Explicit `--dereference` flag required to follow symlinks
-- Preserves symlinks as symlinks by default (copies link target path, not link content)
+### One shared traversal driver
 
-## Mitigation Options
+The recursive safe-walk is not re-implemented per tool. `rcp` (copy), `rchm`, and `rrm`
+are thin [`WalkVisitor`](../common/src/walk_driver.rs) implementations; the single shared
+driver in `common/src/walk_driver.rs` owns the recursive
+spawn/classify/permit/drop-before-recurse skeleton, so the security-relevant invariants
+each live in exactly one place:
 
-### Option 1: libpathrs Integration
+- **Drop-before-recurse (deadlock invariant)**: the leaf-permit "drop the permit before
+  recursing into a directory" rule lives in the driver's directory branch alone, not
+  hand-maintained at every recursion site. A structural lint
+  (`scripts/check-walk-driver-usage.sh`) fails the build if `copy.rs`/`chmod.rs`/`rm.rs`
+  reintroduce a hand-rolled walk (a `JoinSet` or `read_entries`).
+- **Trusted vs hardened boundary**: the symlink-following parent-prefix open returns a
+  distinct `TrustedDir` type (`common/src/safedir.rs`); crossing below the named root
+  yields a hardened `Dir` whose child opens are all `O_NOFOLLOW`. The boundary is
+  type-enforced — a hardened child cannot be silently used where a trusted parent is
+  required, and vice versa.
+- **DT_UNKNOWN classification**: every filter `is_dir` decision routes through the single
+  `walk::filter_is_dir` path, which falls back to an authoritative `fstat` when the
+  `getdents` hint is `DT_UNKNOWN` (never following a symlink), so a real directory's
+  subtree can never be silently omitted by a hint-only check.
 
-[libpathrs](https://github.com/cyphar/libpathrs) is a Rust library designed specifically
-to prevent TOCTTOU attacks through safe path resolution.
+`rlink` is the documented exception: it walks two correlated trees (source plus
+`--update`) and so keeps its own dual-tree enumeration, but it shares the same substrate —
+the `TrustedDir` boundary, the `LeafPermit` lifecycle, and `filter_is_dir` — rather than
+duplicating the hardening.
 
-**How it works**:
+### Scope
 
-1. Opens a "Root" handle to the base directory
-2. Resolves paths **within** that root, returning `O_PATH` file descriptors
-3. All operations use file descriptors, not paths
-4. Leverages Linux `openat2()` with `RESOLVE_NO_SYMLINKS` / `RESOLVE_BENEATH` flags
+The following are fully TOCTOU-hardened on Linux, against both leaf-entry and
+intermediate-directory symlink/path swaps:
 
-```rust
-use pathrs::Root;
+| Tool / path | Notes |
+|---|---|
+| `rcp` local copy | Files, dirs, symlinks; all overwrite branches |
+| `rlink` | Hard-link walk incl. copy delegations |
+| `rchm` | Recursive chmod/chgrp/chown |
+| `rrm` | Recursive remove incl. read-only-dir relax |
+| `--delete` pruning | fd-relative prune; enumeration + removal via held dst fd |
+| `rcp` remote copy — source side | Two-pass fd-map: dirs opened `O_NOFOLLOW`, files read fd-relative |
+| `rcp` remote copy — destination side | Directory tracker fd-map: dirs created/opened `O_NOFOLLOW`, files written fd-relative |
 
-let root = Root::open("/backup")?;
-let handle = root.resolve("subdir/file")?;  // Safe resolution
-let file = handle.reopen(OpenFlags::O_RDONLY)?;  // fd-based open
-```
+Remote `--delete` is not yet supported and is rejected by rcp before any operation begins.
 
-**Advantages**:
+### Trusted boundary
 
-- Designed for exactly this problem (used by container runtimes like runc)
-- Uses kernel features when available (openat2, Linux 5.6+)
-- Falls back to userspace emulation on older kernels
-- Well-tested, security-focused
+The hardening protects everything **at or below the directory named on the command line**.
+It assumes the named root itself and the path components above it are not modifiable by a
+less-privileged actor. More precisely:
 
-**Disadvantages**:
+- For `rcp /backup/foo /dst`, the identity of `/backup/foo` at open time is trusted. Every
+  entry strictly below it is hardened.
+- The components between a fixed sudo prefix and the named operand (e.g., the `foo` part
+  of `/backup/foo` where `/backup` is the fixed prefix and `foo` is actor-supplied) are
+  resolved normally when opening the root. If those intermediate components are
+  actor-writable, that is the operator's responsibility to prevent — typically by using a
+  fixed source path in the sudo rule, not a wildcard.
 
-- Linux-only (no macOS/Windows support)
-- Requires significant refactoring of file operations
-- Older kernel fallback is less secure than kernel-native path
-- Adds external dependency
+The trust of these intermediate components — the prefix the tool follows to reach the named
+root — is the **caller's responsibility** and is not verified in-tool. See
+[Scope of TOCTOU safety](#scope-of-toctou-safety) for why this boundary is delegated to the
+caller, and [The Linter](#the-linter---toctou-check-and---require-toctou-safe) below for what
+`--require-toctou-safe` does enforce (the hardened walk, not the prefix).
 
-**Kernel requirements for full protection**:
+## What Is Not Hardened
 
-| Linux Version | Protection Level |
-|---------------|------------------|
-| < 5.6         | Userspace emulation only (limited protection) |
-| 5.6+          | openat2() with RESOLVE_* flags |
-| 6.8+          | Full protection including procfs safety |
+The following are **not TOCTOU-hardened** and are reported as "not safe" by
+`--toctou-check`:
 
-### Option 2: O_NOFOLLOW and openat()
+- **`--dereference` / `-L`**: Following symlinks is the requested behavior. A swapped link
+  is followed by design. Do not use `-L` in privileged sudo rules over attacker-writable
+  trees.
+- **Non-Linux builds**: The hardened path (`safedir.rs` with `O_NOFOLLOW` + fd-relative
+  ops) is Linux-only. macOS and other non-Linux platforms continue to use path-based
+  operations and are not hardened.
+- **`rcmp`** (read-only compare): `rcmp` cannot mis-permission or destroy files. A
+  concurrent swap could cause a wrong comparison result (treating an unintended file as
+  equal or unequal), but no data is written. This is accepted and `rcmp` is out of scope.
 
-A lighter-weight approach using standard POSIX APIs:
+## Residual Preconditions
 
-```rust
-use std::os::unix::fs::OpenOptionsExt;
+The fd-based mechanism is sound under two Linux kernel conditions that are enabled by
+default:
 
-OpenOptions::new()
-    .read(true)
-    .custom_flags(libc::O_NOFOLLOW)
-    .open(&path)?;
-```
+- **`fs.protected_hardlinks=1`** (Linux default): With this setting disabled, an actor
+  who can hardlink a sensitive file into the traversed tree defeats any userspace
+  hardening — the privileged process opens a real regular file via `O_NOFOLLOW`,
+  `fstat` confirms `S_ISREG`, and dev/ino checks pass, because the entry *is* that
+  inode. This enables unauthorized reads, privileged chmod/chown of the aliased inode,
+  and similar attacks (Scenario 4). No userspace scheme can defend against a missing
+  `protected_hardlinks` guard. Verify with: `sysctl fs.protected_hardlinks`
+- **`/proc` mounted**: Used by `rchm` for file chmod (via `/proc/self/fd/<n>`). Standard
+  on all Linux distributions.
+- **Actor cannot create bind mounts or manipulate mount namespaces**: Requires privilege;
+  an unprivileged actor cannot exploit this.
 
-**Advantages**:
+## The Linter: --toctou-check and --require-toctou-safe
 
-- No external dependencies
-- Works on all Unix systems
-- Simpler to implement
+Every RCP tool supports two security flags:
 
-**Disadvantages**:
+### `--toctou-check`
 
-- Only prevents following symlinks at the **final** component
-- Parent directories can still be swapped for symlinks
-- Must be combined with `openat()` for directory traversal safety
-
-### Option 3: Privilege Separation
-
-Instead of running the entire copy operation as root, separate into privileged and
-unprivileged components:
-
-```
-┌─────────────────────┐         ┌─────────────────────┐
-│  Privileged Helper  │────────▶│  Unprivileged rcp   │
-│  (opens files)      │   fd    │  (copies data)      │
-└─────────────────────┘         └─────────────────────┘
-```
-
-**Advantages**:
-
-- Reduces attack surface
-- Privileged code can be minimal and audited
-- File descriptors cannot be swapped (unlike paths)
-
-**Disadvantages**:
-
-- Complex architecture change
-- Performance overhead from IPC
-- Still needs careful implementation in the helper
-
-### Option 4: chroot/namespace Isolation
-
-Run copy operations inside a restricted namespace:
+Prints whether the invocation is TOCTOU-safe and exits without performing any operation.
+Exit code 0 = safe, 1 = not safe.
 
 ```bash
-# Using unshare to create mount namespace
-unshare --mount --propagation=private -- rcp /source /dest
+# safe invocation
+$ sudo rcp --toctou-check /backup/data /restore/
+TOCTOU status: SAFE
+  Note: Hardening assumes the directory named on the command line (and the path
+  components above it) are not modifiable by a less-privileged actor; it protects
+  everything at or below the named root. Also assumes fs.protected_hardlinks=1
+  (Linux default).
+
+# not safe: -L follows symlinks
+$ sudo rcp --toctou-check -L /backup/data /restore/
+TOCTOU status: NOT SAFE
+  Reason: --dereference/-L follows symlinks by request, so a swapped link is
+  followed — not hardened under privilege asymmetry
+  Note: Hardening assumes the directory named on the command line (and the path
+  components above it) are not modifiable by a less-privileged actor; it protects
+  everything at or below the named root. Also assumes fs.protected_hardlinks=1
+  (Linux default).
 ```
 
-**Advantages**:
+The "safe" verdict always includes a caveat reminding that the trusted-boundary
+assumption (path components above the named root are not actor-writable) cannot be
+statically verified from the invocation alone.
 
-- Kernel-enforced isolation
-- Works with existing rcp code
+### `--require-toctou-safe`
 
-**Disadvantages**:
+Refuses to run unless the invocation uses the TOCTOU-hardened walk — that is, it refuses
+`--dereference`/`-L` (which follows symlinks by request) and non-Linux builds. It is the
+tool's half of the safe-privileged-use contract (see
+[The contract for safe privileged (sudo) use](#the-contract-for-safe-privileged-sudo-use)).
 
-- Requires root/CAP_SYS_ADMIN to set up namespace
-- May not work in all environments (containers, etc.)
-- Doesn't solve the fundamental TOCTTOU issue, just limits scope
-
-## Recommendations
-
-### For Users Running rcp with Sudo
-
-1. **Minimize privilege scope**: Use specific sudo rules instead of blanket root access
-
-   ```bash
-   # Bad: allows copying anywhere
-   user ALL=(root) NOPASSWD: /usr/bin/rcp
-
-   # Better: restricts source and destination
-   user ALL=(root) NOPASSWD: /usr/bin/rcp /specific/source/* /specific/dest/
-   ```
-
-2. **Restrict paths to root-owned directories**: If the source directory is owned by root
-   and not writable by the attacker, they cannot perform symlink swaps
-
-3. **Use `--dereference` carefully**: This flag explicitly follows symlinks and increases
-   the attack surface
-
-4. **Consider alternatives for sensitive operations**:
-   - For backup: Use rsync with `--safe-links` or dedicated backup tools
-   - For system files: Use package managers or configuration management tools
-   - For containers: Use tools designed for container filesystems (with libpathrs)
-
-5. **Monitor for suspicious activity**: Rapid file modifications during copies may
-   indicate an attack attempt
-
-### For Developers
-
-If implementing TOCTTOU mitigations in rcp:
-
-1. **libpathrs is the recommended approach** for comprehensive protection on Linux
-2. Start with a `--safe-resolve` flag that enables libpathrs-based resolution
-3. Make it opt-in initially, with clear documentation about kernel requirements
-4. Consider Linux-only for this feature rather than attempting cross-platform support
-5. Add integration tests that verify TOCTTOU protection using rapid symlink swapping
-
-### Defense in Depth
-
-No single mitigation is perfect. Combine multiple approaches:
-
+```bash
+# Refused: -L is not safe
+$ sudo rcp --require-toctou-safe -L /backup/data /restore/
+Refusing to run: invocation is not TOCTOU-safe.
+  Reason: --dereference/-L follows symlinks by request ...
 ```
-Layer 1: Restrictive sudo rules (limit paths)
-       ↓
-Layer 2: libpathrs safe resolution (prevent symlink following)
-       ↓
-Layer 3: SELinux/AppArmor policies (restrict file access)
-       ↓
-Layer 4: Audit logging (detect attack attempts)
+
+It does **not** verify the trust of the operand path's prefix — the directories above the
+named root. That judgment requires policy context the tool does not have, so it is the
+caller's responsibility (see [Scope of TOCTOU safety](#scope-of-toctou-safety)): the `sudo`
+policy or a vetted wrapper must pass resolved operands whose prefix it trusts.
+`--require-toctou-safe` operates purely on the verdict (`--dereference`/non-Linux) and never
+inspects the operand paths, so it treats local and remote (`host:/path`) operands
+identically.
+
+### Recommended sudo rule pattern
+
+To enforce that `rcp` only runs in a TOCTOU-safe configuration under a `sudo` rule:
+
+```bash
+# rcp: only allow TOCTOU-safe invocations
+user ALL=(root) NOPASSWD: /usr/bin/rcp --require-toctou-safe *
+
+# rchm: same pattern
+user ALL=(root) NOPASSWD: /usr/bin/rchm --require-toctou-safe *
+
+# rrm: same pattern
+user ALL=(root) NOPASSWD: /usr/bin/rrm --require-toctou-safe *
 ```
+
+With this rule, any attempt to invoke with `--dereference`/`-L` or on a non-Linux build
+is rejected by the tool itself before any filesystem operation begins. The `*` wildcard
+means the user can supply any additional arguments, but because the sudo rule lists
+`--require-toctou-safe` as a literal token before the `*`, sudo only authorizes invocations
+where it appears first — so the user cannot omit it. (The tool itself accepts the flag in any
+position; it is the sudo prefix match, not the tool's argument parser, that pins it.) The flag
+enforces only the tool's half (the hardened walk); it does not verify that an arbitrary operand
+path is safe. Locking the paths down in the sudo rule IS the caller's prefix-trust decision (see
+[Scope of TOCTOU safety](#scope-of-toctou-safety)), so restrict source and destination paths
+wherever possible:
+
+```bash
+# Better: also lock down the paths
+user ALL=(root) NOPASSWD: /usr/bin/rcp --require-toctou-safe /specific/source/* /specific/dest/
+```
+
+## Summary
+
+| Aspect | Status |
+|--------|--------|
+| Symlink following (leaf) | Hardened (Linux): `O_NOFOLLOW` on every entry open |
+| Intermediate directory swaps | Hardened (Linux): every dir opened fd-relative from parent |
+| FIFO swap (DoS/side-effect) | Hardened (Linux): `O_NONBLOCK` + `fstat`+`S_ISREG` |
+| Metadata ops (chown/chmod/utimes) | Hardened (Linux): fd-based, no path re-resolution |
+| File data copy | Hardened (Linux): `copy_file_range` between held fds |
+| `--delete` pruning | Hardened (Linux): fd-relative enumeration and removal |
+| Remote copy (source side) | Hardened (Linux): two-pass dir-fd map |
+| Remote copy (destination side) | Hardened (Linux): directory tracker fd-map |
+| Remote `--delete` | Not supported (rejected before operation) |
+| `--dereference` / `-L` | **Not hardened** (follows symlinks by design) |
+| Non-Linux builds | **Not hardened** (path-based code, documented) |
+| `rcmp` | Out of scope (read-only; no mis-permissioning possible) |
+| _Which_ in-subtree file a swap makes us read | Out of scope — reads are not inode-pinned; a same-directory regular-file swap can change which file is read, but cannot escape the subtree or widen permissions (see [Scope of TOCTOU safety](#scope-of-toctou-safety)) |
+| Prefix trust (path above the named root) | Caller's responsibility — out of scope, not verified in-tool (see [Scope of TOCTOU safety](#scope-of-toctou-safety)) |
+| `fs.protected_hardlinks=0` | **Not defended** (userspace cannot close this gap) |
+
+TOCTTOU vulnerabilities in rcp are **real but require local access** and specific
+privilege configurations to exploit. On Linux, the default (non-`-L`) paths of all
+write-capable tools are now fully hardened. Use `--require-toctou-safe` in sudo rules to
+enforce safe invocations automatically.
 
 ## Further Reading
 
 - [LWN: The difficulty of safe path traversal](https://lwn.net/Articles/1050887/)
-- [libpathrs documentation](https://docs.rs/pathrs/latest/pathrs/)
 - [openat2(2) man page](https://man7.org/linux/man-pages/man2/openat2.2.html)
 - [CWE-367: TOCTTOU Race Condition](https://cwe.mitre.org/data/definitions/367.html)
 - [CVE-2019-16884](https://nvd.nist.gov/vuln/detail/CVE-2019-16884) - runc symlink attack
-
-## Summary
-
-| Aspect | Current State | With libpathrs |
-|--------|---------------|----------------|
-| Symlink following | Uses lstat, but path-based ops | fd-based, kernel-enforced |
-| Directory traversal | Path strings, TOCTTOU window | O_PATH handles, atomic |
-| Cross-platform | Linux, macOS, Windows | Linux only |
-| Kernel requirement | Any | 5.6+ recommended, 6.8+ ideal |
-| Implementation effort | - | Significant refactoring |
-
-TOCTTOU vulnerabilities in rcp are **real but require local access** and specific sudo
-configurations to exploit. For high-security environments where rcp runs with elevated
-privileges, consider the mitigations described above, particularly libpathrs for
-Linux-only deployments.

--- a/justfile
+++ b/justfile
@@ -5,7 +5,7 @@
 default:
     @just --list
 
-# Run all lints (fmt, clippy, error logging, anyhow error msg, rust version, remote test naming, package metadata)
+# Run all lints (fmt, clippy, error logging, anyhow error msg, rust version, remote test naming, package metadata, walk-driver usage, source-read fidelity)
 lint:
     @echo "🔍 Checking formatting..."
     cargo fmt --check
@@ -21,6 +21,10 @@ lint:
     ./scripts/check-remote-test-naming.sh
     @echo "🔍 Checking package metadata consistency..."
     ./scripts/check-package-metadata.sh
+    @echo "🔍 Checking walk-driver usage..."
+    ./scripts/check-walk-driver-usage.sh
+    @echo "🔍 Checking source-read fidelity..."
+    ./scripts/check-source-read-fidelity.sh
     @echo "✅ All lints passed!"
 
 # Format code

--- a/rchm/src/main.rs
+++ b/rchm/src/main.rs
@@ -82,6 +82,21 @@ struct Args {
     chunk_size: u64,
     #[command(flatten)]
     common: common::cli::CommonArgs,
+    // TOCTOU safety
+    /// Print TOCTOU-safety verdict for this invocation and exit (0 = safe, 1 = not safe)
+    ///
+    /// Analyzes whether the invocation is hardened against symlink/path-swap races
+    /// and exits without performing the chmod/chown operation.
+    #[arg(long, help_heading = "Security")]
+    toctou_check: bool,
+    /// Refuse to run unless the invocation uses the TOCTOU-hardened walk
+    ///
+    /// Refuses non-Linux builds (rchm has no --dereference). It does NOT verify the trust
+    /// of the operand path's prefix — that is the caller's responsibility (lock paths down
+    /// in the sudo rule). See "Scope of TOCTOU safety" in docs/tocttou.md. Intended for
+    /// sudo rules: `NOPASSWD: /usr/bin/rchm --require-toctou-safe *`.
+    #[arg(long, conflicts_with = "toctou_check", help_heading = "Security")]
+    require_toctou_safe: bool,
     /// Path(s) to modify
     #[arg()]
     paths: Vec<std::path::PathBuf>,
@@ -215,6 +230,14 @@ fn main() -> Result<()> {
              rchm against glibc."
         ));
     }
+
+    // TOCTOU linter: must run before the async runtime starts.
+    // rchm has no --dereference flag; dereference is always false. The linter
+    // does NOT inspect the operand paths — the trust of a path's prefix is the
+    // caller's responsibility (see the "Scope of TOCTOU safety" section of
+    // docs/tocttou.md).
+    common::toctou_check::enforce_or_exit(false, args.toctou_check, args.require_toctou_safe);
+
     let dry_run_warnings = args.dry_run.map(|_| {
         common::DryRunWarnings::new(
             args.common.progress_requested(),

--- a/rchm/tests/cli_parsing_tests.rs
+++ b/rchm/tests/cli_parsing_tests.rs
@@ -60,3 +60,65 @@ fn help_lists_operation_options() {
         .stdout(predicates::str::contains("--group"))
         .stdout(predicates::str::contains("--owner"));
 }
+
+// ============================================================================
+// TOCTOU Safety Flag Tests
+// ============================================================================
+
+/// Test that --toctou-check exits without performing the chmod operation
+#[test]
+fn toctou_check_exits_without_operating() {
+    // even without a valid path, --toctou-check should print verdict and exit
+    let output = rchm()
+        .args(["--toctou-check", "--mode", "g+r", "/nonexistent-path"])
+        .output()
+        .expect("failed to run rchm");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("TOCTOU"),
+        "expected TOCTOU verdict in stdout, got: {stdout}"
+    );
+    // prove it stopped at the linter and did NOT proceed into the chmod: a
+    // --toctou-check verdict prints to stdout and exits before operating, so there
+    // is no operation-side error (e.g. about the nonexistent path) on stderr.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.is_empty(),
+        "--toctou-check must not proceed into operation (stderr should be empty), got: {stderr}"
+    );
+}
+
+/// Test that --toctou-check reports safe on Linux (rchm has no --dereference)
+#[cfg(target_os = "linux")]
+#[test]
+fn toctou_check_reports_safe_on_linux() {
+    let output = rchm()
+        .args(["--toctou-check", "--mode", "g+r", "/tmp"])
+        .output()
+        .expect("failed to run rchm");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("SAFE") && !stdout.contains("NOT SAFE"),
+        "expected SAFE on Linux for rchm, got: {stdout}"
+    );
+    assert!(
+        output.status.success(),
+        "--toctou-check should exit 0 on Linux"
+    );
+}
+
+/// Test that --toctou-check and --require-toctou-safe conflict
+#[test]
+fn toctou_check_and_require_toctou_safe_conflict() {
+    rchm()
+        .args([
+            "--toctou-check",
+            "--require-toctou-safe",
+            "--mode",
+            "g+r",
+            "/tmp",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--require-toctou-safe"));
+}

--- a/rcp/Cargo.toml
+++ b/rcp/Cargo.toml
@@ -43,6 +43,7 @@ common = { workspace = true }
 enum-map = "2.7"
 futures = "0.3"
 hex = "0.4"
+libc = "0.2"
 rand = "0.10"
 regex = "1.12"
 remote = { workspace = true }

--- a/rcp/src/bin/rcp.rs
+++ b/rcp/src/bin/rcp.rs
@@ -245,6 +245,7 @@ struct Args {
         long,
         default_value = "100",
         value_name = "N",
+        value_parser = parse_nonzero_usize,
         help_heading = "Remote copy options"
     )]
     max_connections: usize,
@@ -329,6 +330,23 @@ struct Args {
     /// Used to verify version compatibility with rcpd
     #[arg(long, help_heading = "Remote copy options")]
     protocol_version: bool,
+
+    // TOCTOU safety
+    /// Print TOCTOU-safety verdict for this invocation and exit (0 = safe, 1 = not safe)
+    ///
+    /// Analyzes whether the invocation is hardened against symlink/path-swap races
+    /// and exits without performing the copy operation.
+    #[arg(long, help_heading = "Security")]
+    toctou_check: bool,
+
+    /// Refuse to run unless the invocation uses the TOCTOU-hardened walk
+    ///
+    /// Refuses `--dereference`/`-L` (follows symlinks by design) and non-Linux builds. It
+    /// does NOT verify the trust of the operand path's prefix — that is the caller's
+    /// responsibility (lock paths down in the sudo rule). See "Scope of TOCTOU safety" in
+    /// docs/tocttou.md. Intended for sudo rules: `NOPASSWD: /usr/bin/rcp --require-toctou-safe *`.
+    #[arg(long, conflicts_with = "toctou_check", help_heading = "Security")]
+    require_toctou_safe: bool,
 
     /// Path to rcpd binary on remote hosts
     ///
@@ -823,15 +841,10 @@ async fn async_main(args: Args) -> anyhow::Result<common::copy::Summary> {
         ));
     }
     let src_strings = &args.paths[0..args.paths.len() - 1];
-    for src in src_strings {
-        if src == "." || src.ends_with("/.") {
-            return Err(anyhow!(
-                "expanding source directory ({:?}) using dot operator ('.') is not supported, please use absolute \
-                path or '*' instead",
-                std::path::PathBuf::from(src)
-            ));
-        }
-    }
+    // `.`/`..` (and `dir/.`, `dir/..`) source operands are supported: `common::copy` decomposes them
+    // via `split_root_operand` (canonicalizing `.`/`..`), so `rcp . dst` copies the current
+    // directory just like `cp -r . dst` and like `rrm .`/`rchm .` already work. (`/` is rejected
+    // there.) Use a shell glob (`dir/*`) if you want to expand a directory's contents instead.
     if args.delete && src_strings.len() > 1 {
         return Err(anyhow!(
             "--delete requires a single source; mirroring multiple sources into one destination is not supported"
@@ -1115,6 +1128,18 @@ fn main() -> Result<(), anyhow::Error> {
     }
 
     let args = Args::parse();
+
+    // TOCTOU linter: must run before the async runtime starts. The verdict
+    // (dereference/Linux) applies to every operation, local or remote. The linter
+    // does NOT inspect the operand paths — the trust of a path's prefix is the
+    // caller's responsibility (see the "Scope of TOCTOU safety" section of
+    // docs/tocttou.md).
+    common::toctou_check::enforce_or_exit(
+        args.dereference,
+        args.toctou_check,
+        args.require_toctou_safe,
+    );
+
     let is_remote_operation = has_remote_paths(&args);
     let dry_run_warnings = args.dry_run.map(|_| {
         common::DryRunWarnings::new(

--- a/rcp/src/bin/rcpd.rs
+++ b/rcp/src/bin/rcpd.rs
@@ -156,6 +156,7 @@ struct Args {
         long,
         default_value = "100",
         value_name = "N",
+        value_parser = parse_nonzero_usize,
         help_heading = "Remote copy options"
     )]
     max_connections: usize,

--- a/rcp/src/destination.rs
+++ b/rcp/src/destination.rs
@@ -1,4 +1,8 @@
 use anyhow::Context;
+use common::safedir::Dir;
+use std::ffi::OsStr;
+use std::os::fd::AsFd;
+use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
 use tracing::{Instrument, instrument};
 
@@ -8,11 +12,81 @@ fn progress() -> &'static common::progress::Progress {
     common::get_progress()
 }
 
+/// Resolve the open `Dir` of `dst`'s parent for a fd-relative destination write.
+///
+/// The destination tracks every created directory's `Dir` in the fd-map, top-down
+/// (a parent's `DirectoryCreated` precedes any message for its children), so for a
+/// non-root entry the parent is always already tracked. For the root entry — whose
+/// parent is the trusted user-specified destination parent and is itself never a
+/// tracked directory — the parent is opened once via `open_parent_dir` and cached in
+/// the tracker as `root_parent_dir` (so a root *directory* and its later empty-dir
+/// cleanup share the same pinned parent fd).
+///
+/// Returns the parent `Dir` plus the entry's final-component name (validated to be a
+/// single component by the fd-relative `Dir` methods). Fails closed if a non-root
+/// parent is not tracked (it should always be) — never falls back to a path-based
+/// open that a concurrent symlink swap could redirect.
+async fn resolve_parent_dir(
+    directory_tracker: &directory_tracker::SharedDirectoryTracker,
+    dst: &std::path::Path,
+    is_root: bool,
+) -> anyhow::Result<(Arc<Dir>, std::ffi::OsString)> {
+    let parent_path = dst
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("destination {:?} has no parent directory", dst))?;
+    let name = dst
+        .file_name()
+        .ok_or_else(|| anyhow::anyhow!("destination {:?} has no file name", dst))?
+        .to_owned();
+    if is_root {
+        // the root's parent is the trusted user-specified destination parent. Open it
+        // once and cache it; reuse on a subsequent call (root dir create + cleanup).
+        {
+            let tracker = directory_tracker.lock().await;
+            if let Some(parent) = tracker.root_parent_dir() {
+                return Ok((parent, name));
+            }
+        }
+        // the root's parent is the TRUSTED user-specified destination parent prefix; resolve it
+        // following symlinks normally (a symlinked destination container must be followed into the
+        // real dir). Only entries strictly below the named root are O_NOFOLLOW-hardened.
+        let parent = Dir::open_parent_dir(parent_path, common::Side::Destination)
+            .await
+            .with_context(|| {
+                format!("failed opening destination root parent directory {parent_path:?}")
+            })?;
+        // cross from the trusted parent prefix into the hardened tree (O_NOFOLLOW below here).
+        let parent = Arc::new(parent.into_tree());
+        directory_tracker
+            .lock()
+            .await
+            .set_root_parent_dir(parent.clone());
+        Ok((parent, name))
+    } else {
+        // non-root: the parent must already be tracked (top-down creation guarantees
+        // it). Fail closed if it is missing rather than re-resolving the path.
+        let parent = {
+            let tracker = directory_tracker.lock().await;
+            tracker.get_dir(parent_path)
+        };
+        let parent = parent.ok_or_else(|| {
+            anyhow::anyhow!(
+                "parent directory {:?} of {:?} is not tracked (fd-map miss)",
+                parent_path,
+                dst
+            )
+        })?;
+        Ok((parent, name))
+    }
+}
+
 /// Pool of outbound TCP connections to source's data port.
 ///
 /// Destination opens connections to source's data port to receive file data.
-/// Each connection receives one file then is closed (no reuse since there's
-/// no framing for multiple files on same connection).
+/// A connection carries MULTIPLE files: each file is length-prefixed by its
+/// `File` header (the `size` field delimits its bytes), and a worker keeps
+/// reading files from the connection until the source closes the stream (EOF).
+/// See `handle_file_stream` and the source-side reuse note in `rcp::source`.
 struct DataConnectionPool {
     data_addr: std::net::SocketAddr,
     network_profile: remote::NetworkProfile,
@@ -88,6 +162,19 @@ enum StreamState {
     Corrupted,
 }
 
+/// Drain `size` bytes of a file's data off the stream into a sink, without writing it.
+///
+/// Used when a file is skipped (already exists, identical, dest-newer) so the next file's header
+/// lands at a clean stream boundary. A failure here means the stream position is now unknown.
+async fn drain_file_data(
+    stream: &mut remote::streams::BoxedRecvStream,
+    size: u64,
+) -> anyhow::Result<()> {
+    let mut sink = tokio::io::sink();
+    stream.copy_exact_to_buffered(&mut sink, size, 8192).await?;
+    Ok(())
+}
+
 /// Error from processing a single file, with stream recovery information.
 struct ProcessFileError {
     /// The underlying error.
@@ -103,12 +190,14 @@ struct ProcessFileError {
 /// - `NeedsDrain`: no data was read yet, drain `file_header.size` bytes to recover
 /// - `DataConsumed`: all data consumed, stream at clean boundary, can continue
 /// - `Corrupted`: mid-read error, stream position unknown, must close
-#[instrument(skip(file_recv_stream))]
+#[instrument(skip(file_recv_stream, dst_parent))]
 async fn process_single_file(
     settings: &common::copy::Settings,
     preserve: &common::preserve::Settings,
     file_recv_stream: &mut remote::streams::BoxedRecvStream,
     file_header: &remote::protocol::File,
+    dst_parent: &Arc<Dir>,
+    dst_name: &OsStr,
 ) -> Result<(), ProcessFileError> {
     let prog = progress();
     // errors before we start reading data - stream can be recovered by draining
@@ -126,102 +215,63 @@ async fn process_single_file(
         source: e,
         stream_state: StreamState::DataConsumed,
     };
-    // check if destination exists and handle overwrite logic
-    let dst_exists = common::walk::run_metadata_probed(
-        common::Side::Destination,
-        common::MetadataOp::Stat,
-        tokio::fs::symlink_metadata(&file_header.dst),
-    )
-    .await
-    .is_ok();
-    if dst_exists {
+    // classify any existing destination entry through the parent's pinned fd (O_NOFOLLOW),
+    // never re-resolving file_header.dst by path. handle overwrite/--ignore-existing.
+    if let Ok(dst_handle) = dst_parent.child(dst_name).await {
         if settings.ignore_existing {
             tracing::debug!("destination exists, skipping (--ignore-existing)");
             prog.files_unchanged.inc();
-            let mut sink = tokio::io::sink();
-            file_recv_stream
-                .copy_exact_to_buffered(&mut sink, file_header.size, 8192)
+            drain_file_data(file_recv_stream, file_header.size)
                 .await
                 .map_err(err_corrupted)?;
             return Ok(());
         }
-        if settings.overwrite {
-            tracing::debug!("file exists, check if it's identical");
-            let dst_metadata = common::walk::run_metadata_probed(
-                common::Side::Destination,
-                common::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(&file_header.dst),
-            )
-            .await
-            .map_err(|e| err_needs_drain(e.into()))?;
-            let is_file = dst_metadata.is_file();
-            if is_file {
-                let src_file_metadata = remote::protocol::FileMetadata {
-                    metadata: &file_header.metadata,
-                    size: file_header.size,
-                };
-                let same_metadata = common::filecmp::metadata_equal(
-                    &settings.overwrite_compare,
-                    &src_file_metadata,
-                    &dst_metadata,
-                );
-                if same_metadata {
-                    tracing::debug!("file is identical, skipping");
-                    prog.files_unchanged.inc();
-                    // drain this file's data without writing - if this fails, stream is corrupted
-                    let mut sink = tokio::io::sink();
-                    file_recv_stream
-                        .copy_exact_to_buffered(&mut sink, file_header.size, 8192)
-                        .await
-                        .map_err(err_corrupted)?;
-                    return Ok(());
-                }
-                if let Some(common::copy::OverwriteFilter::Newer) = settings.overwrite_filter
-                    && common::filecmp::dest_is_newer(&src_file_metadata, &dst_metadata)
-                {
-                    tracing::debug!("dest is newer than source, skipping");
-                    prog.files_unchanged.inc();
-                    let mut sink = tokio::io::sink();
-                    file_recv_stream
-                        .copy_exact_to_buffered(&mut sink, file_header.size, 8192)
-                        .await
-                        .map_err(err_corrupted)?;
-                    return Ok(());
-                }
-                tracing::debug!("file exists but is different, removing");
-                let removed_file_size = dst_metadata.len();
-                common::walk::run_metadata_probed(
-                    common::Side::Destination,
-                    common::MetadataOp::Unlink,
-                    tokio::fs::remove_file(&file_header.dst),
-                )
-                .await
-                .map_err(|e| err_needs_drain(e.into()))?;
-                prog.files_removed.inc();
-                prog.bytes_removed.add(removed_file_size);
-            } else {
-                tracing::info!("destination is not a file, removing");
-                common::rm::rm(
-                    common::get_progress(),
-                    &file_header.dst,
-                    &common::rm::Settings {
-                        fail_early: settings.fail_early,
-                        filter: None,
-                        dry_run: None,
-                        time_filter: None,
-                    },
-                )
-                .await
-                .map_err(|err| {
-                    err_needs_drain(anyhow::anyhow!("Failed to remove destination: {err}"))
-                })?;
-            }
-        } else {
+        if !settings.overwrite {
             return Err(err_needs_drain(anyhow::anyhow!(
                 "destination {:?} already exists, did you intend to specify --overwrite?",
                 file_header.dst
             )));
         }
+        tracing::debug!("file exists, check if it's identical");
+        if dst_handle.kind() == common::walk::EntryKind::File {
+            let src_file_metadata = remote::protocol::FileMetadata {
+                metadata: &file_header.metadata,
+                size: file_header.size,
+            };
+            if common::filecmp::metadata_equal(
+                &settings.overwrite_compare,
+                &src_file_metadata,
+                dst_handle.meta(),
+            ) {
+                tracing::debug!("file is identical, skipping");
+                prog.files_unchanged.inc();
+                drain_file_data(file_recv_stream, file_header.size)
+                    .await
+                    .map_err(err_corrupted)?;
+                return Ok(());
+            }
+            if let Some(common::copy::OverwriteFilter::Newer) = settings.overwrite_filter
+                && common::filecmp::dest_is_newer(&src_file_metadata, dst_handle.meta())
+            {
+                tracing::debug!("dest is newer than source, skipping");
+                prog.files_unchanged.inc();
+                drain_file_data(file_recv_stream, file_header.size)
+                    .await
+                    .map_err(err_corrupted)?;
+                return Ok(());
+            }
+        }
+        tracing::debug!("destination differs, removing existing entry");
+        // recheck-guarded, fd-relative removal contained to dst_parent (mirrors copy.rs:1.3).
+        remove_existing_dst(
+            dst_parent,
+            dst_name,
+            &file_header.dst,
+            &dst_handle,
+            settings,
+        )
+        .await
+        .map_err(err_needs_drain)?;
     }
     throttle::get_file_iops_tokens(settings.chunk_size, file_header.size)
         .instrument(tracing::trace_span!(
@@ -229,13 +279,18 @@ async fn process_single_file(
             size = file_header.size
         ))
         .await;
-    let mut file = common::walk::run_metadata_probed(
-        common::Side::Destination,
-        common::MetadataOp::OpenCreate,
-        tokio::fs::File::create(&file_header.dst).instrument(tracing::trace_span!("file_create")),
-    )
-    .await
-    .map_err(|e| err_needs_drain(e.into()))?;
+    // create the destination file fresh through the parent's pinned fd (O_CREAT|O_EXCL|
+    // O_NOFOLLOW): never follows a symlink, never escapes dst_parent. the creation mode
+    // matches the metadata applier's chmod target, mirroring copy.rs.
+    let create_mode = common::preserve::masked_file_mode(&preserve.file, &file_header.metadata);
+    let std_file = dst_parent
+        .create_file(dst_name, create_mode)
+        .await
+        .with_context(|| format!("failed creating {:?}", file_header.dst))
+        .map_err(err_needs_drain)?;
+    // wrap the std file for async writes; the underlying fd is retained so its metadata
+    // can be applied through the held fd (no path re-open).
+    let mut file = tokio::fs::File::from_std(std_file);
     // buffer size is set by tcp_config.effective_remote_copy_buffer_size() based on network profile,
     // but capped at file size to avoid over-allocation for small files
     let file_size = file_header.size.min(usize::MAX as u64) as usize;
@@ -257,26 +312,124 @@ async fn process_single_file(
             copied
         )));
     }
-    // flush before drop to ensure all data reaches the kernel before we set metadata.
+    // flush before metadata to ensure all data reaches the kernel before we set mtime.
     // tokio::fs::File hands writes to a threadpool - without flush, the threadpool
     // may complete after we set mtime, causing the file to appear modified.
     file.flush()
         .await
         .map_err(|e| err_data_consumed(e.into()))?;
-    drop(file);
     tracing::info!(
         "File {} -> {} created, size: {} bytes, setting metadata...",
         file_header.src.display(),
         file_header.dst.display(),
         file_header.size
     );
-    // metadata errors happen after all bytes consumed - stream is at clean boundary
-    common::preserve::set_file_metadata(preserve, &file_header.metadata, &file_header.dst)
-        .await
-        .map_err(err_data_consumed)?;
+    // metadata errors happen after all bytes consumed - stream is at clean boundary.
+    // apply through the file's OWN fd (fd-relative): no path re-resolution of dst.
+    common::safedir::set_file_metadata_fd(
+        preserve,
+        &file_header.metadata,
+        file.as_fd(),
+        common::Side::Destination,
+    )
+    .await
+    .with_context(|| format!("failed setting metadata on {:?}", file_header.dst))
+    .map_err(err_data_consumed)?;
+    drop(file);
     prog.files_copied.inc();
     prog.bytes_copied.add(file_header.size);
     Ok(())
+}
+
+/// Remove an existing destination entry (file / symlink / directory) so a fresh entry can take
+/// its place, fd-relative and recheck-guarded — the destination counterpart of
+/// [`common::copy::remove_existing`].
+///
+/// The entry was already classified into `dst_handle` (via `dst_parent.child(name)`). Removal is:
+/// 1. [`Dir::recheck`] re-opens `name` and confirms it is STILL the same inode (`dev`/`ino`). If a
+///    concurrent symlink swap changed the entry's identity, `recheck` returns `ESTALE` and we fail
+///    closed, removing nothing.
+/// 2. The entry is removed through the held `dst_parent` fd by kind: file/symlink/special via
+///    `unlink_at` (never follows a symlink), empty directory via `rmdir_at`, and a non-empty
+///    directory subtree via [`common::rm::rm_child`] (fd-relative recursive removal on the held
+///    parent). All removal is contained to `dst_parent` — it cannot escape the destination tree.
+async fn remove_existing_dst(
+    dst_parent: &Arc<Dir>,
+    dst_name: &OsStr,
+    dst_path: &std::path::Path,
+    dst_handle: &common::safedir::Handle,
+    settings: &common::copy::Settings,
+) -> anyhow::Result<()> {
+    let prog = progress();
+    // recheck: confirm the entry is still the same inode we classified; fail closed on a swap.
+    dst_parent
+        .recheck(dst_name, dst_handle)
+        .await
+        .with_context(|| {
+            format!(
+                "destination {dst_path:?} changed identity before removal (possible TOCTOU swap)"
+            )
+        })?;
+    match dst_handle.kind() {
+        common::walk::EntryKind::File
+        | common::walk::EntryKind::Symlink
+        | common::walk::EntryKind::Special => {
+            let removed_size = {
+                use common::preserve::Metadata as _;
+                dst_handle.meta().size()
+            };
+            dst_parent
+                .unlink_at(dst_name)
+                .await
+                .with_context(|| format!("failed removing existing destination {dst_path:?}"))?;
+            let is_symlink = dst_handle.kind() == common::walk::EntryKind::Symlink;
+            if is_symlink {
+                prog.symlinks_removed.inc();
+            } else {
+                prog.files_removed.inc();
+                prog.bytes_removed.add(removed_size);
+            }
+            Ok(())
+        }
+        common::walk::EntryKind::Dir => {
+            // fast path: an empty directory removes cleanly via rmdir_at.
+            match dst_parent.rmdir_at(dst_name).await {
+                Ok(()) => {
+                    prog.directories_removed.inc();
+                    Ok(())
+                }
+                // POSIX permits either ENOTEMPTY or EEXIST for a non-empty directory.
+                Err(error)
+                    if matches!(
+                        error.raw_os_error(),
+                        Some(libc::ENOTEMPTY) | Some(libc::EEXIST)
+                    ) =>
+                {
+                    // fd-relative recursive removal of the subtree on the held parent.
+                    common::rm::rm_child(
+                        common::get_progress(),
+                        dst_parent,
+                        dst_name,
+                        dst_path,
+                        &common::rm::Settings {
+                            fail_early: settings.fail_early,
+                            filter: None,
+                            dry_run: None,
+                            time_filter: None,
+                        },
+                    )
+                    .await
+                    .map(|_summary| ())
+                    .map_err(|err| {
+                        err.source
+                            .context(format!("failed removing existing directory {dst_path:?}"))
+                    })
+                }
+                Err(error) => Err(anyhow::Error::new(error)
+                    .context(format!("failed removing existing directory {dst_path:?}"))),
+            }
+        }
+    }
 }
 
 /// Handle a stream that may contain multiple files.
@@ -317,9 +470,30 @@ async fn handle_file_stream(
             .await;
         throttle::get_ops_token().await;
         let _ops_guard = prog.ops.guard();
-        // process this file
+        // resolve the destination parent directory's held fd from the tracker (for the
+        // root file, open the trusted parent via open_parent_dir). all writes for this
+        // file are then fd-relative on that pinned parent. a resolution failure is a
+        // pre-data error: the stream can be recovered by draining this file's bytes.
         let file_result =
-            process_single_file(&settings, &preserve, &mut file_recv_stream, &file_header).await;
+            match resolve_parent_dir(&directory_tracker, &file_header.dst, file_header.is_root)
+                .await
+            {
+                Ok((dst_parent, dst_name)) => {
+                    process_single_file(
+                        &settings,
+                        &preserve,
+                        &mut file_recv_stream,
+                        &file_header,
+                        &dst_parent,
+                        &dst_name,
+                    )
+                    .await
+                }
+                Err(e) => Err(ProcessFileError {
+                    source: e.context("failed resolving destination parent directory"),
+                    stream_state: StreamState::NeedsDrain,
+                }),
+            };
         // track whether we need to close the stream and exit early
         let mut stream_corrupted = false;
         let mut fail_early_error: Option<anyhow::Error> = None;
@@ -332,10 +506,8 @@ async fn handle_file_stream(
             match e.stream_state {
                 StreamState::NeedsDrain => {
                     // no data was read yet, drain the file's data to stay in sync
-                    let mut sink = tokio::io::sink();
-                    if let Err(drain_err) = file_recv_stream
-                        .copy_exact_to_buffered(&mut sink, file_header.size, 8192)
-                        .await
+                    if let Err(drain_err) =
+                        drain_file_data(&mut file_recv_stream, file_header.size).await
                     {
                         tracing::error!("Failed to drain file data: {:#}", drain_err);
                         // drain failed, stream is now corrupted
@@ -444,7 +616,7 @@ async fn process_incoming_file_streams_tcp(
                         break;
                     }
                 };
-                // handle one file on this connection
+                // receive files from this connection until the source closes it (EOF)
                 if let Err(e) = handle_file_stream(
                     (*settings).clone(),
                     *preserve,
@@ -488,52 +660,64 @@ async fn process_incoming_file_streams_tcp(
 }
 
 /// Result of directory creation attempt.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// The `Created`/`AlreadyExisted` variants carry the open `Dir` fd for the resolved
+/// directory so the caller can store it in the tracker's fd-map (children's writes
+/// then resolve relative to it).
 enum DirectoryCreateResult {
-    /// directory was created by us (new)
-    Created,
-    /// directory already existed (reused)
-    AlreadyExisted,
+    /// directory was created by us (new), with its open fd
+    Created(Arc<Dir>),
+    /// directory already existed (reused), with its open fd
+    AlreadyExisted(Arc<Dir>),
     /// skipped due to --ignore-existing (destination is not a directory)
     Skipped,
     /// failed to create directory
     Failed,
 }
 
-/// Create a directory, handling overwrite logic.
-/// Returns the result indicating whether directory was created, reused, or failed.
-/// Note: does NOT increment progress counters - caller is responsible for that
-/// (so we can defer the increment until we know whether to keep the directory).
+/// Create a directory fd-relative on the PARENT's held `Dir`, handling overwrite logic.
+///
+/// All operations resolve relative to `dst_parent`'s pinned fd: classify an existing entry via
+/// `dst_parent.child(dst_name)`; create via `dst_parent.make_dir(dst_name, mode)` (`mkdirat`);
+/// reuse an existing directory via `dst_parent.open_dir(dst_name)` (`O_NOFOLLOW|O_DIRECTORY` — a
+/// directory→symlink swap fails closed with ELOOP/ENOTDIR); replace a non-directory via the
+/// recheck-guarded [`remove_existing_dst`] then `make_dir`. A privileged destination therefore
+/// cannot be redirected by a concurrent symlink swap of the parent into creating a directory
+/// outside the destination tree. The new directory is created mode `0o700` (writable so children
+/// can be populated); its real source mode is applied later by `complete_directory_single`,
+/// mirroring the path-based / local-copy behavior.
+///
+/// Returns the result; does NOT increment progress counters — the caller defers the increment
+/// until completion (when it knows whether the directory is kept).
 async fn create_directory(
     settings: &common::copy::Settings,
+    dst_parent: &Arc<Dir>,
+    dst_name: &OsStr,
     dst: &std::path::Path,
 ) -> anyhow::Result<DirectoryCreateResult> {
     let prog = progress();
-    match common::walk::run_metadata_probed(
-        common::Side::Destination,
-        common::MetadataOp::MkDir,
-        tokio::fs::create_dir(dst),
-    )
-    .await
-    {
-        Ok(()) => {
+    match dst_parent.make_dir(dst_name, 0o700).await {
+        Ok(dir) => {
             // don't increment counter here - will be done in complete_directory
             // when we know we're keeping this directory
-            Ok(DirectoryCreateResult::Created)
+            Ok(DirectoryCreateResult::Created(Arc::new(dir)))
         }
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            // something exists at destination - check what it is
-            let dst_metadata = common::walk::run_metadata_probed(
-                common::Side::Destination,
-                common::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(dst),
-            )
-            .await?;
-            if dst_metadata.is_dir() {
-                // directory already exists - reuse it (no overwrite needed for directories)
+            // something exists at destination - classify it via the parent fd (O_NOFOLLOW).
+            let dst_handle = dst_parent
+                .child(dst_name)
+                .await
+                .with_context(|| format!("failed reading metadata from dst: {dst:?}"))?;
+            if dst_handle.kind() == common::walk::EntryKind::Dir {
+                // directory already exists - reuse it (no overwrite needed for directories).
+                // open_dir is O_NOFOLLOW|O_DIRECTORY, so a swap to a symlink fails closed here.
                 tracing::debug!("destination directory already exists, reusing it");
+                let dir = dst_parent
+                    .open_dir(dst_name)
+                    .await
+                    .with_context(|| format!("cannot open existing directory {dst:?}"))?;
                 prog.directories_unchanged.inc();
-                Ok(DirectoryCreateResult::AlreadyExisted)
+                Ok(DirectoryCreateResult::AlreadyExisted(Arc::new(dir)))
             } else if settings.ignore_existing {
                 // not a directory but ignore_existing is set - skip the subtree
                 tracing::debug!(
@@ -542,27 +726,16 @@ async fn create_directory(
                 prog.directories_unchanged.inc();
                 Ok(DirectoryCreateResult::Skipped)
             } else if settings.overwrite {
-                // not a directory but overwrite is enabled - remove and create
+                // not a directory but overwrite is enabled - remove (recheck-guarded, fd-relative)
+                // and create.
                 tracing::info!("destination is not a directory, removing and creating a new one");
-                common::rm::rm(
-                    common::get_progress(),
-                    dst,
-                    &common::rm::Settings {
-                        fail_early: settings.fail_early,
-                        filter: None,
-                        dry_run: None,
-                        time_filter: None,
-                    },
-                )
-                .await?;
-                common::walk::run_metadata_probed(
-                    common::Side::Destination,
-                    common::MetadataOp::MkDir,
-                    tokio::fs::create_dir(dst),
-                )
-                .await?;
+                remove_existing_dst(dst_parent, dst_name, dst, &dst_handle, settings).await?;
+                let dir = dst_parent
+                    .make_dir(dst_name, 0o700)
+                    .await
+                    .with_context(|| format!("cannot create directory {dst:?}"))?;
                 // don't increment counter here - will be done in complete_directory
-                Ok(DirectoryCreateResult::Created)
+                Ok(DirectoryCreateResult::Created(Arc::new(dir)))
             } else {
                 // not a directory and overwrite disabled
                 tracing::error!(
@@ -572,124 +745,120 @@ async fn create_directory(
             }
         }
         Err(error) => {
-            tracing::error!("Failed to create directory {dst:?}: {error}");
-            Err(error.into())
+            tracing::error!("Failed to create directory {dst:?}: {error:#}");
+            Err(anyhow::Error::new(error).context(format!("cannot create directory {dst:?}")))
         }
     }
 }
 
-/// Create a symlink, handling overwrite logic.
+/// Create a symlink fd-relative on the PARENT's held `Dir`, handling overwrite logic, and apply
+/// its metadata through the created link's own pinned handle.
+///
+/// Creation goes through `dst_parent.symlink_at(dst_name, target)` (`symlinkat` relative to the
+/// pinned parent fd), which fails with `EEXIST` on any pre-existing entry (never following it);
+/// the returned handle pins the link inode for race-free metadata application. Overwrite removal
+/// is recheck-guarded and fd-relative via [`remove_existing_dst`]. A privileged destination
+/// therefore cannot be redirected by a concurrent symlink swap of the parent into creating a link
+/// outside the destination tree.
 async fn create_symlink(
     settings: &common::copy::Settings,
     preserve: &common::preserve::Settings,
+    dst_parent: &Arc<Dir>,
+    dst_name: &OsStr,
     dst: &std::path::Path,
     target: &std::path::Path,
     metadata: &remote::protocol::Metadata,
 ) -> anyhow::Result<()> {
     let prog = progress();
-    match common::walk::run_metadata_probed(
-        common::Side::Destination,
-        common::MetadataOp::Symlink,
-        tokio::fs::symlink(target, dst),
-    )
-    .await
-    {
-        Ok(()) => {
-            common::preserve::set_symlink_metadata(preserve, metadata, dst).await?;
+    // fast path: the destination slot is empty, create the link directly.
+    match dst_parent.symlink_at(dst_name, target).await {
+        Ok(link_handle) => {
+            common::safedir::set_symlink_metadata_fd(
+                preserve,
+                metadata,
+                &link_handle,
+                common::Side::Destination,
+            )
+            .await
+            .with_context(|| format!("failed setting symlink metadata on {dst:?}"))?;
             prog.symlinks_created.inc();
             Ok(())
         }
-        Err(error)
-            if settings.ignore_existing && error.kind() == std::io::ErrorKind::AlreadyExists =>
-        {
-            tracing::debug!("destination exists, skipping symlink (--ignore-existing)");
-            prog.symlinks_unchanged.inc();
-            Ok(())
-        }
-        Err(error) if settings.overwrite && error.kind() == std::io::ErrorKind::AlreadyExists => {
-            let dst_metadata = common::walk::run_metadata_probed(
-                common::Side::Destination,
-                common::MetadataOp::Stat,
-                tokio::fs::symlink_metadata(dst),
-            )
-            .await
-            .with_context(|| format!("failed reading metadata from dst: {dst:?}"))?;
-            if dst_metadata.is_symlink() {
-                let dst_link = common::walk::run_metadata_probed(
-                    common::Side::Destination,
-                    common::MetadataOp::ReadLink,
-                    tokio::fs::read_link(dst),
-                )
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            if settings.ignore_existing {
+                tracing::debug!("destination exists, skipping symlink (--ignore-existing)");
+                prog.symlinks_unchanged.inc();
+                return Ok(());
+            }
+            if !settings.overwrite {
+                return Err(
+                    anyhow::Error::new(error).context(format!("failed creating symlink {dst:?}"))
+                );
+            }
+            // classify the existing entry through the parent fd (O_NOFOLLOW).
+            let dst_handle = dst_parent
+                .child(dst_name)
                 .await
-                .with_context(|| format!("failed reading dst symlink: {dst:?}"))?;
+                .with_context(|| format!("failed reading metadata from dst: {dst:?}"))?;
+            if dst_handle.kind() == common::walk::EntryKind::Symlink {
+                let dst_link = dst_parent
+                    .read_link_at(dst_name)
+                    .await
+                    .with_context(|| format!("failed reading dst symlink: {dst:?}"))?;
                 if *target == dst_link {
                     tracing::debug!(
                         "destination is a symlink and points to the same location as source"
                     );
-                    if preserve.symlink.any() {
-                        if common::filecmp::metadata_equal(
+                    if preserve.symlink.any()
+                        && !common::filecmp::metadata_equal(
                             &settings.overwrite_compare,
                             metadata,
-                            &dst_metadata,
-                        ) {
-                            tracing::debug!("destination symlink is identical, skipping");
-                            prog.symlinks_unchanged.inc();
-                        } else {
-                            tracing::debug!("destination metadata is different, updating");
-                            common::preserve::set_symlink_metadata(preserve, metadata, dst).await?;
-                            prog.symlinks_removed.inc();
-                            prog.symlinks_created.inc();
-                        }
-                    } else {
-                        tracing::debug!("destination symlink is identical, skipping");
-                        prog.symlinks_unchanged.inc();
+                            dst_handle.meta(),
+                        )
+                    {
+                        tracing::debug!("destination metadata is different, updating");
+                        common::safedir::set_symlink_metadata_fd(
+                            preserve,
+                            metadata,
+                            &dst_handle,
+                            common::Side::Destination,
+                        )
+                        .await
+                        .with_context(|| format!("failed setting symlink metadata on {dst:?}"))?;
+                        prog.symlinks_removed.inc();
+                        prog.symlinks_created.inc();
+                        return Ok(());
                     }
-                } else {
-                    tracing::info!(
-                        "destination is a symlink but points to a different location, removing"
-                    );
-                    common::walk::run_metadata_probed(
-                        common::Side::Destination,
-                        common::MetadataOp::Unlink,
-                        tokio::fs::remove_file(dst),
-                    )
-                    .await?;
-                    common::walk::run_metadata_probed(
-                        common::Side::Destination,
-                        common::MetadataOp::Symlink,
-                        tokio::fs::symlink(target, dst),
-                    )
-                    .await?;
-                    common::preserve::set_symlink_metadata(preserve, metadata, dst).await?;
-                    prog.symlinks_removed.inc();
-                    prog.symlinks_created.inc();
+                    tracing::debug!("destination symlink is identical, skipping");
+                    prog.symlinks_unchanged.inc();
+                    return Ok(());
                 }
+                tracing::info!(
+                    "destination is a symlink but points to a different location, removing"
+                );
             } else {
                 tracing::info!("destination is not a symlink, removing");
-                common::rm::rm(
-                    common::get_progress(),
-                    dst,
-                    &common::rm::Settings {
-                        fail_early: settings.fail_early,
-                        filter: None,
-                        dry_run: None,
-                        time_filter: None,
-                    },
-                )
-                .await
-                .map_err(|err| anyhow::anyhow!("Failed to remove destination: {err}"))?;
-                common::walk::run_metadata_probed(
-                    common::Side::Destination,
-                    common::MetadataOp::Symlink,
-                    tokio::fs::symlink(target, dst),
-                )
-                .await?;
-                common::preserve::set_symlink_metadata(preserve, metadata, dst).await?;
-                prog.symlinks_created.inc();
             }
+            // remove the conflicting entry (recheck-guarded, fd-relative) then create the link.
+            remove_existing_dst(dst_parent, dst_name, dst, &dst_handle, settings).await?;
+            let link_handle = dst_parent
+                .symlink_at(dst_name, target)
+                .await
+                .with_context(|| format!("failed creating symlink {dst:?}"))?;
+            common::safedir::set_symlink_metadata_fd(
+                preserve,
+                metadata,
+                &link_handle,
+                common::Side::Destination,
+            )
+            .await
+            .with_context(|| format!("failed setting symlink metadata on {dst:?}"))?;
+            prog.symlinks_created.inc();
             Ok(())
         }
-        Err(error) => Err(error.into()),
+        Err(error) => {
+            Err(anyhow::Error::new(error).context(format!("failed creating symlink {dst:?}")))
+        }
     }
 }
 
@@ -716,7 +885,6 @@ async fn process_control_stream(
                 ref metadata,
                 is_root,
                 entry_count,
-                file_count,
                 keep_if_empty,
             } => {
                 let _ops_guard = prog.ops.guard();
@@ -727,6 +895,15 @@ async fn process_control_stream(
                 };
                 if has_failed_ancestor {
                     tracing::warn!("Skipping directory {:?} - ancestor failed to create", dst);
+                    // nack so the source releases this directory's held fd (it was
+                    // never created, so no files will be requested for it).
+                    {
+                        let tracker = directory_tracker.lock().await;
+                        tracker
+                            .send_directory_skipped(src, dst)
+                            .await
+                            .context("Failed to send DirectorySkipped for skipped directory")?;
+                    }
                     // still count as a processed child entry for the parent
                     if !is_root && let Some(parent) = dst.parent() {
                         directory_tracker
@@ -738,35 +915,49 @@ async fn process_control_stream(
                     }
                     continue;
                 }
+                // resolve the destination parent directory's held fd (for the root, open
+                // the trusted parent via open_parent_dir). all creation is then fd-relative
+                // on that pinned parent.
+                let create_result = match resolve_parent_dir(&directory_tracker, dst, is_root).await
+                {
+                    Ok((dst_parent, dst_name)) => {
+                        create_directory(settings, &dst_parent, &dst_name, dst).await
+                    }
+                    Err(e) => Err(e.context("failed resolving destination parent directory")),
+                };
                 // try to create directory
-                let (create_result, error_already_pushed) =
-                    match create_directory(settings, dst).await {
-                        Ok(result) => (result, false),
-                        Err(e) => {
-                            tracing::error!("Failed to create directory {:?}: {:#}", dst, e);
-                            if settings.fail_early {
-                                return Err(e);
-                            }
-                            error_collector.push(e);
-                            (DirectoryCreateResult::Failed, true)
+                let (create_result, error_already_pushed) = match create_result {
+                    Ok(result) => (result, false),
+                    Err(e) => {
+                        tracing::error!("Failed to create directory {:?}: {:#}", dst, e);
+                        if settings.fail_early {
+                            return Err(e);
                         }
-                    };
+                        error_collector.push(e);
+                        (DirectoryCreateResult::Failed, true)
+                    }
+                };
+                // classify the outcome before the match consumes it: whether we created the
+                // directory (vs reused an existing one) and whether create reported a hard
+                // failure (vs an --ignore-existing skip).
+                let was_created = matches!(create_result, DirectoryCreateResult::Created(_));
+                let create_failed = matches!(create_result, DirectoryCreateResult::Failed);
                 match create_result {
-                    DirectoryCreateResult::Created | DirectoryCreateResult::AlreadyExisted => {
-                        // add to tracker (sends DirectoryCreated)
+                    DirectoryCreateResult::Created(dir)
+                    | DirectoryCreateResult::AlreadyExisted(dir) => {
+                        // add to tracker (sends DirectoryCreated, stores the dir fd in the fd-map)
                         // tracker handles root directory tracking internally
-                        let was_created = create_result == DirectoryCreateResult::Created;
                         directory_tracker
                             .lock()
                             .await
                             .add_directory(
                                 src,
                                 dst,
+                                dir,
                                 metadata.clone(),
                                 is_root,
                                 was_created,
                                 entry_count,
-                                file_count,
                                 keep_if_empty,
                             )
                             .await
@@ -778,13 +969,23 @@ async fn process_control_stream(
                         // for Failed, push the synthetic "not a directory" error when
                         // create_directory returned Ok(Failed). when it returned
                         // Err(e), the real error (e.g. EACCES) was already pushed.
-                        if create_result == DirectoryCreateResult::Failed && !error_already_pushed {
+                        if create_failed && !error_already_pushed {
                             error_collector.push(anyhow::anyhow!(
                                 "destination {dst:?} exists and is not a directory, use --overwrite to replace"
                             ));
                         }
                         let mut tracker = directory_tracker.lock().await;
                         tracker.mark_directory_failed(dst);
+                        // nack so the source releases this directory's held fd: it was
+                        // not created and no files will be requested for it. Without this
+                        // a no-ack subtree larger than the source's dir-fd budget hangs
+                        // the copy. (Sent even on the fail_early return path below — the
+                        // source's Pass 1 may still be mid-walk when the failure races
+                        // its DestinationDone; an extra nack is harmless there.)
+                        tracker
+                            .send_directory_skipped(src, dst)
+                            .await
+                            .context("Failed to send DirectorySkipped for failed directory")?;
                         // if root directory failed, mark root as complete to avoid hang
                         if is_root {
                             tracker.set_root_complete();
@@ -797,7 +998,7 @@ async fn process_control_stream(
                                 .await
                                 .context("Failed to update parent tracker for failed directory")?;
                         }
-                        if create_result == DirectoryCreateResult::Failed && settings.fail_early {
+                        if create_failed && settings.fail_early {
                             return Err(anyhow::anyhow!(
                                 "destination {dst:?} exists and is not a directory, use --overwrite to replace"
                             ));
@@ -833,8 +1034,23 @@ async fn process_control_stream(
                     }
                     continue;
                 }
-                // create symlink
-                let result = create_symlink(settings, preserve, dst, target, metadata).await;
+                // resolve the destination parent's held fd (for the root, open the trusted
+                // parent via open_parent_dir), then create the symlink fd-relative on it.
+                let result = match resolve_parent_dir(&directory_tracker, dst, is_root).await {
+                    Ok((dst_parent, dst_name)) => {
+                        create_symlink(
+                            settings,
+                            preserve,
+                            &dst_parent,
+                            &dst_name,
+                            dst,
+                            target,
+                            metadata,
+                        )
+                        .await
+                    }
+                    Err(e) => Err(e.context("failed resolving destination parent directory")),
+                };
                 if let Err(e) = result {
                     tracing::error!("Failed to create symlink {:?} -> {:?}: {:#}", src, dst, e);
                     if settings.fail_early {

--- a/rcp/src/directory_tracker.rs
+++ b/rcp/src/directory_tracker.rs
@@ -29,9 +29,33 @@
 //!
 //! When a directory fails to be created:
 //! - It's added to `failed_directories`
-//! - No `DirectoryCreated` is sent (source won't send files)
+//! - A `DirectorySkipped` nack is sent instead of `DirectoryCreated`, so the source releases the
+//!   directory's held fd and sends no files for it (exactly one of `DirectoryCreated`/
+//!   `DirectorySkipped` is sent per `Directory`)
 //! - Descendant directories/symlinks are skipped via `has_failed_ancestor()`
 //! - Skipped entries still call `process_child_entry()` on the parent
+//!
+//! # Directory fd-map (TOCTOU-safe destination writes)
+//!
+//! Every successfully created/reused directory also has its open [`Dir`] handle
+//! (an `O_NOFOLLOW|O_DIRECTORY` fd) stored in the tracker, keyed by its destination
+//! path. Because directories are created **top-down** (a parent's `DirectoryCreated`
+//! precedes any message for its children), a parent's `Dir` is always present in the
+//! tracker before its child files/dirs/symlinks are processed. All destination writes
+//! are then fd-relative on the held parent `Dir`: file/symlink/subdirectory creation,
+//! overwrite removal, directory-metadata application, and empty-directory cleanup. A
+//! privileged `rcpd` destination therefore cannot be redirected by a concurrent
+//! symlink swap of an intermediate destination directory into writing/creating/
+//! deleting outside the destination tree — the `openat`/`mkdirat`/`unlinkat`/… resolve
+//! relative to the pinned fd, never re-walking the path from the root.
+//!
+//! The map holds `Arc<Dir>`: callers clone the Arc out under the tracker lock, release
+//! the lock, then perform the (possibly slow) fd syscall — the lock is never held
+//! across a syscall, and the cloned Arc keeps the fd alive for the operation even if
+//! the directory completes and is dropped from the map concurrently.
+
+use common::safedir::Dir;
+use std::sync::Arc;
 
 /// State for a single directory waiting for child entries.
 #[derive(Debug)]
@@ -52,6 +76,16 @@ pub struct DirectoryTracker {
     failed_directories: std::collections::HashSet<std::path::PathBuf>,
     /// directories that we created (vs reused existing) - used for empty dir cleanup
     created_directories: std::collections::HashSet<std::path::PathBuf>,
+    /// open `Dir` fd for each tracked directory, keyed by destination path. All
+    /// destination writes for a directory's children resolve relative to the parent's
+    /// fd held here (see the module-level "Directory fd-map" docs). Dropped when the
+    /// directory completes.
+    dirs: std::collections::HashMap<std::path::PathBuf, Arc<Dir>>,
+    /// open `Dir` fd for the root directory's PARENT (the trusted user-specified
+    /// destination parent, opened once via `open_parent_dir`). Held so the root
+    /// directory's own empty-directory cleanup can `rmdir_at` it through a pinned
+    /// parent fd, since the root's parent is itself never a tracked directory.
+    root_parent_dir: Option<Arc<Dir>>,
     /// stored metadata for each directory (applied when complete)
     metadata: std::collections::HashMap<std::path::PathBuf, remote::protocol::Metadata>,
     /// have we received DirStructureComplete?
@@ -83,6 +117,8 @@ impl DirectoryTracker {
             pending_directories: std::collections::HashMap::new(),
             failed_directories: std::collections::HashSet::new(),
             created_directories: std::collections::HashSet::new(),
+            dirs: std::collections::HashMap::new(),
+            root_parent_dir: None,
             metadata: std::collections::HashMap::new(),
             structure_complete: false,
             root_complete: false,
@@ -105,29 +141,77 @@ impl DirectoryTracker {
         }
         false
     }
+    /// Send `DirectorySkipped` to the source for a `Directory` message the
+    /// destination did NOT create (create failed, ancestor failed, or
+    /// `--ignore-existing` skipped a non-directory). The source releases the
+    /// matching held directory fd from its fd-map; no files are requested for a
+    /// skipped directory. This balances the one-response-per-`Directory`-message
+    /// contract that keeps the source's dir-fd budget effective and deadlock-free.
+    ///
+    /// Skipped directories are never inserted into `pending_directories`, so this
+    /// does not affect `DestinationDone`/done-detection accounting.
+    pub async fn send_directory_skipped(
+        &self,
+        src: &std::path::Path,
+        dst: &std::path::Path,
+    ) -> anyhow::Result<()> {
+        let message = remote::protocol::DestinationMessage::DirectorySkipped {
+            src: src.to_path_buf(),
+            dst: dst.to_path_buf(),
+        };
+        let mut stream = self.control_send_stream.lock().await;
+        stream.send_control_message(&message).await?;
+        tracing::debug!("Sent DirectorySkipped: {:?} -> {:?}", src, dst);
+        Ok(())
+    }
+    /// Look up a tracked directory's held `Arc<Dir>` by destination path.
+    ///
+    /// The returned Arc is a clone (a refcount bump under the tracker lock); the
+    /// caller releases the lock and then performs the fd-relative syscall, so the
+    /// lock is never held across a syscall and the fd stays alive for the operation
+    /// even if the directory completes and is dropped from the map meanwhile.
+    pub fn get_dir(&self, dst: &std::path::Path) -> Option<Arc<Dir>> {
+        self.dirs.get(dst).cloned()
+    }
+    /// The root directory's PARENT `Dir`, if it has been opened.
+    ///
+    /// This is the trusted user-specified destination parent (opened via
+    /// `open_parent_dir`), used to create the root directory itself and to `rmdir_at`
+    /// it during empty-directory cleanup.
+    pub fn root_parent_dir(&self) -> Option<Arc<Dir>> {
+        self.root_parent_dir.clone()
+    }
+    /// Record the root directory's PARENT `Dir` (opened once via `open_parent_dir`).
+    pub fn set_root_parent_dir(&mut self, dir: Arc<Dir>) {
+        self.root_parent_dir = Some(dir);
+    }
     /// Add a successfully created directory to tracking.
-    /// Sends `DirectoryCreated` to source with the `file_count`.
+    /// Sends `DirectoryCreated` to source (the Pass-2 trigger; no count is echoed —
+    /// the source retains its own authoritative Pass-1 file count).
     /// If `entry_count` is 0, the directory completes immediately.
     ///
     /// # Arguments
+    /// * `dir` - the open `Dir` fd for this directory (stored in the fd-map so its
+    ///   children's writes resolve relative to it)
     /// * `was_created` - true if we created this directory, false if it already existed
     /// * `entry_count` - total child entries (files + dirs + symlinks)
-    /// * `file_count` - number of child files, echoed back to source
     /// * `keep_if_empty` - whether to keep this directory if empty
     #[allow(clippy::too_many_arguments)]
     pub async fn add_directory(
         &mut self,
         src: &std::path::Path,
         dst: &std::path::Path,
+        dir: Arc<Dir>,
         metadata: remote::protocol::Metadata,
         is_root: bool,
         was_created: bool,
         entry_count: usize,
-        file_count: usize,
         keep_if_empty: bool,
     ) -> anyhow::Result<()> {
         // store metadata for later application
         self.metadata.insert(dst.to_path_buf(), metadata);
+        // store the open dir fd so children resolve relative to it (fd-map).
+        self.dirs.insert(dst.to_path_buf(), dir);
         // track root directory path
         if is_root {
             self.root_directory = Some(dst.to_path_buf());
@@ -145,22 +229,21 @@ impl DirectoryTracker {
                 keep_if_empty,
             },
         );
-        // send DirectoryCreated with file_count to trigger file sending
+        // send DirectoryCreated to trigger file sending (Pass-2 trigger only; the
+        // source retains the authoritative Pass-1 file count, so none is echoed).
         let message = remote::protocol::DestinationMessage::DirectoryCreated {
             src: src.to_path_buf(),
             dst: dst.to_path_buf(),
-            file_count,
         };
         {
             let mut stream = self.control_send_stream.lock().await;
             stream.send_control_message(&message).await?;
         }
         tracing::info!(
-            "Sent DirectoryCreated: {:?} -> {:?} (entries={}, files={})",
+            "Sent DirectoryCreated: {:?} -> {:?} (entries={})",
             src,
             dst,
-            entry_count,
-            file_count
+            entry_count
         );
         // if entry_count is 0, directory is immediately complete
         if entry_count == 0 {
@@ -168,8 +251,8 @@ impl DirectoryTracker {
         }
         Ok(())
     }
-    /// Mark a directory as failed (creation error).
-    /// Does NOT send DirectoryCreated - source won't send files.
+    /// Mark a directory as failed (creation error). Records the failure only; the caller sends a
+    /// `DirectorySkipped` nack (not `DirectoryCreated`), so the source won't send files for it.
     pub fn mark_directory_failed(&mut self, dst: &std::path::Path) {
         self.failed_directories.insert(dst.to_path_buf());
         tracing::info!("Directory marked as failed: {:?}", dst);
@@ -178,10 +261,14 @@ impl DirectoryTracker {
     /// Increments entries_processed and checks completion.
     /// Returns true if directory is now complete.
     pub async fn process_file(&mut self, dst_dir: &std::path::Path) -> anyhow::Result<bool> {
-        let state = self
-            .pending_directories
-            .get_mut(dst_dir)
-            .ok_or_else(|| anyhow::anyhow!("directory {:?} not being tracked", dst_dir))?;
+        // no-op if the parent is not tracked (e.g. a FAILED directory whose counted
+        // children are still being accounted via `FileSkipped`, or the root). Nothing
+        // waits on an untracked directory's completion, so tolerating it is safe and
+        // mirrors `process_child_entry` — without this, a `FileSkipped` (or `File`)
+        // received under a failed ancestor would abort the whole destination.
+        let Some(state) = self.pending_directories.get_mut(dst_dir) else {
+            return Ok(false);
+        };
         state.entries_processed += 1;
         tracing::debug!(
             "Directory {:?} entries processed: {}/{}",
@@ -261,6 +348,15 @@ impl DirectoryTracker {
     /// Complete a single directory: apply metadata and remove from pending.
     /// Uses `keep_if_empty` from the directory state to decide whether to remove
     /// empty directories that were only created for traversal purposes.
+    ///
+    /// All filesystem operations are fd-relative on held `Dir` handles: the empty-
+    /// directory cleanup `rmdir_at`s the directory through its PARENT's pinned fd
+    /// (the parent is still tracked when a child completes, since completion is
+    /// bottom-up), and metadata is applied through the directory's OWN pinned fd via
+    /// `set_dir_metadata_fd`. The directory's `Dir` is dropped from the fd-map on
+    /// completion. Neither the parent fd nor the own fd is re-resolved by path, so a
+    /// concurrent symlink swap of the destination path cannot redirect the cleanup or
+    /// metadata application outside the destination tree.
     async fn complete_directory_single(
         &mut self,
         dst: &std::path::Path,
@@ -272,33 +368,56 @@ impl DirectoryTracker {
         if state.is_none() {
             tracing::warn!("directory {:?} was not in pending when completing", dst);
         }
+        // drop this directory's own fd from the fd-map: it is completing, no more
+        // children will be created under it. The own fd is kept locally below for the
+        // metadata application (the clone keeps it alive even though it's now out of
+        // the map).
+        let own_dir = self.dirs.remove(dst);
+        // resolve the PARENT's held Dir (and this entry's name) for fd-relative
+        // empty-dir cleanup. For a nested directory the parent is still tracked
+        // (bottom-up completion); for the root directory the parent is the trusted
+        // root_parent_dir opened via open_parent_dir.
+        let parent_dir = if is_root {
+            self.root_parent_dir.clone()
+        } else {
+            dst.parent().and_then(|p| self.dirs.get(p).cloned())
+        };
+        let entry_name = dst.file_name();
         // check if we created this directory (vs reused existing)
         let was_created = self.created_directories.remove(dst);
         // handle empty directory cleanup for directories we created
         if was_created && !keep_if_empty {
-            // try to remove if empty (best effort - may fail if not empty due to races)
-            match common::walk::run_metadata_probed(
-                common::Side::Destination,
-                common::MetadataOp::RmDir,
-                tokio::fs::remove_dir(dst),
-            )
-            .await
-            {
-                Ok(()) => {
-                    tracing::info!("Removed empty directory: {:?}", dst);
-                    // don't apply metadata or increment counter for removed directories
-                    self.metadata.remove(dst);
-                    if is_root {
-                        self.set_root_complete();
+            // try to remove if empty (best effort - may fail if not empty due to races).
+            // fd-relative rmdir_at on the parent fd: never re-resolves dst by path, so a
+            // swapped intermediate dir cannot redirect the removal. ENOTEMPTY (the common
+            // "directory has content" case) is handled by keeping the directory below.
+            match (parent_dir.as_ref(), entry_name) {
+                (Some(parent), Some(name)) => match parent.rmdir_at(name).await {
+                    Ok(()) => {
+                        tracing::info!("Removed empty directory: {:?}", dst);
+                        // don't apply metadata or increment counter for removed directories
+                        self.metadata.remove(dst);
+                        if is_root {
+                            self.set_root_complete();
+                        }
+                        return Ok(());
                     }
-                    return Ok(());
-                }
-                Err(e) => {
-                    // not empty or other error - keep it and proceed normally
-                    tracing::debug!(
-                        "Could not remove empty directory {:?} (keeping): {:#}",
-                        dst,
-                        e
+                    Err(e) => {
+                        // not empty or other error - keep it and proceed normally
+                        tracing::debug!(
+                            "Could not remove empty directory {:?} (keeping): {:#}",
+                            dst,
+                            e
+                        );
+                    }
+                },
+                _ => {
+                    // parent fd missing (shouldn't happen: parent is tracked until the
+                    // child completes) — keep the directory rather than fall back to a
+                    // path-based removal that could be redirected.
+                    tracing::warn!(
+                        "No parent fd for empty-directory cleanup of {:?}; keeping it",
+                        dst
                     );
                 }
             }
@@ -307,14 +426,33 @@ impl DirectoryTracker {
         if was_created {
             common::get_progress().directories_created.inc();
         }
-        // apply stored metadata
+        // apply stored metadata through the directory's OWN held fd (fd-relative).
         if let Some(metadata) = self.metadata.remove(dst) {
-            match common::preserve::set_dir_metadata(&self.preserve, &metadata, dst).await {
-                Ok(()) => {
-                    tracing::info!("Directory complete, metadata applied: {:?}", dst);
+            match own_dir.as_ref() {
+                Some(dir) => {
+                    match common::safedir::set_dir_metadata_fd(&self.preserve, &metadata, dir).await
+                    {
+                        Ok(()) => {
+                            tracing::info!("Directory complete, metadata applied: {:?}", dst);
+                        }
+                        Err(e) => {
+                            let err = anyhow::Error::new(e)
+                                .context(format!("failed to set metadata on directory {:?}", dst));
+                            tracing::error!("{:#}", err);
+                            if self.fail_early {
+                                return Err(err);
+                            }
+                            self.error_collector.push(err);
+                        }
+                    }
                 }
-                Err(e) => {
-                    let err = e.context(format!("failed to set metadata on directory {:?}", dst));
+                None => {
+                    // no held fd for this directory (shouldn't happen for a tracked
+                    // directory) — fail closed rather than re-resolve dst by path.
+                    let err = anyhow::anyhow!(
+                        "no held directory fd for {:?} when applying metadata",
+                        dst
+                    );
                     tracing::error!("{:#}", err);
                     if self.fail_early {
                         return Err(err);

--- a/rcp/src/source.rs
+++ b/rcp/src/source.rs
@@ -1,9 +1,232 @@
 use anyhow::Context;
 use async_recursion::async_recursion;
+use common::safedir::Dir;
+use std::collections::HashMap;
+use std::sync::Arc;
 use tracing::{Instrument, instrument};
 
 fn progress() -> &'static common::progress::Progress {
     common::get_progress()
+}
+
+/// How the source reads file DATA for this copy. Chosen once per operation in
+/// [`handle_connection`] and threaded through both passes.
+///
+/// This makes the hardened/dereference distinction *explicit* instead of encoding
+/// it as `Option<Arc<SourceDirMap>>`, where `None` (dereference) and `Some(map)` +
+/// a lookup *miss* both collapsed into the same path-based fallback. That collapse
+/// was a TOCTOU fail-*open*: in hardened mode the held directory fd IS the safety
+/// boundary, so a miss means the pinned handle is gone and the source MUST fail
+/// closed rather than silently re-resolve the data read by path.
+///
+/// - [`SourceRead::Hardened`]: every directory is opened `O_NOFOLLOW` from its
+///   parent's held fd (Pass 1) and its `Arc<Dir>` stored in the [`SourceDirMap`];
+///   Pass 2 consumes that handle and opens file data fd-relative via
+///   `dir.open_file_read(name)` — never re-resolving the path from the root. A map
+///   miss is fatal (the whole copy aborts).
+/// - [`SourceRead::DereferencePath`]: the `-L`/`--dereference` path-based walk,
+///   where nested symlink following is intentional and the data open is the
+///   ordinary `File::open(src)`. It holds no directory fd, but it DOES retain the
+///   Pass-1 file count per directory in a `path → file_count` map: with no count
+///   echoed back over the wire, Pass 2 (`-L`) reads its expected count from here.
+///   A `-L` miss is NOT a TOCTOU violation (this path is not hardened), so it is
+///   treated as count 0 + a debug log rather than failing closed.
+#[derive(Clone)]
+enum SourceRead {
+    Hardened(Arc<SourceDirMap>),
+    DereferencePath(DereferenceCountMap),
+}
+
+/// Source-side `path → file_count` map for the `-L`/`--dereference` walk, the
+/// dereference analogue of the hardened [`SourceDirMap`] minus the held fd and the
+/// fd-budget permit.
+///
+/// With the destination no longer echoing `file_count` in `DirectoryCreated`, the
+/// `-L` path (which holds no fd-map) must retain its own Pass-1 count: Pass 1
+/// inserts each directory's count as it sends the `Directory` message, and
+/// [`resolve_pass2_source`] takes it back when the matching `DirectoryCreated`
+/// triggers Pass 2. A missing entry is treated as count 0 with a debug log — `-L`
+/// is intentionally not hardened, so a miss is not a TOCTOU/fail-closed condition.
+type DereferenceCountMap = Arc<std::sync::Mutex<HashMap<std::path::PathBuf, usize>>>;
+
+impl SourceRead {
+    /// The hardened fd-map, or `None` in dereference mode. Used by Pass 1 to decide
+    /// between the fd-relative walk and the path-based walk.
+    fn dir_map(&self) -> Option<&Arc<SourceDirMap>> {
+        match self {
+            SourceRead::Hardened(map) => Some(map),
+            SourceRead::DereferencePath(_) => None,
+        }
+    }
+
+    /// The `-L`/--dereference `path → file_count` map, or `None` in hardened mode.
+    /// Used by Pass 1's path-based body to record each directory's count and by
+    /// [`resolve_pass2_source`] to recover it (no count is echoed over the wire).
+    fn deref_counts(&self) -> Option<&DereferenceCountMap> {
+        match self {
+            SourceRead::Hardened(_) => None,
+            SourceRead::DereferencePath(counts) => Some(counts),
+        }
+    }
+}
+
+/// Source-side `path → MapEntry` map that bridges the network round-trip between
+/// the two source passes, making file DATA reads TOCTOU-safe.
+///
+/// Pass 1 ([`send_directories_and_symlinks`]) opens every directory `O_NOFOLLOW`
+/// from its parent's held fd and stores the resulting `Arc<Dir>` here, keyed by
+/// the directory's source path. Pass 2 ([`send_files_in_directory_tcp`], spawned
+/// later from the `DirectoryCreated` handler) takes ownership of that entry and
+/// opens file data via `dir.open_file_read(name)` — fd-relative, never
+/// re-resolving the path from the root — instead of the path-based
+/// `File::open(src)` that a concurrent symlink swap could redirect.
+///
+/// # One-shot entry ownership (linear Pass 1 → Pass 2 handoff)
+///
+/// Each entry is *consumed* by exactly one of the destination's two mutually
+/// exclusive responses, removing it from the map under the lock:
+/// - [`Self::take_for_created`] (on `DirectoryCreated`): the owned [`MapEntry`]
+///   (its `Arc<Dir>` plus the held fd-budget permit) moves INTO the spawned Pass 2
+///   task, which releases the permit when it drops the entry after all files are
+///   sent. Pass 2 is network-bound and independent of the dir-fd permit, so it
+///   always makes progress.
+/// - [`Self::take_for_skipped`] (on `DirectorySkipped`): the entry is dropped
+///   immediately (releasing the permit) since no files are ever requested for a
+///   skipped directory.
+///
+/// Ownership is therefore linear: there is no clone-and-leave + deferred RAII
+/// cleanup. A second/absent take for the same path returns `None` (see the
+/// dispatch loop for how each response handles that).
+///
+/// # Bounding semaphore (prevents EMFILE)
+///
+/// Pass 1 is an *unthrottled* full-tree DFS while Pass 2 is network-paced, so
+/// without a bound the peak number of held directory fds would approach the whole
+/// tree's directory count → `EMFILE` on large trees. The map is gated by a
+/// dir-fd-in-flight semaphore: Pass 1 acquires one permit per [`Self::insert`]
+/// (awaiting if the bound is reached), and the permit is released when the
+/// directory's [`MapEntry`] is dropped (after a take).
+///
+/// # Release invariant (deadlock-free)
+///
+/// Pass 1 only ever *acquires*; it must never release. **Every Pass-1 insert is
+/// matched by exactly one release**, driven by the destination's exactly-one
+/// response per `Directory` message (the two `take_*` methods above). This keeps
+/// the budget both *effective* (a large no-ack subtree releases its fds promptly
+/// via `DirectorySkipped` nacks instead of accumulating to connection-end) and
+/// *deadlock-free*. Pass 2 must never acquire a dir-fd permit.
+///
+/// # Fail-closed teardown
+///
+/// [`Self::close_fd_budget`] closes the bounding semaphore so any pending or
+/// future [`Self::insert`] fails immediately. The dispatch loop calls it when it
+/// must fail closed on a `DirectoryCreated` miss, unblocking a Pass-1 walk that
+/// might otherwise be parked on the budget so the whole operation tears down
+/// cleanly instead of hanging.
+struct SourceDirMap {
+    entries: std::sync::Mutex<HashMap<std::path::PathBuf, MapEntry>>,
+    fd_budget: Arc<tokio::sync::Semaphore>,
+}
+
+/// A consumed source-directory map entry, in one of two states; dropping it (after a
+/// take) releases any held fd-budget permit. Encoding the state as an enum makes the
+/// lifecycle explicit — the previous `Option`-triple had only two valid combinations
+/// (all-set vs. all-clear), which lived in comments rather than the type.
+///
+/// # Tombstone entries (committed unreadable directories)
+///
+/// When Pass 1 commits a directory to the wire but cannot read it (its
+/// `open_root_dir`/`open_dir` failed, or its enumeration failed), it sends a 0-entry
+/// `Directory` and stores a [`MapEntry::Tombstone`]. The destination still creates an
+/// empty directory and acks `DirectoryCreated`, which must be CONSUMED normally — not
+/// treated as a fail-closed miss. A tombstone holds no fd, so it deliberately consumes
+/// no fd-budget permit, and Pass 2 for it sends zero files and needs no fd.
+enum MapEntry {
+    /// A readable directory: its held fd (Pass 2 opens file DATA fd-relative through
+    /// it), the Pass-1 expected `file_count` (authoritative for Pass 2's truncation /
+    /// synthetic-`FileSkipped` logic), and the fd-budget permit that bounds how many
+    /// real directory fds Pass 1 holds in flight (released when this drops).
+    Readable {
+        dir: Arc<Dir>,
+        file_count: usize,
+        _permit: tokio::sync::OwnedSemaphorePermit,
+    },
+    /// A committed-but-unreadable directory (0-entry `Directory` sent). Holds no fd and
+    /// no permit; its file count is implicitly 0 and Pass 2 sends no files.
+    Tombstone,
+}
+
+impl SourceDirMap {
+    /// Create a map bounded to at most `fd_budget` directory fds held in flight
+    /// across the round-trip between Pass 1 and Pass 2.
+    fn new(fd_budget: usize) -> Self {
+        Self {
+            entries: std::sync::Mutex::new(HashMap::new()),
+            fd_budget: Arc::new(tokio::sync::Semaphore::new(fd_budget)),
+        }
+    }
+
+    /// Store the directory's `Arc<Dir>` plus its Pass-1 expected `file_count`,
+    /// keyed by source path, first acquiring a dir-fd-in-flight permit (awaiting if
+    /// the bound is reached). Only Pass 1 calls this.
+    async fn insert(
+        &self,
+        src: std::path::PathBuf,
+        dir: Arc<Dir>,
+        file_count: usize,
+    ) -> anyhow::Result<()> {
+        let permit = self
+            .fd_budget
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| anyhow::anyhow!("source dir-fd budget semaphore closed"))?;
+        self.entries.lock().unwrap().insert(
+            src,
+            MapEntry::Readable {
+                dir,
+                file_count,
+                _permit: permit,
+            },
+        );
+        Ok(())
+    }
+
+    /// Store a *tombstone* for a directory Pass 1 committed to the wire (a 0-entry
+    /// `Directory`) but could not open/enumerate. The destination still creates an
+    /// empty directory and acks `DirectoryCreated`; the tombstone makes that ack
+    /// CONSUME a real entry (via [`Self::take_for_created`]) instead of hitting the
+    /// fail-closed miss path. A tombstone holds NO fd, so it acquires NO fd-budget
+    /// permit (`dir: None`, `_permit: None`, `file_count: 0`). Only Pass 1 calls
+    /// this. Infallible — there is no permit to await.
+    fn insert_tombstone(&self, src: std::path::PathBuf) {
+        self.entries
+            .lock()
+            .unwrap()
+            .insert(src, MapEntry::Tombstone);
+    }
+
+    /// Consume the entry for a directory the destination created, transferring
+    /// ownership of its `Arc<Dir>` + fd-budget permit to the caller (Pass 2).
+    /// Returns `None` if no entry is present — in hardened mode the caller treats
+    /// that as a fail-closed condition (the pinned handle is gone).
+    fn take_for_created(&self, src: &std::path::Path) -> Option<MapEntry> {
+        self.entries.lock().unwrap().remove(src)
+    }
+
+    /// Consume and drop the entry for a directory the destination did NOT create
+    /// (the `DirectorySkipped` nack), releasing its dir-fd permit. Returns whether
+    /// an entry was actually present so the caller can log an absent/double nack.
+    fn take_for_skipped(&self, src: &std::path::Path) -> bool {
+        self.entries.lock().unwrap().remove(src).is_some()
+    }
+
+    /// Close the dir-fd-in-flight semaphore so any pending or future
+    /// [`Self::insert`] fails immediately. Used to fail closed without hanging a
+    /// Pass-1 walk parked on the budget (see the struct-level docs).
+    fn close_fd_budget(&self) {
+        self.fd_budget.close();
+    }
 }
 
 /// increment the appropriate skipped counter based on file type.
@@ -20,8 +243,52 @@ struct ChildEntry {
     metadata: std::fs::Metadata,
 }
 
-#[instrument(skip(error_collector, control_send_stream))]
+/// Open the trusted parent prefix of a root operand and return it as a hardened `Dir` plus the
+/// operand's final component, so the root file/symlink can be read fd-relative (`O_NOFOLLOW`) — the
+/// same trusted-parent + hardened-final-component model the local copy uses. `open_parent_dir`
+/// follows symlinks in the prefix (the caller's trust responsibility, per docs/tocttou.md), then
+/// the final component is opened/classified `O_NOFOLLOW` below it, so a swap of the root entry in a
+/// writable parent is caught at open. This hardens the remote source root the same way nested
+/// entries are already hardened by the fd-map.
+async fn open_root_parent(src: &std::path::Path) -> anyhow::Result<(Arc<Dir>, std::ffi::OsString)> {
+    let operand = common::walk::split_root_operand(src).await?;
+    let parent = Dir::open_parent_dir(&operand.parent, common::Side::Source)
+        .await
+        .with_context(|| format!("cannot open parent directory of root operand {src:?}"))?
+        .into_tree();
+    Ok((Arc::new(parent), operand.name))
+}
+
+/// Send a `SymlinkSkipped` for a symlink the source could not read (so the destination accounts for
+/// it; for a root symlink this also signals root completion). The single source-side helper for the
+/// three symlink-skip sites (root path-based, hardened root, nested).
+async fn send_symlink_skipped(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    is_root: bool,
+    control_send_stream: &remote::streams::BoxedSharedSendStream,
+) -> anyhow::Result<()> {
+    let skip_msg = remote::protocol::SourceMessage::SymlinkSkipped {
+        src_dst: remote::protocol::SrcDst {
+            src: src.to_path_buf(),
+            dst: dst.to_path_buf(),
+        },
+        is_root,
+    };
+    control_send_stream
+        .lock()
+        .await
+        .send_batch_message(&skip_msg)
+        .await
+}
+
+/// The `-L`/`--dereference` path-based Pass-1 walk (directories + symlinks). The hardened
+/// (non-`-L`) walk lives in [`send_directory_fd_walk`] (nested) and [`send_root_hardened`] (root);
+/// this function is reached only in dereference mode, so every read here is path-based by design
+/// (following symlinks is requested; documented not hardened).
+#[instrument(skip(error_collector, control_send_stream, deref_counts))]
 #[async_recursion]
+#[allow(clippy::too_many_arguments)]
 async fn send_directories_and_symlinks(
     settings: &common::copy::Settings,
     src: &std::path::Path,
@@ -30,18 +297,17 @@ async fn send_directories_and_symlinks(
     is_root: bool,
     control_send_stream: &remote::streams::BoxedSharedSendStream,
     error_collector: &std::sync::Arc<common::error_collector::ErrorCollector>,
+    // the `-L`/--dereference `path → file_count` map: Pass 1 records each directory's Pass-1 file
+    // count here so [`resolve_pass2_source`] can recover it without a wire echo (no count is echoed
+    // over the wire).
+    deref_counts: Option<&DereferenceCountMap>,
 ) -> anyhow::Result<()> {
     tracing::debug!("Sending data from {:?} to {:?}", &src, dst);
     let src_metadata = match common::walk::run_metadata_probed(
         common::Side::Source,
         common::MetadataOp::Stat,
-        async {
-            if settings.dereference {
-                tokio::fs::metadata(&src).await
-            } else {
-                tokio::fs::symlink_metadata(&src).await
-            }
-        },
+        // `-L`-only path: always follow symlinks (dereference is always set here).
+        tokio::fs::metadata(&src),
     )
     .await
     {
@@ -86,7 +352,7 @@ async fn send_directories_and_symlinks(
         let target = match common::walk::run_metadata_probed(
             common::Side::Source,
             common::MetadataOp::ReadLink,
-            tokio::fs::read_link(&src),
+            tokio::fs::read_link(&src), // rcp-toctou-allow: -L path (dereference, documented not hardened)
         )
         .await
         {
@@ -95,18 +361,7 @@ async fn send_directories_and_symlinks(
                 tracing::error!("Failed reading symlink {src:?}: {e:#}");
                 // notify destination that this symlink was skipped
                 // for root symlinks, this also signals root completion (even if failed)
-                let skip_msg = remote::protocol::SourceMessage::SymlinkSkipped {
-                    src_dst: remote::protocol::SrcDst {
-                        src: src.to_path_buf(),
-                        dst: dst.to_path_buf(),
-                    },
-                    is_root,
-                };
-                control_send_stream
-                    .lock()
-                    .await
-                    .send_batch_message(&skip_msg)
-                    .await?;
+                send_symlink_skipped(src, dst, is_root, control_send_stream).await?;
                 if settings.fail_early {
                     return Err(e.into());
                 }
@@ -166,14 +421,18 @@ async fn send_directories_and_symlinks(
             }
             error_collector.push(e.into());
             // directory unreadable but we already committed to sending it -
-            // send with 0 entries so destination can still complete
+            // send with 0 entries so destination can still complete. Record a
+            // 0 count for this `-L` directory so Pass 2's count lookup resolves
+            // (no wire echo carries it anymore).
+            if let Some(deref_counts) = deref_counts {
+                deref_counts.lock().unwrap().insert(src.to_path_buf(), 0);
+            }
             let dir = remote::protocol::SourceMessage::Directory {
                 src: src.to_path_buf(),
                 dst: dst.to_path_buf(),
                 metadata: remote::protocol::Metadata::from(&src_metadata),
                 is_root,
                 entry_count: 0,
-                file_count: 0,
                 keep_if_empty: true,
             };
             control_send_stream
@@ -197,13 +456,8 @@ async fn send_directories_and_symlinks(
                 let entry_metadata = match common::walk::run_metadata_probed(
                     common::Side::Source,
                     common::MetadataOp::Stat,
-                    async {
-                        if settings.dereference {
-                            tokio::fs::metadata(&entry_path).await
-                        } else {
-                            tokio::fs::symlink_metadata(&entry_path).await
-                        }
-                    },
+                    // `-L`-only path: always follow symlinks (dereference is always set here).
+                    tokio::fs::metadata(&entry_path),
                 )
                 .await
                 {
@@ -311,14 +565,23 @@ async fn send_directories_and_symlinks(
     } else {
         true
     };
-    // send Directory message with pre-computed counts
+    // record this `-L` directory's Pass-1 file count so Pass 2 can recover it
+    // without a wire echo (the count lives only on the source now). Inserted before
+    // the `Directory` send so it is present before the destination can ack
+    // `DirectoryCreated` and trigger the Pass-2 lookup.
+    if let Some(deref_counts) = deref_counts {
+        deref_counts
+            .lock()
+            .unwrap()
+            .insert(src.to_path_buf(), file_count);
+    }
+    // send Directory message with pre-computed entry count
     let dir = remote::protocol::SourceMessage::Directory {
         src: src.to_path_buf(),
         dst: dst.to_path_buf(),
         metadata: remote::protocol::Metadata::from(&src_metadata),
         is_root,
         entry_count,
-        file_count,
         keep_if_empty,
     };
     tracing::debug!(
@@ -333,7 +596,10 @@ async fn send_directories_and_symlinks(
         .await
         .send_batch_message(&dir)
         .await?;
-    // recurse into non-file children (symlinks first, then directories)
+    // recurse into non-file children (symlinks first, then directories).
+    // this path-based body only runs when the fd-map is inactive (`-L` mode), so
+    // the recursive calls carry `None` for the hardened fd-map and forward the
+    // dereference count map.
     for child in symlink_children {
         if let Err(e) = send_directories_and_symlinks(
             settings,
@@ -343,6 +609,7 @@ async fn send_directories_and_symlinks(
             false,
             control_send_stream,
             error_collector,
+            deref_counts,
         )
         .await
         {
@@ -362,6 +629,7 @@ async fn send_directories_and_symlinks(
             false,
             control_send_stream,
             error_collector,
+            deref_counts,
         )
         .await
         {
@@ -375,7 +643,419 @@ async fn send_directories_and_symlinks(
     Ok(())
 }
 
-#[instrument(skip(error_collector, stream_pool, control_send_stream))]
+/// Emit a 0-entry `Directory` message for a directory that we committed to
+/// sending but cannot read (open/enumerate failed), so the destination can still
+/// complete its tracking. Shared by the path-based and fd-walk directory bodies.
+///
+/// # Hardened-map bookkeeping (fail-closed correctness)
+///
+/// In hardened mode (`dir_map` is `Some`) the destination will still create an
+/// empty directory and ack `DirectoryCreated` for the 0-entry `Directory` sent
+/// here. That ack MUST consume a real map entry, otherwise it hits
+/// [`resolve_pass2_source`]'s fail-closed miss path and spuriously aborts the
+/// copy — the very bug this committed-unreadable-directory case must avoid. So
+/// before sending we register an entry keyed by `src`:
+/// - `dir: Some(_)` (enumeration failed but the directory fd is held): insert a
+///   real entry via [`SourceDirMap::insert`] (file_count 0, holds the fd's
+///   permit). Its `DirectoryCreated` ack consumes it; Pass 2 sends no files.
+/// - `dir: None` (the directory could not even be opened): insert a *tombstone*
+///   via [`SourceDirMap::insert_tombstone`] (no fd, no permit, file_count 0).
+///
+/// This registration happens only on the non-fail-early path: with `fail_early`
+/// we return `Err` before sending the `Directory`, so no ack will ever arrive and
+/// no entry is needed. `-L` mode passes `dir_map: None` (it has no fd-map), so
+/// nothing is registered there.
+#[allow(clippy::too_many_arguments)]
+async fn send_unreadable_directory(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    metadata: remote::protocol::Metadata,
+    is_root: bool,
+    control_send_stream: &remote::streams::BoxedSharedSendStream,
+    error_collector: &std::sync::Arc<common::error_collector::ErrorCollector>,
+    fail_early: bool,
+    err: anyhow::Error,
+    // hardened fd-map (None under `-L`) and the held directory fd if one was
+    // opened (None when the open itself failed). Together they decide whether to
+    // register a real entry or a tombstone so the destination's `DirectoryCreated`
+    // ack is consumed instead of failing closed.
+    dir_map: Option<&Arc<SourceDirMap>>,
+    dir: Option<Arc<Dir>>,
+) -> anyhow::Result<()> {
+    if fail_early {
+        return Err(err);
+    }
+    error_collector.push(err);
+    // register the map entry (real or tombstone) BEFORE sending the `Directory`, so
+    // the entry is present before the destination can echo `DirectoryCreated` and
+    // Pass 2 / the dispatch loop looks it up.
+    if let Some(dir_map) = dir_map {
+        match dir {
+            Some(dir) => dir_map.insert(src.to_path_buf(), dir, 0).await?,
+            None => dir_map.insert_tombstone(src.to_path_buf()),
+        }
+    }
+    let dir_msg = remote::protocol::SourceMessage::Directory {
+        src: src.to_path_buf(),
+        dst: dst.to_path_buf(),
+        metadata,
+        is_root,
+        entry_count: 0,
+        keep_if_empty: true,
+    };
+    control_send_stream
+        .lock()
+        .await
+        .send_batch_message(&dir_msg)
+        .await?;
+    Ok(())
+}
+
+/// Emit a per-child accounting message for a counted child the source can no
+/// longer process (e.g. `open_dir` failed, or the recursive descent returned an
+/// error).
+///
+/// The child was already tallied in its parent's `entry_count` when the parent's
+/// `Directory` message was sent, so the destination's `DirectoryTracker` is waiting
+/// for exactly one response accounting for it. Without this message that parent
+/// never completes → `DestinationDone` is never sent → the copy hangs. We send
+/// `FileSkipped`, which the destination handles via `process_file(parent)`,
+/// incrementing the parent's processed-entry count by exactly one. `FileSkipped`
+/// (rather than a directory-specific message) is appropriate because it is the
+/// source-side "counted but not sent" signal already used for vanished/unreadable
+/// children, and after a failed open the source has no trustworthy type to assert.
+///
+/// Liveness over precision (the `fail_early` edge): this is sent whenever the child
+/// recursion returns `Err`, even in the case where the child had already sent its
+/// own `Directory` *and* self-accounted before erroring (e.g. a deeper `fail_early`
+/// abort after a grandchild failed). There the extra `FileSkipped` over-counts the
+/// parent by one, which can complete it before the (incomplete, never-completing)
+/// child subtree does. That is deliberately accepted: the alternative — withholding
+/// the skip whenever the child sent its `Directory` — would hang the far more common
+/// case where the child sent its `Directory` but errored *before* completing (its
+/// subtree then never propagates upward, so the parent needs this skip). The
+/// over-count is benign because (a) it only arises during a `fail_early` teardown
+/// that fails the whole copy, and (b) remote `--delete` is rejected up front, so an
+/// early parent completion cannot prune — at worst directory metadata is applied
+/// early on a copy that is aborting anyway.
+async fn send_child_failed_skip(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    control_send_stream: &remote::streams::BoxedSharedSendStream,
+) -> anyhow::Result<()> {
+    let skip_msg = remote::protocol::SourceMessage::FileSkipped {
+        src: src.to_path_buf(),
+        dst: dst.to_path_buf(),
+    };
+    control_send_stream
+        .lock()
+        .await
+        .send_batch_message(&skip_msg)
+        .await?;
+    tracing::debug!(
+        "Sent FileSkipped to account for unprocessable child {:?} -> {:?}",
+        src,
+        dst
+    );
+    Ok(())
+}
+
+/// Collected child entry from an fd-relative directory pre-read (Pass 1, hardened
+/// path). Carries the child's name (for fd-relative recursion) plus its display
+/// paths. Metadata is NOT cached here: each entry's wire metadata is read at send
+/// time from the same fd as its payload (files via `open_file_read`, symlinks via
+/// `Handle::read_symlink`, dirs via `Dir::meta`) for read-side fidelity.
+struct FdChildEntry {
+    name: std::ffi::OsString,
+    src_path: std::path::PathBuf,
+    dst_path: std::path::PathBuf,
+}
+
+/// Pass 1 directory body, hardened: enumerate `dir` via `read_entries()` and
+/// classify each child via `child()` (fd-relative `fstat`, never following a
+/// symlink), send the same `Directory`/`Symlink` protocol messages as the
+/// path-based body, store `dir`'s `Arc<Dir>` in the fd-map for Pass 2, and recurse
+/// into child directories opened `O_NOFOLLOW` from `dir`.
+///
+/// `dir` is the already-open handle to `src` itself; its wire metadata is read from that same fd
+/// (`Dir::meta`), so the directory's metadata pairs with the contents enumerated here (read-side
+/// fidelity). `is_root` drives `keep_if_empty` and the `Directory`/`Symlink` message flags exactly
+/// as the path-based body does.
+#[async_recursion]
+#[allow(clippy::too_many_arguments)]
+async fn send_directory_fd_walk(
+    settings: &common::copy::Settings,
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    source_root: &std::path::Path,
+    is_root: bool,
+    dir: Arc<Dir>,
+    control_send_stream: &remote::streams::BoxedSharedSendStream,
+    error_collector: &std::sync::Arc<common::error_collector::ErrorCollector>,
+    dir_map: &Arc<SourceDirMap>,
+) -> anyhow::Result<()> {
+    // the directory's wire metadata comes from its OWN held fd (the fd whose contents we enumerate
+    // below), so a same-name dir swap can't pair the enumerated contents with another inode's
+    // metadata (read-side fidelity, docs/tocttou.md).
+    let metadata = remote::protocol::Metadata::from(
+        &dir.meta()
+            .await
+            .with_context(|| format!("cannot read directory metadata from {src:?}"))?,
+    );
+    // enumerate children; `read_entries` returns names + a best-effort d_type hint
+    // (advisory only — `child()` re-classifies authoritatively via fstat below).
+    // the directory's held fd is stored in the map only once `file_count` is known
+    // (just before the `Directory` message is sent, below) so the map entry carries
+    // the authoritative Pass-1 count for Pass 2. The destination cannot echo
+    // `DirectoryCreated` before that message, so Pass 2 never looks up early.
+    let raw_entries = match dir.read_entries().await {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::error!("Cannot enumerate directory {src:?} for reading: {e:#}");
+            // we still committed to sending a (0-entry) `Directory` for this dir.
+            // The directory fd IS held (open succeeded, only enumeration failed), so
+            // register a real 0-file entry (it holds the fd's permit):
+            // `send_unreadable_directory` does the insert before sending so the
+            // destination's `DirectoryCreated` ack is consumed instead of being a
+            // hardened map miss → spurious fail-closed.
+            return send_unreadable_directory(
+                src,
+                dst,
+                metadata,
+                is_root,
+                control_send_stream,
+                error_collector,
+                settings.fail_early,
+                e.into(),
+                Some(dir_map),
+                Some(dir.clone()),
+            )
+            .await;
+        }
+    };
+    let mut file_children: Vec<FdChildEntry> = Vec::new();
+    let mut dir_children: Vec<FdChildEntry> = Vec::new();
+    let mut symlink_children: Vec<FdChildEntry> = Vec::new();
+    for (entry_name, _hint) in raw_entries {
+        let entry_path = src.join(&entry_name);
+        let dst_path = dst.join(&entry_name);
+        // classify authoritatively via fd-relative fstat (never follows a symlink).
+        let handle = match dir.child(&entry_name).await {
+            Ok(h) => h,
+            Err(e) => {
+                let e: anyhow::Error = e.into();
+                tracing::error!("Failed reading metadata from {entry_path:?}: {e:#}");
+                if settings.fail_early {
+                    return Err(e);
+                }
+                error_collector.push(e);
+                continue;
+            }
+        };
+        let kind = handle.kind();
+        let is_dir = kind == common::walk::EntryKind::Dir;
+        // apply filter for child entries (same logic as the path-based body)
+        if let Some(ref filter) = settings.filter {
+            let relative_path = common::walk::relative_to_root(&entry_path, source_root);
+            match filter.should_include(relative_path, is_dir) {
+                common::filter::FilterResult::Included => { /* proceed */ }
+                common::filter::FilterResult::ExcludedByPattern(_) => {
+                    tracing::debug!("Filtered out {:?}", entry_path);
+                    // only count dirs/symlinks here; files are counted in
+                    // send_files_in_directory_tcp which re-traverses
+                    if kind != common::walk::EntryKind::File {
+                        kind.inc_skipped(progress());
+                    }
+                    continue;
+                }
+                common::filter::FilterResult::ExcludedByDefault => {
+                    if is_dir {
+                        let mut could_match = false;
+                        for pattern in &filter.includes {
+                            if filter.could_contain_matches(relative_path, pattern) {
+                                could_match = true;
+                                break;
+                            }
+                        }
+                        if !could_match {
+                            tracing::debug!("Filtered out {:?}", entry_path);
+                            kind.inc_skipped(progress());
+                            continue;
+                        }
+                        // directory might contain matches - include it
+                    } else {
+                        tracing::debug!("Filtered out {:?}", entry_path);
+                        // only count symlinks here; files are counted in
+                        // send_files_in_directory_tcp
+                        if kind != common::walk::EntryKind::File {
+                            kind.inc_skipped(progress());
+                        }
+                        continue;
+                    }
+                }
+            }
+        }
+        let child = FdChildEntry {
+            name: entry_name,
+            src_path: entry_path,
+            dst_path,
+        };
+        match kind {
+            common::walk::EntryKind::File => file_children.push(child),
+            common::walk::EntryKind::Symlink => symlink_children.push(child),
+            common::walk::EntryKind::Dir => dir_children.push(child),
+            common::walk::EntryKind::Special => {
+                if settings.skip_specials {
+                    tracing::debug!("skipping special file {:?}", &child.src_path);
+                    progress().specials_skipped.inc();
+                } else {
+                    let err = anyhow::anyhow!(
+                        "copy: {:?} -> {:?} failed, unsupported src file type",
+                        &child.src_path,
+                        &child.dst_path,
+                    );
+                    tracing::error!("{:#}", &err);
+                    if settings.fail_early {
+                        return Err(err);
+                    }
+                    error_collector.push(err);
+                }
+            }
+        }
+    }
+    // compute counts and keep_if_empty (identical semantics to the path-based body)
+    let file_count = file_children.len();
+    let entry_count = file_count + dir_children.len() + symlink_children.len();
+    let keep_if_empty = if is_root {
+        true
+    } else if let Some(ref filter) = settings.filter {
+        let relative_path = common::walk::relative_to_root(src, source_root);
+        filter.directly_matches_include(relative_path, true)
+    } else {
+        true
+    };
+    let dir_msg = remote::protocol::SourceMessage::Directory {
+        src: src.to_path_buf(),
+        dst: dst.to_path_buf(),
+        metadata,
+        is_root,
+        entry_count,
+        keep_if_empty,
+    };
+    // store this directory's held fd + authoritative file_count so Pass 2 can open
+    // file data fd-relative and size its truncation / synthetic-skip logic. Acquiring
+    // the permit here bounds how many dir fds Pass 1 holds ahead of the network-paced
+    // Pass 2 (prevents EMFILE); it must precede the `Directory` send so the entry is
+    // present before the destination can echo `DirectoryCreated` and trigger Pass 2's
+    // lookup.
+    dir_map
+        .insert(src.to_path_buf(), dir.clone(), file_count)
+        .await?;
+    tracing::debug!(
+        "Sending directory: {:?} -> {:?} (entries={}, files={})",
+        &src,
+        dst,
+        entry_count,
+        file_count
+    );
+    control_send_stream
+        .lock()
+        .await
+        .send_batch_message(&dir_msg)
+        .await?;
+    // send symlink children: re-classify each at send time and read BOTH its target and metadata
+    // from that one pinned handle (never following the link), so a same-name symlink swap can't pair
+    // one link's target with another link's owner/timestamps — target and metadata are a faithful
+    // pair, matching the file path. A swap to a non-symlink fails the classify/read and is skipped.
+    for child in symlink_children {
+        let read = async {
+            let handle = dir.child(&child.name).await?;
+            let (target, meta) = handle.read_symlink(dir.side()).await?;
+            std::io::Result::Ok((target, remote::protocol::Metadata::from(&meta)))
+        }
+        .await;
+        let (target, metadata) = match read {
+            Ok(v) => v,
+            Err(e) => {
+                let e: anyhow::Error = e.into();
+                tracing::error!("Failed reading symlink {:?}: {e:#}", child.src_path);
+                send_symlink_skipped(&child.src_path, &child.dst_path, false, control_send_stream)
+                    .await?;
+                if settings.fail_early {
+                    return Err(e);
+                }
+                error_collector.push(e);
+                continue;
+            }
+        };
+        let symlink = remote::protocol::SourceMessage::Symlink {
+            src: child.src_path.clone(),
+            dst: child.dst_path.clone(),
+            target,
+            metadata,
+            is_root: false,
+        };
+        control_send_stream
+            .lock()
+            .await
+            .send_batch_message(&symlink)
+            .await?;
+    }
+    // recurse into child directories: open each `O_NOFOLLOW` from this dir's held
+    // fd and hand the resulting `Arc<Dir>` to the recursive call. The child's wire
+    // metadata is built from its fd-pinned `FileMeta` (captured at classify time).
+    for child in dir_children {
+        let child_dir = match dir.open_dir(&child.name).await {
+            Ok(d) => Arc::new(d),
+            Err(e) => {
+                let e: anyhow::Error = e.into();
+                tracing::error!("Failed to open directory {:?}: {e:#}", child.src_path);
+                // this child was counted in this directory's `entry_count`, but we
+                // never sent its `Directory` message — account for it with a
+                // `FileSkipped` so the destination's parent count can still reach
+                // zero (otherwise the parent waits forever and the copy hangs).
+                send_child_failed_skip(&child.src_path, &child.dst_path, control_send_stream)
+                    .await?;
+                if settings.fail_early {
+                    return Err(e);
+                }
+                error_collector.push(e);
+                continue;
+            }
+        };
+        if let Err(e) = send_directory_fd_walk(
+            settings,
+            &child.src_path,
+            &child.dst_path,
+            source_root,
+            false,
+            child_dir,
+            control_send_stream,
+            error_collector,
+            dir_map,
+        )
+        .await
+        {
+            tracing::error!("Failed to send directory {:?}: {e:#}", child.src_path);
+            // the recursive descent returned an error. the child is counted in this
+            // directory's `entry_count`, so account for it with a `FileSkipped` to keep the
+            // destination's parent count balanced and avoid a hang when the child's subtree
+            // never completes. This is sent even if the child had already sent its own
+            // `Directory` (a deeper `fail_early` abort) — a deliberate, benign over-count;
+            // see `send_child_failed_skip` for why liveness is favored over precision here.
+            // (If the error was a transport failure, this send also fails and propagates — the
+            // copy is already tearing down.)
+            send_child_failed_skip(&child.src_path, &child.dst_path, control_send_stream).await?;
+            if settings.fail_early {
+                return Err(e);
+            }
+            error_collector.push(e);
+        }
+    }
+    Ok(())
+}
+
+#[instrument(skip(error_collector, stream_pool, control_send_stream, source_read))]
 #[async_recursion]
 async fn send_fs_objects_tcp(
     settings: &common::copy::Settings,
@@ -384,8 +1064,27 @@ async fn send_fs_objects_tcp(
     control_send_stream: remote::streams::BoxedSharedSendStream,
     stream_pool: std::sync::Arc<AcceptingSendStreamPool>,
     error_collector: std::sync::Arc<common::error_collector::ErrorCollector>,
+    // explicit source read mode: hardened (fd-map active) or `-L` path-based walk.
+    source_read: SourceRead,
 ) -> anyhow::Result<()> {
     tracing::info!("Sending data from {:?} to {:?}", src, dst);
+    // hardened (non-`-L`) root: classify the named root ONCE via its trusted parent's fd, driving
+    // has_root_item, filtering, metadata, and dispatch from that single snapshot — no second path
+    // stat. This closes the root-kind-swap double-stat window (a dir/symlink→file swap between the
+    // has_root_item decision and the dispatch could otherwise announce a root item but send none,
+    // hanging the destination). `-L` keeps the path-based flow below (documented not hardened).
+    if !settings.dereference {
+        return send_root_hardened(
+            settings,
+            src,
+            dst,
+            control_send_stream,
+            stream_pool,
+            error_collector,
+            source_read,
+        )
+        .await;
+    }
     let src_metadata = match common::walk::run_metadata_probed(
         common::Side::Source,
         common::MetadataOp::Stat,
@@ -433,6 +1132,7 @@ async fn send_fs_objects_tcp(
             true,
             &control_send_stream,
             &error_collector,
+            source_read.deref_counts(),
         )
         .await
     {
@@ -454,16 +1154,19 @@ async fn send_fs_objects_tcp(
         progress().files_skipped.inc();
     }
     if src_metadata.is_file() && has_root_item {
-        // root file
+        // `-L` root file: path-based open (following symlinks is requested by design and documented
+        // not hardened). The hardened (non-`-L`) root file is handled in `send_root_hardened`.
         if let Err(e) = send_file_tcp(
             settings,
             src,
             dst,
-            &src_metadata,
+            src_metadata.len(),
+            remote::protocol::Metadata::from(&src_metadata),
             true,
             stream_pool,
             &error_collector,
             control_send_stream.clone(),
+            FileRead::Path,
         )
         .await
         {
@@ -476,18 +1179,223 @@ async fn send_fs_objects_tcp(
     Ok(())
 }
 
-#[instrument(skip(error_collector, control_send_stream, stream_pool))]
+/// Hardened (non-`-L`) root handling: classify the named root ONCE via its trusted parent's fd and
+/// drive `has_root_item`, filtering, wire metadata, and the file/symlink/dir/special dispatch from
+/// that single authoritative snapshot — there is no second path stat. This closes the double-stat
+/// TOCTOU window where a root *kind* swap (e.g. dir→file) between the `has_root_item` decision and
+/// the dispatch could announce `has_root_item: true` yet send no root message, hanging the
+/// destination. Wire metadata comes from the fd-pinned classification (Guarantee 2) and the file /
+/// symlink reads are fd-relative `O_NOFOLLOW` (Guarantee 1).
+#[instrument(skip(error_collector, stream_pool, control_send_stream, source_read))]
+async fn send_root_hardened(
+    settings: &common::copy::Settings,
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    control_send_stream: remote::streams::BoxedSharedSendStream,
+    stream_pool: std::sync::Arc<AcceptingSendStreamPool>,
+    error_collector: std::sync::Arc<common::error_collector::ErrorCollector>,
+    source_read: SourceRead,
+) -> anyhow::Result<()> {
+    use common::preserve::Metadata as _;
+    use common::walk::EntryKind;
+    let dir_map = source_read
+        .dir_map()
+        .expect("hardened source_read carries an fd-map")
+        .clone();
+    // open the trusted parent prefix and classify the root ONCE (O_PATH | O_NOFOLLOW + fstat).
+    let (parent, name) = open_root_parent(src).await?;
+    let handle = match parent.child(&name).await {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::error!("Failed reading metadata from src {src:?}: {e:#}");
+            // root classification failure is fatal (matches the old root stat failure).
+            return Err(e.into());
+        }
+    };
+    let kind = handle.kind();
+    let meta = remote::protocol::Metadata::from(handle.meta());
+    // has_root_item from the authoritative kind: specials never produce a message; otherwise the
+    // root-item filter decides (anchored patterns match inside the source, not the root itself).
+    let has_root_item = match kind {
+        EntryKind::Special => false,
+        _ => match &settings.filter {
+            Some(filter) => {
+                let file_name = src.file_name().map(std::path::Path::new).unwrap_or(src);
+                matches!(
+                    filter.should_include_root_item(file_name, kind == EntryKind::Dir),
+                    common::filter::FilterResult::Included
+                )
+            }
+            None => true,
+        },
+    };
+    // ── pre-DirStructureComplete: send the root directory tree / symlink (NOT the file) ──
+    match kind {
+        EntryKind::Dir if has_root_item => {
+            // open the dir O_NOFOLLOW from the parent fd and descend via the fd-walk engine. On an
+            // open failure (e.g. a swap to a non-dir between classify and open) emit a 0-entry
+            // Directory + tombstone so the destination still completes (no hang), mirroring the
+            // nested unreadable-directory path.
+            match parent.open_dir(&name).await {
+                Ok(dir) => {
+                    if let Err(e) = send_directory_fd_walk(
+                        settings,
+                        src,
+                        dst,
+                        src, // source_root is src for the root item
+                        true,
+                        Arc::new(dir),
+                        &control_send_stream,
+                        &error_collector,
+                        &dir_map,
+                    )
+                    .await
+                    {
+                        // a root-directory walk failure is ALWAYS fatal, even in non-fail-early mode
+                        // (protocol §3.3 Root Item Failure Invariant). The walk returns Err only on a
+                        // pre-`Directory`-commit failure (root metadata read / fd-map insert) or a
+                        // transport failure; collected nested child errors keep it Ok (compensated by
+                        // per-child `FileSkipped`s), so there is no "collect and continue" case here.
+                        // Continuing would send `DirStructureComplete { has_root_item: true }` with no
+                        // root `Directory` committed, hanging the destination forever on `root_complete`.
+                        tracing::error!("Failed to send root directory {src:?}: {e:#}");
+                        return Err(e);
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("Cannot open root directory {src:?} for reading: {e:#}");
+                    send_unreadable_directory(
+                        src,
+                        dst,
+                        meta.clone(),
+                        true,
+                        &control_send_stream,
+                        &error_collector,
+                        settings.fail_early,
+                        e.into(),
+                        Some(&dir_map),
+                        None,
+                    )
+                    .await?;
+                }
+            }
+        }
+        EntryKind::Symlink if has_root_item => {
+            // read the target AND metadata inode-exact from the one pinned handle (`read_symlink`),
+            // so a same-name symlink swap can't pair one link's target with another link's
+            // owner/timestamps — target and metadata are a faithful pair, matching the file path. A
+            // swap to a non-symlink fails the read and is accounted as skipped.
+            match handle.read_symlink(parent.side()).await {
+                Ok((target, sym_meta)) => {
+                    let symlink = remote::protocol::SourceMessage::Symlink {
+                        src: src.to_path_buf(),
+                        dst: dst.to_path_buf(),
+                        target,
+                        metadata: remote::protocol::Metadata::from(&sym_meta),
+                        is_root: true,
+                    };
+                    control_send_stream
+                        .lock()
+                        .await
+                        .send_batch_message(&symlink)
+                        .await?;
+                }
+                Err(e) => {
+                    let e: anyhow::Error = e.into();
+                    tracing::error!("Failed reading root symlink {src:?}: {e:#}");
+                    send_symlink_skipped(src, dst, true, &control_send_stream).await?;
+                    if settings.fail_early {
+                        return Err(e);
+                    }
+                    error_collector.push(e);
+                }
+            }
+        }
+        EntryKind::Special if !settings.skip_specials => {
+            let err = anyhow::anyhow!(
+                "copy: {src:?} -> {dst:?} failed, unsupported src file type (special file)"
+            );
+            tracing::error!("{:#}", &err);
+            // a special root with no --skip-specials is fatal (matches the path-based body).
+            return Err(err);
+        }
+        EntryKind::Special => {
+            progress().specials_skipped.inc();
+        }
+        // filtered-out dir/symlink: account the skip. The root file is handled after
+        // DirStructureComplete (its data rides the file stream).
+        EntryKind::Dir | EntryKind::Symlink => {
+            kind.inc_skipped(progress());
+        }
+        EntryKind::File => {}
+    }
+    // ── DirStructureComplete ──
+    control_send_stream
+        .lock()
+        .await
+        .send_control_message(&remote::protocol::SourceMessage::DirStructureComplete {
+            has_root_item,
+        })
+        .await?;
+    // ── post-DirStructureComplete: the root file's data (fd-relative, O_NOFOLLOW) ──
+    if kind == EntryKind::File {
+        if !has_root_item {
+            progress().files_skipped.inc();
+        } else if let Err(e) = send_file_tcp(
+            settings,
+            src,
+            dst,
+            handle.meta().size(),
+            meta,
+            true,
+            stream_pool,
+            &error_collector,
+            control_send_stream.clone(),
+            FileRead::Hardened(parent, name),
+        )
+        .await
+        {
+            tracing::error!("Failed to send root file: {e:#}");
+            // nothing else to transfer; returning the error avoids a protocol hang.
+            return Err(e);
+        }
+    }
+    Ok(())
+}
+
+/// How a single file's DATA is opened for sending.
+///
+/// This is the file-open analogue of [`SourceRead`]: the hardened/path choice is a
+/// type, not a nullable handle, so there is no ambiguous "hardened but no handle"
+/// state at this seam. Hardened Pass 2 always holds the directory's `Arc<Dir>` (it
+/// took the owned [`MapEntry`]), so it always constructs [`FileRead::Hardened`];
+/// only the `-L` walk (which follows symlinks by design) constructs
+/// [`FileRead::Path`]. The hardened root file is read via [`FileRead::Hardened`]
+/// in [`send_root_hardened`]. The hardened-miss fail-closed decision is made once,
+/// earlier, in the dispatch loop — not re-litigated per file.
+enum FileRead {
+    /// Open fd-relative from the directory's held fd via `open_file_read(name)`
+    /// (TOCTOU-safe: `O_NOFOLLOW` + `S_ISREG`, no path re-resolution).
+    Hardened(Arc<Dir>, std::ffi::OsString),
+    /// Path-based `File::open(src)`: the `-L`/`--dereference` walk (follows symlinks by design).
+    Path,
+}
+
+#[instrument(skip(error_collector, control_send_stream, stream_pool, file_read))]
 #[async_recursion]
 #[allow(clippy::too_many_arguments)]
 async fn send_file_tcp(
     settings: &common::copy::Settings,
     src: &std::path::Path,
     dst: &std::path::Path,
-    src_metadata: &std::fs::Metadata,
+    size: u64,
+    metadata: remote::protocol::Metadata,
     is_root: bool,
     stream_pool: std::sync::Arc<AcceptingSendStreamPool>,
     error_collector: &std::sync::Arc<common::error_collector::ErrorCollector>,
     control_send_stream: remote::streams::BoxedSharedSendStream,
+    // how to open this file's data: fd-relative (hardened) or by path (`-L`).
+    file_read: FileRead,
 ) -> anyhow::Result<()> {
     let prog = progress();
     let _ops_guard = prog.ops.guard();
@@ -502,20 +1410,28 @@ async fn send_file_tcp(
     let _open_file_guard = throttle::open_file_permit()
         .instrument(tracing::trace_span!("open_file_permit"))
         .await;
-    throttle::get_file_iops_tokens(settings.chunk_size, src_metadata.len())
-        .instrument(tracing::trace_span!(
-            "iops_throttle",
-            size = src_metadata.len()
-        ))
+    throttle::get_file_iops_tokens(settings.chunk_size, size)
+        .instrument(tracing::trace_span!("iops_throttle", size))
         .await;
-    // open the file AFTER borrowing a stream for backpressure
-    let file = match common::walk::run_metadata_probed(
-        common::Side::Source,
-        common::MetadataOp::Stat,
-        tokio::fs::File::open(src).instrument(tracing::trace_span!("file_open")),
-    )
-    .await
-    {
+    // open the file AFTER borrowing a stream for backpressure. on the hardened path
+    // open fd-relative (O_NOFOLLOW + S_ISREG, no path re-resolution) so a concurrent
+    // symlink swap can't redirect the read; the path-based open is only for the
+    // `-L`/`--dereference` walk (which follows symlinks by design).
+    let open_result = match &file_read {
+        FileRead::Hardened(dir, name) => dir
+            .open_file_read(name)
+            .instrument(tracing::trace_span!("file_open"))
+            .await
+            .map(|(file, meta)| (tokio::fs::File::from_std(file), Some(meta))),
+        FileRead::Path => common::walk::run_metadata_probed(
+            common::Side::Source,
+            common::MetadataOp::Stat,
+            tokio::fs::File::open(src).instrument(tracing::trace_span!("file_open")), // rcp-toctou-allow: -L path (dereference, documented not hardened)
+        )
+        .await
+        .map(|file| (file, None)),
+    };
+    let (file, read_meta) = match open_result {
         Ok(f) => f,
         Err(e) => {
             tracing::error!("Failed to open file {src:?}: {e:#}");
@@ -551,34 +1467,43 @@ async fn send_file_tcp(
             return Ok(());
         }
     };
+    // Permission/ownership fidelity (Guarantee 2, docs/tocttou.md): the wire header must
+    // describe the bytes we actually send. On the hardened path the data fd was opened
+    // fd-relative by name, so a concurrent same-name swap can change which regular file it
+    // resolves to; derive size + metadata (mode/owner/times) from THAT fd's fstat, not the
+    // Pass-1 classification, so the destination never writes one file's contents under
+    // another's size/mode and the stream honors the "exactly size bytes" invariant. The
+    // `-L`/root path keeps its caller-supplied values (read_meta is None).
+    let (size, metadata) = match &read_meta {
+        Some(meta) => {
+            use common::preserve::Metadata as _;
+            (meta.size(), remote::protocol::Metadata::from(meta))
+        }
+        None => (size, metadata),
+    };
     // wrap file in a buffered reader for better network throughput
     // buffer size is set by tcp_config.effective_remote_copy_buffer_size() based on network profile,
     // but capped at file size to avoid over-allocation for small files
-    let file_size = src_metadata.len().min(usize::MAX as u64) as usize;
+    let file_size = size.min(usize::MAX as u64) as usize;
     let buffer_size = settings.remote_copy_buffer_size.min(file_size).max(1);
     let mut buffered_file = tokio::io::BufReader::with_capacity(buffer_size, file);
-    let metadata = remote::protocol::Metadata::from(src_metadata);
     let file_header = remote::protocol::File {
         src: src.to_path_buf(),
         dst: dst.to_path_buf(),
-        size: src_metadata.len(),
+        size,
         metadata,
         is_root,
     };
     let send_result = pooled_stream
         .stream_mut()
         .send_message_with_data_buffered(&file_header, &mut buffered_file)
-        .instrument(tracing::trace_span!(
-            "send_data",
-            size = src_metadata.len(),
-            buffer_size
-        ))
+        .instrument(tracing::trace_span!("send_data", size, buffer_size))
         .await;
     match send_result {
         Ok(_bytes_sent) => {
             // stream is returned to pool when pooled_stream is dropped
             prog.files_copied.inc();
-            prog.bytes_copied.add(src_metadata.len());
+            prog.bytes_copied.add(size);
             tracing::info!("Sent file: {:?} -> {:?}", src, dst);
             Ok(())
         }
@@ -597,129 +1522,347 @@ async fn send_file_tcp(
     }
 }
 
-#[instrument(skip(error_collector, control_send_stream, stream_pool, pending_limit))]
+/// A file selected for sending in Pass 2, with its size and wire metadata already
+/// resolved (from an fd-pinned `FileMeta` on the hardened path, or a path
+/// `std::fs::Metadata` on the `-L` fallback). `name` lets the data open go
+/// fd-relative against the held source directory.
+struct FileToSend {
+    src_path: std::path::PathBuf,
+    dst_path: std::path::PathBuf,
+    name: std::ffi::OsString,
+    size: u64,
+    metadata: remote::protocol::Metadata,
+}
+
+/// The owned input to Pass 2 for one directory. Ownership is linear: the dispatch
+/// loop consumes the directory's map entry (or builds the dereference variant) and
+/// moves the result into the spawned Pass-2 task — there is no clone-and-leave +
+/// deferred RAII cleanup.
+///
+/// - [`Pass2Source::Hardened`] carries the owned [`MapEntry`]: its `Arc<Dir>` (when
+///   present) lets the file data opens go fd-relative, its `file_count` is the
+///   authoritative Pass-1 count, and its held fd-budget permit is released when the
+///   entry drops at the end of Pass 2 (the entry is owned by the task for its whole
+///   lifetime). For a *tombstone* (committed-but-unreadable directory) the entry is a
+///   [`MapEntry::Tombstone`] (no fd, file count 0), so Pass 2 returns immediately,
+///   sending no files and needing no fd.
+/// - [`Pass2Source::DereferencePath`] carries only the `file_count` recovered from
+///   the source-side `-L` count map: the `-L` walk holds no directory fd and
+///   re-enumerates by path (unchanged).
+enum Pass2Source {
+    Hardened(MapEntry),
+    DereferencePath { file_count: usize },
+}
+
+impl Pass2Source {
+    /// The authoritative expected file count for this directory: the Pass-1 count
+    /// stored in the map entry (hardened) or recovered from the `-L` count map.
+    fn file_count(&self) -> usize {
+        match self {
+            Pass2Source::Hardened(MapEntry::Readable { file_count, .. }) => *file_count,
+            Pass2Source::Hardened(MapEntry::Tombstone) => 0,
+            Pass2Source::DereferencePath { file_count } => *file_count,
+        }
+    }
+
+    /// The held source directory fd for fd-relative file opens, or `None` under
+    /// `-L` (path-based enumeration) and for a hardened tombstone (no fd, 0 files).
+    fn dir(&self) -> Option<&Arc<Dir>> {
+        match self {
+            Pass2Source::Hardened(MapEntry::Readable { dir, .. }) => Some(dir),
+            Pass2Source::Hardened(MapEntry::Tombstone) => None,
+            Pass2Source::DereferencePath { .. } => None,
+        }
+    }
+}
+
+/// Resolve the owned Pass-2 input for a `DirectoryCreated { src, dst }`, applying
+/// the hardened fail-closed rule. This is the TOCTOU-safety seam. The destination
+/// no longer echoes a file count, so the count is recovered source-side: from the
+/// consumed map entry (hardened) or the `-L` count map (dereference).
+///
+/// - `SourceRead::Hardened`: CONSUME the directory's held fd-map entry (one-shot
+///   ownership) and use its stored Pass-1 `file_count`. The entry may be a real
+///   held-fd entry or a tombstone (committed-but-unreadable directory, `dir: None`,
+///   `file_count: 0`) — both are legitimately committed entries, so both are
+///   consumed normally. On a MISS — the entry is gone (never inserted, or already
+///   consumed by a prior `DirectoryCreated` for the same `src`) — FAIL CLOSED: this
+///   is a TOCTOU-safety / protocol-invariant violation, so close the fd-budget (so
+///   a Pass-1 walk parked on it unblocks and the whole copy tears down cleanly) and
+///   return an error. NEVER fall back to a path-based read.
+/// - `SourceRead::DereferencePath`: the `-L` walk holds no fd. Recover the Pass-1
+///   count from the `path → file_count` map. A missing entry is treated as count 0
+///   with a debug log — `-L` is intentionally NOT hardened, so a miss is not a
+///   TOCTOU/fail-closed condition (the destination's `entries_expected` is the
+///   Pass-1 count, and Pass 2 does not re-count). The entry is CONSUMED (removed),
+///   mirroring the hardened one-shot lifecycle — a directory's files are requested
+///   exactly once, so this bounds the map's memory during large dereference copies.
+fn resolve_pass2_source(
+    source_read: &SourceRead,
+    src: &std::path::Path,
+) -> anyhow::Result<Pass2Source> {
+    match source_read {
+        SourceRead::Hardened(map) => match map.take_for_created(src) {
+            Some(entry) => Ok(Pass2Source::Hardened(entry)),
+            None => {
+                let err = anyhow::anyhow!(
+                    "hardened source read: no held directory fd for {src:?} on DirectoryCreated \
+                     (TOCTOU-safety violation: refusing to re-resolve by path)"
+                );
+                tracing::error!("{:#}", &err);
+                map.close_fd_budget();
+                Err(err)
+            }
+        },
+        SourceRead::DereferencePath(counts) => {
+            let file_count = counts.lock().unwrap().remove(src).unwrap_or_else(|| {
+                tracing::debug!(
+                    "no recorded -L file count for {src:?} on DirectoryCreated; defaulting to 0 \
+                     (dereference path is not hardened, so this is not a fail-closed condition)"
+                );
+                0
+            });
+            Ok(Pass2Source::DereferencePath { file_count })
+        }
+    }
+}
+
+/// Handle Pass 2 failing to read a directory it committed to: emit a synthetic
+/// `FileSkipped` for every expected file so the destination's per-directory tally
+/// still reaches zero and it can complete, then propagate per the `fail_early`
+/// policy. Shared by the hardened and path-based enumeration paths.
+async fn send_files_missing_directory(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    file_count: usize,
+    settings: &common::copy::Settings,
+    error_collector: &std::sync::Arc<common::error_collector::ErrorCollector>,
+    control_send_stream: &remote::streams::BoxedSharedSendStream,
+    err: anyhow::Error,
+) -> anyhow::Result<()> {
+    for i in 0..file_count {
+        let skip_msg = remote::protocol::SourceMessage::FileSkipped {
+            src: src.join(format!("<missing-{i}>")),
+            dst: dst.join(format!("<missing-{i}>")),
+        };
+        control_send_stream
+            .lock()
+            .await
+            .send_batch_message(&skip_msg)
+            .await?;
+    }
+    if settings.fail_early {
+        // Defense-in-depth: the FileSkipped messages above let the destination
+        // tally to zero and emit DestinationDone, which can race with the Err
+        // return below and cause the shutdown drain in
+        // dispatch_control_messages_tcp to swallow this task's error. Push a
+        // formatted copy into the collector so run_source's take_error() catches
+        // it, keeping the original chain in the Err return.
+        error_collector.push(anyhow::anyhow!("{err:#}"));
+        return Err(err);
+    }
+    error_collector.push(err);
+    Ok(())
+}
+
+#[instrument(skip(
+    error_collector,
+    control_send_stream,
+    stream_pool,
+    pending_limit,
+    pass2_source
+))]
 #[allow(clippy::too_many_arguments)]
 async fn send_files_in_directory_tcp(
     settings: common::copy::Settings,
     src: std::path::PathBuf,
     dst: std::path::PathBuf,
     source_root: std::path::PathBuf,
-    file_count: usize,
+    // owned Pass-2 input: the held map entry (hardened) or the `-L` file count
+    // recovered from the source-side count map. Carries the authoritative
+    // `file_count` and, in hardened mode, the held `Dir` fd used to open file DATA
+    // fd-relative (None for a tombstone, which has 0 files). The owned entry's
+    // fd-budget permit is released when this function returns (entry dropped here).
+    pass2_source: Pass2Source,
     stream_pool: std::sync::Arc<AcceptingSendStreamPool>,
     pending_limit: std::sync::Arc<tokio::sync::Semaphore>,
     error_collector: std::sync::Arc<common::error_collector::ErrorCollector>,
     control_send_stream: remote::streams::BoxedSharedSendStream,
 ) -> anyhow::Result<()> {
+    // the Pass-1 count is authoritative for this directory's send logic (truncation
+    // and synthetic `FileSkipped`). It comes entirely from the source side now (the
+    // consumed map entry or the `-L` count map); the destination echoes nothing.
+    let file_count = pass2_source.file_count();
+    let src_dir = pass2_source.dir();
     tracing::info!(
         "Sending files from {src:?} (expected file_count={})",
         file_count
     );
-    // if no files expected, nothing to do
+    // if no files expected, nothing to do (the owned entry, if any, drops here,
+    // releasing its dir-fd-in-flight permit back to Pass 1)
     if file_count == 0 {
         return Ok(());
     }
     // iterate directory and collect files to send
-    let mut file_entries: Vec<(std::path::PathBuf, std::path::PathBuf, std::fs::Metadata)> =
-        Vec::new();
-    let mut entries = match tokio::fs::read_dir(&src).await {
-        Ok(e) => e,
-        Err(e) => {
-            tracing::error!("Cannot open directory {src:?} for reading: {e:#}");
-            // send synthetic FileSkipped for all expected files so destination can complete
-            for i in 0..file_count {
-                let skip_msg = remote::protocol::SourceMessage::FileSkipped {
-                    src: src.join(format!("<missing-{i}>")),
-                    dst: dst.join(format!("<missing-{i}>")),
-                };
-                control_send_stream
-                    .lock()
-                    .await
-                    .send_batch_message(&skip_msg)
-                    .await?;
-            }
-            if settings.fail_early {
-                // Same defense-in-depth as the file-open branch in
-                // send_file_tcp: the FileSkipped messages above let the
-                // destination tally to zero and emit DestinationDone,
-                // which can race with the Err return below and cause the
-                // shutdown drain in dispatch_control_messages_tcp to
-                // swallow this task's error. Push a copy into the
-                // collector so run_source's take_error() catches it.
-                let err: anyhow::Error = e.into();
-                error_collector.push(anyhow::anyhow!("{err:#}"));
-                return Err(err);
-            }
-            error_collector.push(e.into());
-            return Ok(());
-        }
-    };
-    loop {
-        match common::walk::next_entry_probed(&mut entries, common::Side::Source, || {
-            format!("failed traversing src directory {:?}", &src)
-        })
-        .await
-        {
-            Ok(Some((entry, _file_type))) => {
-                let entry_path = entry.path();
-                let entry_name = entry_path.file_name().unwrap();
-                let dst_path = dst.join(entry_name);
-                let entry_metadata = match common::walk::run_metadata_probed(
-                    common::Side::Source,
-                    common::MetadataOp::Stat,
-                    async {
-                        if settings.dereference {
-                            tokio::fs::metadata(&entry_path).await
-                        } else {
-                            tokio::fs::symlink_metadata(&entry_path).await
-                        }
-                    },
+    let mut file_entries: Vec<FileToSend> = Vec::new();
+    if let Some(dir) = src_dir {
+        // hardened enumeration: list + classify fd-relative (never follows a symlink).
+        let raw_entries = match dir.read_entries().await {
+            Ok(entries) => entries,
+            Err(e) => {
+                tracing::error!("Cannot enumerate directory {src:?} for reading: {e:#}");
+                return send_files_missing_directory(
+                    &src,
+                    &dst,
+                    file_count,
+                    &settings,
+                    &error_collector,
+                    &control_send_stream,
+                    e.into(),
                 )
-                .await
-                {
-                    Ok(m) => m,
-                    Err(e) => {
-                        tracing::error!("Failed reading metadata from {entry_path:?}: {e:#}");
-                        if settings.fail_early {
-                            return Err(e.into());
-                        }
-                        error_collector.push(e.into());
+                .await;
+            }
+        };
+        for (entry_name, _hint) in raw_entries {
+            let entry_path = src.join(&entry_name);
+            let dst_path = dst.join(&entry_name);
+            let handle = match dir.child(&entry_name).await {
+                Ok(h) => h,
+                Err(e) => {
+                    let e: anyhow::Error = e.into();
+                    tracing::error!("Failed reading metadata from {entry_path:?}: {e:#}");
+                    if settings.fail_early {
+                        return Err(e);
+                    }
+                    error_collector.push(e);
+                    continue;
+                }
+            };
+            if handle.kind() != common::walk::EntryKind::File {
+                continue;
+            }
+            // apply filter if configured
+            if let Some(ref filter) = settings.filter {
+                let relative_path = common::walk::relative_to_root(&entry_path, &source_root);
+                match filter.should_include(relative_path, false) {
+                    common::filter::FilterResult::Included => { /* proceed */ }
+                    result => {
+                        tracing::debug!(
+                            "Filtered out file {:?} (relative: {:?}): {:?}",
+                            entry_path,
+                            relative_path,
+                            result
+                        );
+                        progress().files_skipped.inc();
                         continue;
                     }
-                };
-                if entry_metadata.is_file() {
-                    // apply filter if configured
-                    if let Some(ref filter) = settings.filter {
-                        let relative_path =
-                            entry_path.strip_prefix(&source_root).unwrap_or(&entry_path);
-                        match filter.should_include(relative_path, false) {
-                            common::filter::FilterResult::Included => { /* proceed */ }
-                            result => {
-                                tracing::debug!(
-                                    "Filtered out file {:?} (relative: {:?}): {:?}",
-                                    entry_path,
-                                    relative_path,
-                                    result
-                                );
-                                progress().files_skipped.inc();
-                                continue;
+                }
+            }
+            let meta = handle.meta();
+            file_entries.push(FileToSend {
+                src_path: entry_path,
+                dst_path,
+                name: entry_name,
+                size: {
+                    use common::preserve::Metadata as _;
+                    meta.size()
+                },
+                metadata: remote::protocol::Metadata::from(meta),
+            });
+        }
+    } else {
+        // path-based enumeration (`-L`/--dereference): unchanged from the original
+        // behavior — nested symlink following is intentionally not hardened.
+        let mut entries = match tokio::fs::read_dir(&src).await {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::error!("Cannot open directory {src:?} for reading: {e:#}");
+                return send_files_missing_directory(
+                    &src,
+                    &dst,
+                    file_count,
+                    &settings,
+                    &error_collector,
+                    &control_send_stream,
+                    e.into(),
+                )
+                .await;
+            }
+        };
+        loop {
+            match common::walk::next_entry_probed(&mut entries, common::Side::Source, || {
+                format!("failed traversing src directory {:?}", &src)
+            })
+            .await
+            {
+                Ok(Some((entry, _file_type))) => {
+                    let entry_path = entry.path();
+                    let entry_name = entry_path.file_name().unwrap().to_owned();
+                    let dst_path = dst.join(&entry_name);
+                    let entry_metadata = match common::walk::run_metadata_probed(
+                        common::Side::Source,
+                        common::MetadataOp::Stat,
+                        async {
+                            if settings.dereference {
+                                tokio::fs::metadata(&entry_path).await
+                            } else {
+                                tokio::fs::symlink_metadata(&entry_path).await
+                            }
+                        },
+                    )
+                    .await
+                    {
+                        Ok(m) => m,
+                        Err(e) => {
+                            tracing::error!("Failed reading metadata from {entry_path:?}: {e:#}");
+                            if settings.fail_early {
+                                return Err(e.into());
+                            }
+                            error_collector.push(e.into());
+                            continue;
+                        }
+                    };
+                    if entry_metadata.is_file() {
+                        // apply filter if configured
+                        if let Some(ref filter) = settings.filter {
+                            let relative_path =
+                                entry_path.strip_prefix(&source_root).unwrap_or(&entry_path);
+                            match filter.should_include(relative_path, false) {
+                                common::filter::FilterResult::Included => { /* proceed */ }
+                                result => {
+                                    tracing::debug!(
+                                        "Filtered out file {:?} (relative: {:?}): {:?}",
+                                        entry_path,
+                                        relative_path,
+                                        result
+                                    );
+                                    progress().files_skipped.inc();
+                                    continue;
+                                }
                             }
                         }
+                        file_entries.push(FileToSend {
+                            src_path: entry_path,
+                            dst_path,
+                            name: entry_name,
+                            size: entry_metadata.len(),
+                            metadata: remote::protocol::Metadata::from(&entry_metadata),
+                        });
                     }
-                    file_entries.push((entry_path, dst_path, entry_metadata));
                 }
-            }
-            Ok(None) => break,
-            Err(e) => {
-                tracing::error!("Failed traversing src directory {src:?}: {e:#}");
-                if settings.fail_early {
-                    return Err(e);
+                Ok(None) => break,
+                Err(e) => {
+                    tracing::error!("Failed traversing src directory {src:?}: {e:#}");
+                    if settings.fail_early {
+                        return Err(e);
+                    }
+                    error_collector.push(e);
+                    break;
                 }
-                error_collector.push(e);
-                break;
             }
         }
+        drop(entries);
     }
-    drop(entries);
     let files_found = file_entries.len();
     tracing::info!(
         "Directory {:?} has {} files to send (expected {})",
@@ -727,7 +1870,9 @@ async fn send_files_in_directory_tcp(
         files_found,
         file_count
     );
-    // handle discrepancy between expected file_count and actual files found
+    // handle discrepancy between the authoritative (Pass-1) file_count and the
+    // files actually found at send time (the directory may have changed since the
+    // Pass-1 pre-read)
     if files_found > file_count {
         // extra files appeared since traversal - only send up to file_count
         tracing::warn!(
@@ -748,7 +1893,7 @@ async fn send_files_in_directory_tcp(
     let files_to_send = file_entries.len();
     // send the files
     let mut join_set = tokio::task::JoinSet::new();
-    for (entry_path, dst_path, entry_metadata) in file_entries {
+    for file in file_entries {
         throttle::get_ops_token().await;
         // wait for a pending slot - this is the main backpressure point
         let permit = pending_limit
@@ -760,16 +1905,32 @@ async fn send_files_in_directory_tcp(
         let collector = error_collector.clone();
         let control_stream = control_send_stream.clone();
         let settings = settings.clone();
+        // on the hardened path, open file data fd-relative against the held source
+        // directory (clone the Arc per file so all spawned tasks share the one fd).
+        // in `-L` mode there is no held fd, so the data open is by path.
+        let file_read = match src_dir {
+            Some(dir) => FileRead::Hardened(dir.clone(), file.name.clone()),
+            None => FileRead::Path,
+        };
+        let FileToSend {
+            src_path,
+            dst_path,
+            size,
+            metadata,
+            ..
+        } = file;
         join_set.spawn(async move {
             let result = send_file_tcp(
                 &settings,
-                &entry_path,
+                &src_path,
                 &dst_path,
-                &entry_metadata,
+                size,
+                metadata,
                 false,
                 pool,
                 &collector,
                 control_stream,
+                file_read,
             )
             .await;
             drop(permit); // release permit when file is done
@@ -860,7 +2021,8 @@ enum RecvResult {
     stream_pool,
     control_recv_stream,
     control_send_stream,
-    pool_shutdown
+    pool_shutdown,
+    source_read
 ))]
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_control_messages_tcp(
@@ -872,6 +2034,10 @@ async fn dispatch_control_messages_tcp(
     max_pending_files: usize,
     error_collector: std::sync::Arc<common::error_collector::ErrorCollector>,
     pool_shutdown: PoolShutdownToken,
+    // explicit source read mode. In hardened mode each directory's `DirectoryCreated`
+    // consumes the held fd-map entry (the owned `Dir` + permit) for Pass 2 and a miss
+    // fails closed; under `-L` there is no fd-map and Pass 2 re-enumerates by path.
+    source_read: SourceRead,
 ) -> anyhow::Result<()> {
     // create semaphore to limit pending file tasks for backpressure
     let pending_limit = std::sync::Arc::new(tokio::sync::Semaphore::new(max_pending_files));
@@ -945,14 +2111,23 @@ async fn dispatch_control_messages_tcp(
                     remote::protocol::DestinationMessage::DirectoryCreated {
                         ref src,
                         ref dst,
-                        file_count,
                     } => {
                         tracing::info!(
-                            "Received directory creation confirmation for: {:?} -> {:?} (file_count={})",
+                            "Received directory creation confirmation for: {:?} -> {:?}",
                             src,
-                            dst,
-                            file_count
+                            dst
                         );
+                        // build the owned Pass-2 input. In hardened mode this CONSUMES the
+                        // directory's held fd-map entry (one-shot ownership) and fails closed
+                        // on a miss (see `resolve_pass2_source`); the owned `Dir` + permit
+                        // then move into the spawned task. The file count is recovered
+                        // source-side (map entry or `-L` count map) — no wire echo.
+                        let pass2_source = match resolve_pass2_source(&source_read, src) {
+                            Ok(source) => source,
+                            // fail closed: the fd-budget was already closed inside the helper
+                            // to unblock any parked Pass-1 walk; abort the dispatch loop.
+                            Err(e) => break Err(e),
+                        };
                         let collector = error_collector.clone();
                         let settings = settings.clone();
                         join_set.spawn(send_files_in_directory_tcp(
@@ -960,12 +2135,48 @@ async fn dispatch_control_messages_tcp(
                             src.clone(),
                             dst.clone(),
                             source_root.clone(),
-                            file_count,
+                            pass2_source,
                             stream_pool.clone(),
                             pending_limit.clone(),
                             collector,
                             control_send_stream.clone(),
                         ));
+                    }
+                    remote::protocol::DestinationMessage::DirectorySkipped {
+                        ref src,
+                        ref dst,
+                    } => {
+                        tracing::info!(
+                            "Received directory skipped for: {:?} -> {:?}",
+                            src,
+                            dst
+                        );
+                        // the destination did not create this directory and will not
+                        // request its files, so Pass 2 never runs for it. Consume this
+                        // directory's Pass-1 bookkeeping now — the nack that matches the
+                        // Pass-1 insert — so a no-ack subtree doesn't accumulate to
+                        // connection-end. Unlike a `DirectoryCreated` miss this does not
+                        // fail closed: there is nothing TOCTOU-sensitive to do and an
+                        // absent/double nack is at worst a benign protocol-invariant
+                        // violation we just log.
+                        match &source_read {
+                            // hardened: drop the held fd-map entry (releasing its dir-fd
+                            // budget permit, keeping the budget deadlock-free).
+                            SourceRead::Hardened(map) => {
+                                if !map.take_for_skipped(src) {
+                                    tracing::warn!(
+                                        "DirectorySkipped for {src:?} but no held directory fd present \
+                                         (absent or duplicate nack — protocol-invariant violation under trusted rcpd)"
+                                    );
+                                }
+                            }
+                            // -L: no fd is held, but Pass 1 recorded a count entry; remove it
+                            // here so a skipped subtree's counts don't grow until the connection
+                            // ends (mirrors the DirectoryCreated consume + the hardened nack).
+                            SourceRead::DereferencePath(counts) => {
+                                counts.lock().unwrap().remove(src);
+                            }
+                        }
                     }
                     remote::protocol::DestinationMessage::DestinationDone => {
                         tracing::info!("Received DestinationDone message");
@@ -1244,6 +2455,21 @@ async fn handle_connection(
         "Created accepting send stream pool with {} slots",
         pool_size
     );
+    // explicit source read mode (Phase 5a, hardened TOCTOU-safe file reads). Hardened
+    // unless dereferencing: with `-L` the walk must follow nested symlinks, which the
+    // O_NOFOLLOW fd primitives intentionally don't (that path stays as-is, matching
+    // local copy). The hardened fd-map is shared (via the `Arc` inside `SourceRead`)
+    // between Pass 1 (`send_fs_objects_tcp`, below) and Pass 2 (spawned inside
+    // dispatch from each `DirectoryCreated`). Its dir-fd-in-flight budget bounds how
+    // far the unthrottled Pass-1 walk can race ahead of the network-paced Pass 2
+    // (prevents EMFILE); sized like the file pending-writes pool. The `-L` variant
+    // instead carries a shared `path → file_count` map so Pass 2 can recover each
+    // directory's Pass-1 count (the destination no longer echoes it over the wire).
+    let source_read = if settings.dereference {
+        SourceRead::DereferencePath(Arc::new(std::sync::Mutex::new(HashMap::new())))
+    } else {
+        SourceRead::Hardened(Arc::new(SourceDirMap::new(max_pending_files)))
+    };
     // pass a clone of the shutdown token to dispatch - it will signal shutdown before
     // draining its tasks to prevent deadlock when destination closes unexpectedly.
     // see dispatch_control_messages_tcp doc comment for detailed shutdown flow.
@@ -1256,6 +2482,7 @@ async fn handle_connection(
         max_pending_files,
         error_collector.clone(),
         pool_shutdown.clone(),
+        source_read.clone(),
     ));
     // send files to destination. returns Err only for fatal errors (e.g., root file failure).
     // individual file failures with fail_early=false return Ok but push errors to collector,
@@ -1267,6 +2494,7 @@ async fn handle_connection(
         control_send_stream,
         stream_pool,
         error_collector.clone(),
+        source_read,
     )
     .await;
     // if send failed, we need to close the pool FIRST so destination's data connections
@@ -1386,7 +2614,7 @@ async fn dry_run_traverse(
         let target = match common::walk::run_metadata_probed(
             common::Side::Source,
             common::MetadataOp::ReadLink,
-            tokio::fs::read_link(src),
+            tokio::fs::read_link(src), // rcp-toctou-allow: -L path (dereference, documented not hardened)
         )
         .await
         {

--- a/rcp/tests/cli_parsing_tests.rs
+++ b/rcp/tests/cli_parsing_tests.rs
@@ -671,3 +671,133 @@ fn test_remote_copy_timeout() {
         .assert()
         .success();
 }
+
+// ============================================================================
+// TOCTOU Safety Flag Tests
+// ============================================================================
+
+/// Test that --toctou-check exits without performing the copy
+#[test]
+fn toctou_check_exits_without_operating() {
+    // should exit (with any code) without needing valid src/dst
+    let output = Command::cargo_bin("rcp")
+        .unwrap()
+        .args(["--toctou-check", "/nonexistent-src", "/nonexistent-dst"])
+        .output()
+        .expect("failed to run rcp");
+    // must not hang and must produce output about TOCTOU
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("TOCTOU"),
+        "expected TOCTOU verdict in stdout, got: {stdout}"
+    );
+    // prove it stopped at the linter and did NOT proceed into the copy: a
+    // --toctou-check verdict prints to stdout and exits before operating, so there
+    // is no operation-side error (e.g. about the nonexistent source) on stderr.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.is_empty(),
+        "--toctou-check must not proceed into operation (stderr should be empty), got: {stderr}"
+    );
+}
+
+/// Test that --toctou-check -L reports not safe
+#[test]
+fn toctou_check_with_dereference_reports_not_safe() {
+    let output = Command::cargo_bin("rcp")
+        .unwrap()
+        .args(["-L", "--toctou-check", "/tmp/src", "/tmp/dst"])
+        .output()
+        .expect("failed to run rcp");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("NOT SAFE"),
+        "expected NOT SAFE with -L, got: {stdout}"
+    );
+    assert!(
+        !output.status.success(),
+        "--toctou-check -L should exit non-zero"
+    );
+}
+
+/// Test that --toctou-check without -L reports safe on Linux
+#[cfg(target_os = "linux")]
+#[test]
+fn toctou_check_without_dereference_reports_safe_on_linux() {
+    let output = Command::cargo_bin("rcp")
+        .unwrap()
+        .args(["--toctou-check", "/tmp/src", "/tmp/dst"])
+        .output()
+        .expect("failed to run rcp");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // on Linux without -L the verdict should be SAFE
+    assert!(
+        stdout.contains("SAFE") && !stdout.contains("NOT SAFE"),
+        "expected SAFE (without NOT SAFE) on Linux without -L, got: {stdout}"
+    );
+    assert!(
+        output.status.success(),
+        "--toctou-check without -L should exit 0 on Linux"
+    );
+}
+
+/// Test that --require-toctou-safe -L refuses to run
+#[test]
+fn require_toctou_safe_refuses_with_dereference() {
+    let output = Command::cargo_bin("rcp")
+        .unwrap()
+        .args(["-L", "--require-toctou-safe", "/tmp/src", "/tmp/dst"])
+        .output()
+        .expect("failed to run rcp");
+    assert!(
+        !output.status.success(),
+        "--require-toctou-safe -L should exit non-zero"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Refusing") || stdout.contains("not TOCTOU-safe"),
+        "expected refusal message, got: {stdout}"
+    );
+}
+
+/// Test that --toctou-check and --require-toctou-safe conflict
+#[test]
+fn toctou_check_and_require_toctou_safe_conflict() {
+    Command::cargo_bin("rcp")
+        .unwrap()
+        .args([
+            "--toctou-check",
+            "--require-toctou-safe",
+            "/tmp/src",
+            "/tmp/dst",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--require-toctou-safe"));
+}
+
+/// `--max-connections=0` must be rejected: a zero-size connection pool / zero
+/// pending-file budget (`max_connections * multiplier`) would deadlock the remote
+/// source. Regression for PR #247 review — the nonzero parser was previously wired
+/// only to `--pending-writes-multiplier`, not `--max-connections`.
+#[test]
+fn test_max_connections_zero_rejected() {
+    Command::cargo_bin("rcp")
+        .unwrap()
+        .args(["--max-connections=0", "/tmp/src", "/tmp/dst"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("at least 1"));
+}
+
+/// `--pending-writes-multiplier=0` is likewise rejected (the sibling nonzero
+/// validation that was already wired — locked in here alongside max-connections).
+#[test]
+fn test_pending_writes_multiplier_zero_rejected() {
+    Command::cargo_bin("rcp")
+        .unwrap()
+        .args(["--pending-writes-multiplier=0", "/tmp/src", "/tmp/dst"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("at least 1"));
+}

--- a/rcp/tests/remote_tests.rs
+++ b/rcp/tests/remote_tests.rs
@@ -1358,6 +1358,185 @@ fn test_remote_copy_nested_directories_with_unreadable_files() {
     assert!(!output.status.success());
 }
 
+/// Returns true if this process can read a freshly-created `chmod 000` directory.
+/// That only happens when running effectively as root (which bypasses the rwx
+/// permission bits), in which case the unreadable-directory tests cannot reproduce
+/// the EACCES they rely on and must be skipped.
+fn can_read_unreadable_dir() -> bool {
+    let probe = tempfile::tempdir().unwrap();
+    let dir = probe.path().join("probe_000");
+    std::fs::create_dir(&dir).unwrap();
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let readable = std::fs::read_dir(&dir).is_ok();
+    // restore perms so the tempdir can be cleaned up
+    let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755));
+    readable
+}
+
+/// A root directory that EXISTS but is unreadable (`chmod 000`) must, in hardened
+/// mode WITHOUT `--fail-early`, produce an EMPTY destination directory and SUCCEED
+/// at the protocol level (an empty dir landed, only its contents could not be
+/// read), rather than aborting with a fail-closed "no held directory fd" error.
+///
+/// This exercises Change A (the unreadable-directory tombstone): the source can't
+/// open the root dir, sends a 0-entry `Directory`, and registers a tombstone so the
+/// destination's `DirectoryCreated` ack is consumed instead of hitting the
+/// fail-closed miss path. Before the tombstone fix this aborted the copy.
+#[test]
+fn test_remote_copy_unreadable_root_directory_continues() {
+    require_local_ssh();
+    if can_read_unreadable_dir() {
+        eprintln!(
+            "skipping test_remote_copy_unreadable_root_directory_continues: running as root, \
+             chmod 000 directories remain readable so EACCES cannot be reproduced"
+        );
+        return;
+    }
+    let (src_dir, dst_dir) = setup_test_env();
+    // a directory we own that exists but cannot be opened for reading: symlink_metadata
+    // still reports it as a directory (the source commits to sending it), but
+    // open_root_dir gets EACCES.
+    let src_subdir = src_dir.path().join("unreadable_root");
+    std::fs::create_dir(&src_subdir).unwrap();
+    create_test_file(&src_subdir.join("hidden.txt"), "cannot be read", 0o644);
+    std::fs::set_permissions(&src_subdir, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let dst_subdir = dst_dir.path().join("unreadable_root");
+    let src_remote = format!("localhost:{}", src_subdir.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_subdir.to_str().unwrap());
+    // without --fail-early: the unreadable directory becomes an empty destination
+    // directory and the copy reports a (partial) error for the unreadable dir, but
+    // must NOT hang or abort with a fail-closed "no held directory fd" error.
+    let output = run_rcp_with_args(&["--summary", &src_remote, &dst_remote]);
+    print_command_output(&output);
+    // restore perms so the source tempdir cleans up
+    let _ = std::fs::set_permissions(&src_subdir, std::fs::Permissions::from_mode(0o755));
+    // the empty destination directory must have been created (the empty dir "landed").
+    // it inherits the source's 0o000 mode, so make it readable before inspecting it.
+    assert!(
+        dst_subdir.is_dir(),
+        "destination directory should exist as an empty directory"
+    );
+    std::fs::set_permissions(&dst_subdir, std::fs::Permissions::from_mode(0o755)).unwrap();
+    assert_eq!(
+        std::fs::read_dir(&dst_subdir).unwrap().count(),
+        0,
+        "destination directory should be empty (its contents were unreadable)"
+    );
+    // critically: the copy must not have hung / been killed by the timeout wrapper
+    // and must not have aborted with the fail-closed message. The unreadable dir is
+    // still reported as an error, so the exit code is non-zero, but the run completed.
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !combined.contains("no held directory fd"),
+        "copy must not fail closed for a committed unreadable directory (tombstone should be consumed)"
+    );
+}
+
+/// A counted-child `FileSkipped` received under a FAILED (untracked) parent must be
+/// a no-op on the destination, not abort the whole copy with "not being tracked".
+///
+/// Reproduces PR #247 review: the destination cannot create directory `conflict`
+/// because a NON-DIRECTORY already exists there and `--overwrite` is NOT set, so
+/// `conflict` lands in `failed_directories` (NOT `pending_directories`). The source
+/// meanwhile fails to `open_dir` the counted child `conflict/sub` (it is `chmod 000`)
+/// and emits a counted-child `FileSkipped` for it. That `FileSkipped` routes to
+/// `process_file(conflict)` on the destination. Before the fix this hit the
+/// fail-closed "directory {:?} not being tracked" path and aborted the destination
+/// mid-protocol (manifesting as an abort/hang); after the fix it is tolerated and the
+/// copy completes (reporting the non-fatal `conflict` non-directory error, exit != 0).
+#[test]
+fn test_remote_copy_file_skipped_under_failed_parent_does_not_abort() {
+    require_local_ssh();
+    if can_read_unreadable_dir() {
+        eprintln!(
+            "skipping test_remote_copy_file_skipped_under_failed_parent_does_not_abort: \
+             running as root, chmod 000 directories remain readable so EACCES cannot be reproduced"
+        );
+        return;
+    }
+    let (src_dir, dst_dir) = setup_test_env();
+    // source: a directory `conflict` whose ONLY child is the subdirectory `sub`
+    // (so `conflict`'s entry_count == 1, file_count == 0). `sub` is chmod 000 so the
+    // source's `open_dir("sub")` from `conflict`'s held fd fails EACCES at Pass-1,
+    // emitting a counted-child `FileSkipped` for `sub` under parent `conflict`.
+    let src_conflict = src_dir.path().join("conflict");
+    std::fs::create_dir(&src_conflict).unwrap();
+    let src_sub = src_conflict.join("sub");
+    std::fs::create_dir(&src_sub).unwrap();
+    create_test_file(&src_sub.join("hidden.txt"), "cannot be read", 0o644);
+    std::fs::set_permissions(&src_sub, std::fs::Permissions::from_mode(0o000)).unwrap();
+    // destination: pre-create `dst/` (a real directory) and `dst/conflict` as a FILE,
+    // so the destination's mkdir of `conflict` fails as a non-directory conflict and
+    // `conflict` is added to `failed_directories` (no `--overwrite`).
+    let dst_conflict = dst_dir.path().join("conflict");
+    create_test_file(&dst_conflict, "i am a file, not a directory", 0o644);
+    let src_remote = format!("localhost:{}", src_conflict.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_conflict.to_str().unwrap());
+    // default hardened mode (no --dereference), WITHOUT --overwrite, WITHOUT --fail-early.
+    let output = run_rcp_with_args(&["--summary", &src_remote, &dst_remote]);
+    print_command_output(&output);
+    // restore perms so the source tempdir cleans up
+    let _ = std::fs::set_permissions(&src_sub, std::fs::Permissions::from_mode(0o755));
+    // the run must have completed (not hung / killed by the timeout wrapper — already
+    // asserted in run_rcp_with_args_internal) and must NOT have aborted the destination
+    // mid-protocol with the pre-fix "not being tracked" message.
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !combined.contains("not being tracked"),
+        "destination must tolerate a FileSkipped under a failed parent, not abort with \
+         'not being tracked'. Combined output:\n{combined}"
+    );
+    // the non-directory `conflict` conflict is still a (non-fatal) error, so exit != 0.
+    assert!(
+        !output.status.success(),
+        "the non-directory conflict should still be reported as an error (exit != 0)"
+    );
+}
+
+/// Dereference (`-L`) copy of a directory tree, exercising the source-side `-L`
+/// `path → file_count` map introduced in Change B (the destination no longer echoes
+/// the count, so `-L` must retain its own Pass-1 count for each directory). The
+/// directory is reached through a symlink and must be copied as a real directory
+/// with all files present.
+#[test]
+fn test_remote_copy_dereference_directory_tree() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    // a real directory tree with nested files...
+    let target_dir = src_dir.path().join("real_tree");
+    std::fs::create_dir(&target_dir).unwrap();
+    create_test_file(&target_dir.join("a.txt"), "alpha", 0o644);
+    create_test_file(&target_dir.join("b.txt"), "bravo", 0o644);
+    let nested = target_dir.join("nested");
+    std::fs::create_dir(&nested).unwrap();
+    create_test_file(&nested.join("c.txt"), "charlie", 0o644);
+    // ...reached through a symlink, so -L must follow it and copy a directory.
+    let link = src_dir.path().join("tree_link");
+    std::os::unix::fs::symlink(&target_dir, &link).unwrap();
+    let dst_path = dst_dir.path().join("copied_tree");
+    let src_remote = format!("localhost:{}", link.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_path.to_str().unwrap());
+    let output = run_rcp_and_expect_success(&["-L", "--summary", &src_remote, &dst_remote]);
+    // result is a real directory tree, not a symlink
+    assert!(dst_path.is_dir());
+    assert!(!dst_path.is_symlink());
+    assert_eq!(get_file_content(&dst_path.join("a.txt")), "alpha");
+    assert_eq!(get_file_content(&dst_path.join("b.txt")), "bravo");
+    assert_eq!(get_file_content(&dst_path.join("nested/c.txt")), "charlie");
+    // 3 files across 2 directories (root + nested) copied
+    let summary = parse_summary_from_output(&output).expect("Failed to parse summary");
+    assert_eq!(summary.files_copied, 3);
+    assert_eq!(summary.directories_created, 2);
+}
+
 #[test]
 fn test_remote_copy_mixed_success_with_symlink_errors() {
     require_local_ssh();
@@ -4765,4 +4944,460 @@ fn test_remote_auto_meta_throttle_flags_propagate_to_rcpd() {
             );
         }
     }
+}
+
+// ── TOCTOU source hardening (Phase 5a) ──────────────────────────────────────────
+
+/// The remote SOURCE must not dereference a nested symlink to read file DATA on
+/// the default (non-`-L`) path. A directory child that is a symlink to an
+/// out-of-tree sentinel regular file must be copied AS a symlink — its target's
+/// bytes must never be streamed into a destination regular file.
+///
+/// This exercises the source-side fd-map's classification: Pass 1 opens the child
+/// `O_NOFOLLOW` and `fstat`s it, so a symlink is a symlink (never a File), and the
+/// sentinel is never opened for data. (With `-L` the symlink would be followed —
+/// that path is intentionally not hardened and is covered by the dereference
+/// tests above.)
+#[test]
+fn test_remote_source_nested_symlink_not_dereferenced_for_data() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    // out-of-tree sentinel: content that must never reach the destination as data.
+    let sentinel = src_dir.path().join("sentinel_secret.txt");
+    create_test_file(&sentinel, "TOP-SECRET-SENTINEL", 0o600);
+    // source subtree we actually copy
+    let src_subdir = src_dir.path().join("tree");
+    std::fs::create_dir(&src_subdir).unwrap();
+    let real_file = src_subdir.join("real.txt");
+    create_test_file(&real_file, "real data", 0o644);
+    // a child symlink pointing at the out-of-tree sentinel
+    let link = src_subdir.join("link_to_secret");
+    std::os::unix::fs::symlink(&sentinel, &link).unwrap();
+    let dst_subdir = dst_dir.path().join("tree");
+    let src_remote = format!("localhost:{}", src_subdir.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_subdir.to_str().unwrap());
+    run_rcp_and_expect_success(&[&src_remote, &dst_remote]);
+    // the real file copies through unchanged
+    let dst_real = dst_subdir.join("real.txt");
+    assert_eq!(get_file_content(&dst_real), "real data");
+    // the symlink is preserved as a symlink; the sentinel's bytes are NOT copied
+    // into a regular destination file.
+    let dst_link = dst_subdir.join("link_to_secret");
+    assert!(
+        dst_link.is_symlink(),
+        "nested symlink must be copied as a symlink, not dereferenced for data"
+    );
+    assert!(
+        !std::fs::symlink_metadata(&dst_link).unwrap().is_file(),
+        "sentinel content must never be written as a destination regular file"
+    );
+}
+
+/// Best-effort race test: while a remote copy runs, rapidly swap a source file
+/// between a real regular file and a symlink-to-sentinel. The source must never
+/// transfer the sentinel's content — either it reads the real file, or the
+/// fd-relative `O_NOFOLLOW` open fails closed and the entry is skipped.
+///
+/// NOTE: this is a best-effort race (the source runs as a separate subprocess over
+/// SSH, so we can't deterministically hit the Pass-2 open window). A leaked
+/// sentinel is a true-positive failure; a clean run is the expected outcome. The
+/// deterministic guarantee is covered by
+/// `test_remote_source_nested_symlink_not_dereferenced_for_data`.
+#[test]
+fn test_remote_source_file_swap_never_transfers_sentinel() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let sentinel = src_dir.path().join("sentinel_secret.txt");
+    create_test_file(&sentinel, "TOP-SECRET-SENTINEL", 0o600);
+    let src_subdir = src_dir.path().join("tree");
+    std::fs::create_dir(&src_subdir).unwrap();
+    // a bed of real files so the copy has work to do (widens the race window).
+    for i in 0..200 {
+        create_test_file(&src_subdir.join(format!("f{i}.txt")), "real data", 0o644);
+    }
+    // the entry we race: starts as a real file.
+    let target = src_subdir.join("racer.txt");
+    create_test_file(&target, "real racer", 0o644);
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop_thread = stop.clone();
+    let target_thread = target.clone();
+    let sentinel_thread = sentinel.clone();
+    let swapper = std::thread::spawn(move || {
+        let mut as_link = false;
+        while !stop_thread.load(std::sync::atomic::Ordering::Relaxed) {
+            let _ = std::fs::remove_file(&target_thread);
+            if as_link {
+                let _ = std::os::unix::fs::symlink(&sentinel_thread, &target_thread);
+            } else {
+                let _ = std::fs::write(&target_thread, "real racer");
+            }
+            as_link = !as_link;
+        }
+        // leave it as a real file for a clean final state
+        let _ = std::fs::remove_file(&target_thread);
+        let _ = std::fs::write(&target_thread, "real racer");
+    });
+    let dst_subdir = dst_dir.path().join("tree");
+    let src_remote = format!("localhost:{}", src_subdir.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_subdir.to_str().unwrap());
+    // run several iterations to widen the chance of hitting the swap window.
+    for _ in 0..3 {
+        let _ = std::fs::remove_dir_all(&dst_subdir);
+        let _ = run_rcp_with_args(&[&src_remote, &dst_remote]);
+        // whatever landed at the destination for `racer.txt`, it must not be the
+        // sentinel content. it may be the real content, a symlink, or absent.
+        let dst_racer = dst_subdir.join("racer.txt");
+        if let Ok(meta) = std::fs::symlink_metadata(&dst_racer)
+            && meta.is_file()
+            && let Ok(content) = std::fs::read_to_string(&dst_racer)
+        {
+            assert_ne!(
+                content, "TOP-SECRET-SENTINEL",
+                "source transferred out-of-tree sentinel content via a symlink swap"
+            );
+        }
+    }
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    swapper.join().unwrap();
+}
+
+/// The remote source must not dereference a ROOT symlink for data: a root operand that is a symlink
+/// to an out-of-tree sentinel is copied as a symlink (read fd-relative via its trusted parent),
+/// never followed to write the sentinel's bytes as a destination regular file. Deterministic
+/// companion to `test_remote_source_root_file_swap_never_transfers_sentinel`, exercising the
+/// hardened root-symlink read.
+#[test]
+fn test_remote_source_root_symlink_not_dereferenced_for_data() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let sentinel = src_dir.path().join("sentinel_secret.txt");
+    create_test_file(&sentinel, "TOP-SECRET-SENTINEL", 0o600);
+    // the ROOT operand itself is a symlink to the out-of-tree sentinel.
+    let root_link = src_dir.path().join("root_link");
+    std::os::unix::fs::symlink(&sentinel, &root_link).unwrap();
+    let dst = dst_dir.path().join("out");
+    let src_remote = format!("localhost:{}", root_link.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst.to_str().unwrap());
+    run_rcp_and_expect_success(&[&src_remote, &dst_remote]);
+    // copied as a symlink, NOT dereferenced into a destination regular file of sentinel bytes.
+    assert!(
+        dst.is_symlink(),
+        "root symlink must be copied as a symlink, not dereferenced for data"
+    );
+    assert!(
+        !std::fs::symlink_metadata(&dst).unwrap().is_file(),
+        "sentinel content must never be written as a destination regular file"
+    );
+}
+
+// NOTE: there is deliberately no best-effort root-FILE swap race test (analogous to
+// `test_remote_source_file_swap_never_transfers_sentinel` for nested files). When a swap lands
+// during the root open, the hardened `open_file_read` correctly fails closed — but a root failure
+// returns `Err` and the destination then waits for the never-arriving root data until a transport
+// timeout (the pre-existing "root failure → Err" design; nested failures skip fast instead). That
+// makes such a test slow and flaky under concurrent load without adding coverage: the root file now
+// uses the same `open_file_read` primitive as nested files (swap-tested above and unit-tested in
+// `safedir`), and every existing root-file copy test now exercises the hardened root read.
+
+/// Regression for the source fd-map deadlock: a no-ack destination subtree larger
+/// than the source's dir-fd budget must NOT hang the copy.
+///
+/// The source-side fd-map gates Pass 1 with a dir-fd-in-flight semaphore. Pass 2's
+/// `MapEntryGuard` releases a permit only for directories the destination acks with
+/// `DirectoryCreated`. A directory the destination skips (here: its destination path
+/// is blocked by a pre-existing non-directory, so `create_directory` fails and every
+/// descendant is skipped as a failed-ancestor) sends no `DirectoryCreated`. Before
+/// the fix those skipped directories held their Pass-1 permits forever, so once the
+/// no-ack subtree exceeded the budget, Pass 1 blocked on `insert().await`,
+/// `DirStructureComplete` was never sent, and the whole copy hung. The fix is the
+/// `DirectorySkipped` nack: the destination sends exactly one ack/nack per
+/// `Directory`, and the source releases the permit on nack too.
+///
+/// We shrink the budget with `--max-connections 2 --pending-writes-multiplier 2`
+/// (budget = 4) and make the blocked subtree 16 directories (> budget), so the
+/// deadlock is deterministic without the fix. Bounding: the test harness wraps rcp
+/// in `timeout 90`; a hang trips that (exit 124) and `assert_not_timeout` (inside
+/// `run_rcp_with_args`) fails the test, so an unfixed build FAILS rather than
+/// hanging the suite forever. A fixed build completes in ~1s.
+#[test]
+fn test_remote_source_no_ack_subtree_over_budget_does_not_hang() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    // source: root/ with a real file, a copyable sibling subtree, and a `blocked`
+    // subtree holding > budget directories (budget below is 4).
+    let src_root = src_dir.path().join("root");
+    std::fs::create_dir(&src_root).unwrap();
+    create_test_file(&src_root.join("top.txt"), "top content", 0o644);
+    // sibling subtree that must copy fine
+    let src_ok = src_root.join("ok");
+    std::fs::create_dir(&src_ok).unwrap();
+    create_test_file(&src_ok.join("ok.txt"), "ok content", 0o644);
+    // blocked subtree: 16 directories (flat fan-out), each with a file so Pass 1
+    // definitely inserts a held fd per directory.
+    let src_blocked = src_root.join("blocked");
+    std::fs::create_dir(&src_blocked).unwrap();
+    let blocked_dir_count = 16usize;
+    for i in 0..blocked_dir_count {
+        let d = src_blocked.join(format!("d{i}"));
+        std::fs::create_dir(&d).unwrap();
+        create_test_file(&d.join("inner.txt"), "inner", 0o644);
+    }
+    // destination: pre-create root/ as a real dir, but block root/blocked with a
+    // pre-existing REGULAR FILE so the destination cannot create it (no --overwrite).
+    let dst_root = dst_dir.path().join("root");
+    std::fs::create_dir(&dst_root).unwrap();
+    create_test_file(&dst_root.join("blocked"), "i am a file, not a dir", 0o644);
+    let src_remote = format!("localhost:{}", src_root.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_root.to_str().unwrap());
+    // shrink the dir-fd budget to 4 (2 * 2) so 16 no-ack dirs exceed it.
+    // default mode (no -L); fail_early off so the copy proceeds past the blocked dir.
+    let output = run_rcp_with_args(&[
+        "--max-connections",
+        "2",
+        "--pending-writes-multiplier",
+        "2",
+        &src_remote,
+        &dst_remote,
+    ]);
+    print_command_output(&output);
+    // the copy must COMPLETE (the harness already failed us on a 90s timeout/hang).
+    // it exits non-zero because the blocked dir is a real error, but it must not hang.
+    // the sibling subtree and the top-level file must have copied.
+    assert_eq!(get_file_content(&dst_root.join("top.txt")), "top content");
+    assert_eq!(get_file_content(&dst_root.join("ok/ok.txt")), "ok content");
+    // the blocked path stays the pre-existing regular file (subtree skipped).
+    assert!(
+        dst_root.join("blocked").is_file(),
+        "blocked destination path should remain the pre-existing file"
+    );
+    assert!(
+        !dst_root.join("blocked").join("d0").exists(),
+        "blocked subtree must not have been copied"
+    );
+}
+
+/// Regression for the SOURCE skip-accounting deadlock (PR #247 review): a counted
+/// child directory that the source FAILS TO OPEN mid fd-walk must not hang the copy.
+///
+/// On the hardened (non-`-L`) remote source walk, `send_directory_fd_walk`
+/// pre-reads each directory's children and tallies every child (including
+/// subdirectories) into the parent's `Directory { entry_count }`. A subdirectory is
+/// classified via the parent's fd (`fstatat`, which succeeds even for a `0o000`
+/// child), so it IS counted — but the later `dir.open_dir(child)` fails with EACCES
+/// for a `0o000` directory. Before the fix that failure only recorded an error and
+/// `continue`d, emitting NO protocol message for the counted child, so the
+/// destination's `DirectoryTracker` for the parent waited forever for that entry →
+/// `complete_directory` never fired → `DestinationDone` was never sent → the copy
+/// HUNG. The fix emits a `FileSkipped` for the unprocessable child so the parent's
+/// expected-entry count still reaches zero.
+///
+/// Here `blocked/` holds 16 subdirectories all mode `0o000`: each is counted in
+/// `blocked/`'s `entry_count` but every `open_dir` fails. Bounding/determinism is
+/// the same as the budget test: the harness wraps rcp in `timeout 90`, so an
+/// unfixed build trips the timeout (exit 124) and `assert_not_timeout` fails the
+/// test rather than hanging the suite; a fixed build completes in ~1s with the rest
+/// of the tree copied.
+#[test]
+fn test_remote_source_counted_child_open_failure_does_not_hang() {
+    require_local_ssh();
+    // root bypasses directory permission bits, so a `0o000` dir would still open and
+    // the counted-child-open-failure path would not be exercised. Skip under root.
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: running as root, cannot make a directory unopenable to self");
+        return;
+    }
+    let (src_dir, dst_dir) = setup_test_env();
+    // source: root/ with a top-level file, a sibling subtree that must copy fine,
+    // and `blocked/` whose children are all counted but un-openable.
+    let src_root = src_dir.path().join("root");
+    std::fs::create_dir(&src_root).unwrap();
+    create_test_file(&src_root.join("top.txt"), "top content", 0o644);
+    let src_ok = src_root.join("ok");
+    std::fs::create_dir(&src_ok).unwrap();
+    create_test_file(&src_ok.join("ok.txt"), "ok content", 0o644);
+    // `blocked/` is itself readable (so the source enumerates and counts its
+    // children), but each child directory is mode 0o000 so `open_dir` fails EACCES.
+    let src_blocked = src_root.join("blocked");
+    std::fs::create_dir(&src_blocked).unwrap();
+    let blocked_dir_count = 16usize;
+    let mut unopenable: Vec<std::path::PathBuf> = Vec::new();
+    for i in 0..blocked_dir_count {
+        let d = src_blocked.join(format!("d{i}"));
+        std::fs::create_dir(&d).unwrap();
+        // put a file inside so, were the dir openable, there'd be content to send —
+        // it must never be reached because the dir itself cannot be opened.
+        create_test_file(&d.join("inner.txt"), "inner", 0o644);
+        std::fs::set_permissions(&d, std::fs::Permissions::from_mode(0o000)).unwrap();
+        unopenable.push(d);
+    }
+    let src_remote = format!("localhost:{}", src_root.to_str().unwrap());
+    let dst_remote = format!(
+        "localhost:{}",
+        dst_dir.path().join("root").to_str().unwrap()
+    );
+    // default mode (no -L → hardened fd-walk); fail_early off so the copy proceeds
+    // past the un-openable children and must still COMPLETE.
+    let output = run_rcp_with_args(&[&src_remote, &dst_remote]);
+    print_command_output(&output);
+    // restore permissions so the TempDir cleanup can remove the 0o000 directories.
+    for d in &unopenable {
+        let _ = std::fs::set_permissions(d, std::fs::Permissions::from_mode(0o755));
+    }
+    // the copy must COMPLETE (the harness already failed us on a 90s timeout/hang).
+    // it exits non-zero because the un-openable dirs are real errors, but it must not
+    // hang. The top-level file and the sibling subtree must have copied.
+    let dst_root = dst_dir.path().join("root");
+    assert_eq!(get_file_content(&dst_root.join("top.txt")), "top content");
+    assert_eq!(get_file_content(&dst_root.join("ok/ok.txt")), "ok content");
+    // the un-openable children's contents must NOT have been transferred.
+    assert!(
+        !dst_root
+            .join("blocked")
+            .join("d0")
+            .join("inner.txt")
+            .exists(),
+        "contents of an un-openable source directory must not have been copied"
+    );
+    assert!(
+        !output.status.success(),
+        "copy should report a non-zero exit because some source dirs could not be opened"
+    );
+}
+
+/// TOCTOU hardening (Scenario 2 — destination write-escape): a symlink planted at an
+/// intermediate DESTINATION directory path must NOT be followed when the remote `rcpd`
+/// destination creates the subtree under it. The destination opens each tracked directory
+/// `O_NOFOLLOW|O_DIRECTORY` and creates children fd-relative on that pinned fd, so a
+/// directory-position-occupied-by-a-symlink fails closed (ELOOP/ENOTDIR) rather than letting
+/// the privileged destination write files into the symlink's out-of-tree target.
+///
+/// This is the deterministic, pre-planted-symlink form of the race (a live mid-copy swap is not
+/// reproducible through the subprocess harness): we plant the symlink before the copy, so the
+/// create path is guaranteed to encounter it. The assertion that matters is that NO file ever
+/// lands in the out-of-tree target directory.
+#[test]
+fn test_remote_dest_symlink_at_intermediate_dir_not_followed_out_of_tree() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    // out-of-tree sentinel directory: nothing must ever be written here.
+    let out_of_tree = tempfile::tempdir().unwrap();
+    // source tree:  root/sub/file.txt  (sub is a real directory at the source).
+    let src_root = src_dir.path().join("root");
+    let src_sub = src_root.join("sub");
+    std::fs::create_dir_all(&src_sub).unwrap();
+    create_test_file(
+        &src_sub.join("file.txt"),
+        "must stay in the dst tree",
+        0o644,
+    );
+    // destination: pre-create root/, then plant a SYMLINK where root/sub must go,
+    // pointing at the out-of-tree directory. If the destination followed it, the file
+    // would be written to out_of_tree/file.txt.
+    let dst_root = dst_dir.path().join("root");
+    std::fs::create_dir(&dst_root).unwrap();
+    let dst_sub_link = dst_root.join("sub");
+    std::os::unix::fs::symlink(out_of_tree.path(), &dst_sub_link).unwrap();
+    let src_remote = format!("localhost:{}", src_root.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_root.to_str().unwrap());
+    // no --overwrite: the destination must NOT replace the symlink, and crucially must
+    // not follow it. The copy fails (the symlinked dir position is a real error), but the
+    // harness already fails us on a hang/timeout, so a clean non-zero exit is fine.
+    let output = run_rcp_with_args(&[&src_remote, &dst_remote]);
+    print_command_output(&output);
+    // THE load-bearing assertion: the out-of-tree target was never written through.
+    assert!(
+        !out_of_tree.path().join("file.txt").exists(),
+        "file escaped the destination tree through a planted intermediate symlink \
+         (O_NOFOLLOW create was bypassed) — TOCTOU destination write-escape"
+    );
+    // the planted symlink itself must be untouched (not followed, not replaced without --overwrite).
+    assert!(
+        dst_sub_link.is_symlink(),
+        "planted intermediate symlink should remain a symlink (was not followed/replaced)"
+    );
+    // and no real file landed at the in-tree path either (the subtree was skipped, fail-closed).
+    assert!(
+        !dst_root.join("sub").join("file.txt").is_file()
+            || std::fs::symlink_metadata(dst_root.join("sub"))
+                .unwrap()
+                .is_symlink(),
+        "no regular file should have been created under the symlinked dst path"
+    );
+}
+
+/// Companion to the test above with `--overwrite`: even when the destination is allowed to
+/// REPLACE the planted intermediate symlink, the replacement is fd-relative and recheck-guarded
+/// (it removes the symlink itself via `unlink_at`, never following it), then creates a real
+/// directory in its place. The file must end up inside the destination tree, and NOTHING must
+/// ever be written to the symlink's out-of-tree target.
+#[test]
+fn test_remote_dest_overwrite_replaces_intermediate_symlink_in_tree() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let out_of_tree = tempfile::tempdir().unwrap();
+    let src_root = src_dir.path().join("root");
+    let src_sub = src_root.join("sub");
+    std::fs::create_dir_all(&src_sub).unwrap();
+    create_test_file(&src_sub.join("file.txt"), "lands in the dst tree", 0o644);
+    let dst_root = dst_dir.path().join("root");
+    std::fs::create_dir(&dst_root).unwrap();
+    let dst_sub_link = dst_root.join("sub");
+    std::os::unix::fs::symlink(out_of_tree.path(), &dst_sub_link).unwrap();
+    let src_remote = format!("localhost:{}", src_root.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_root.to_str().unwrap());
+    let output = run_rcp_and_expect_success(&["--overwrite", &src_remote, &dst_remote]);
+    print_command_output(&output);
+    // out-of-tree target must remain empty — the symlink was unlinked, never followed.
+    assert!(
+        !out_of_tree.path().join("file.txt").exists(),
+        "file escaped the destination tree through a replaced intermediate symlink"
+    );
+    // the dst path is now a real directory containing the copied file, inside the tree.
+    let dst_sub = dst_root.join("sub");
+    assert!(
+        dst_sub.is_dir() && !dst_sub.symlink_metadata().unwrap().is_symlink(),
+        "dst/sub should be replaced with a real directory"
+    );
+    assert_eq!(
+        get_file_content(&dst_sub.join("file.txt")),
+        "lands in the dst tree",
+        "copied file should land inside the destination tree"
+    );
+}
+
+/// TOCTOU hardening: a symlink planted where a destination FILE must be created must not be
+/// followed — the file's bytes must not be written through the symlink to its out-of-tree target.
+/// The destination creates files with `O_CREAT|O_EXCL|O_NOFOLLOW` relative to the parent's pinned
+/// fd, so a symlink occupying the file's name fails closed (EEXIST) without `--overwrite`.
+#[test]
+fn test_remote_dest_symlink_at_file_path_not_followed_out_of_tree() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let out_of_tree = tempfile::tempdir().unwrap();
+    let out_of_tree_target = out_of_tree.path().join("victim.txt");
+    // source: a single file root/data.txt
+    let src_root = src_dir.path().join("root");
+    std::fs::create_dir(&src_root).unwrap();
+    create_test_file(&src_root.join("data.txt"), "secret payload", 0o644);
+    // destination: plant a symlink at root/data.txt -> out-of-tree victim path.
+    let dst_root = dst_dir.path().join("root");
+    std::fs::create_dir(&dst_root).unwrap();
+    let dst_file_link = dst_root.join("data.txt");
+    std::os::unix::fs::symlink(&out_of_tree_target, &dst_file_link).unwrap();
+    let src_remote = format!("localhost:{}", src_root.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_root.to_str().unwrap());
+    // no --overwrite: create must fail closed (EEXIST via O_EXCL), never following the symlink.
+    let output = run_rcp_with_args(&[&src_remote, &dst_remote]);
+    print_command_output(&output);
+    // the out-of-tree victim path must never be created/written through the symlink.
+    assert!(
+        !out_of_tree_target.exists(),
+        "file data was written through a planted symlink to an out-of-tree path \
+         (O_EXCL|O_NOFOLLOW create was bypassed) — TOCTOU destination write-escape"
+    );
+    // the planted symlink is left intact (no --overwrite, and never followed).
+    assert!(
+        dst_file_link.is_symlink(),
+        "planted file-path symlink should remain a symlink"
+    );
 }

--- a/remote/src/protocol/mod.rs
+++ b/remote/src/protocol/mod.rs
@@ -123,6 +123,25 @@ impl From<&std::fs::Metadata> for Metadata {
     }
 }
 
+impl From<&common::safedir::FileMeta> for Metadata {
+    /// Build a wire `Metadata` from an fd-pinned [`common::safedir::FileMeta`]
+    /// snapshot (obtained via `fstat`/`fstatat` during a TOCTOU-safe walk),
+    /// reading every field through the shared `preserve::Metadata` trait so it
+    /// stays in lock-step with the `&std::fs::Metadata` conversion above.
+    fn from(meta: &common::safedir::FileMeta) -> Self {
+        use common::preserve::Metadata as _;
+        Metadata {
+            mode: meta.permissions().mode(),
+            uid: meta.uid(),
+            gid: meta.gid(),
+            atime: meta.atime(),
+            mtime: meta.mtime(),
+            atime_nsec: meta.atime_nsec(),
+            mtime_nsec: meta.mtime_nsec(),
+        }
+    }
+}
+
 /// File header sent on unidirectional streams, followed by raw file data.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct File {
@@ -180,8 +199,6 @@ pub enum SourceMessage {
         is_root: bool,
         /// total child entries (files + directories + symlinks) for completion tracking
         entry_count: usize,
-        /// number of child files, echoed back via `DirectoryCreated` for file sending
-        file_count: usize,
         /// whether to keep this directory if it ends up empty after filtering
         keep_if_empty: bool,
     },
@@ -219,13 +236,29 @@ pub struct SrcDst {
 /// Messages sent from destination to source on the control stream.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum DestinationMessage {
-    /// Confirm directory created, request file transfers.
-    /// `file_count` is echoed back from the `Directory` message so source knows
-    /// how many files to send from this directory.
+    /// Confirm directory created, request file transfers. This is purely the
+    /// Pass-2 trigger: it tells the source the destination created the directory
+    /// and is ready to receive its files. The source already retains the
+    /// authoritative Pass-1 file count for the directory (in its fd-map entry under
+    /// hardened reads, or in a path→count map under `-L`), so no count is echoed
+    /// back here.
     DirectoryCreated {
         src: std::path::PathBuf,
         dst: std::path::PathBuf,
-        file_count: usize,
+    },
+    /// Acknowledge a `Directory` message the destination did NOT create (create
+    /// failed, ancestor failed, or `--ignore-existing` skipped a non-directory).
+    /// No files will be requested for it. The destination sends exactly one of
+    /// `DirectoryCreated` / `DirectorySkipped` per `Directory` message so the
+    /// source can release the matching held directory fd (see the source-side
+    /// fd-map / dir-fd budget in `rcp::source`): without this nack a skipped
+    /// directory's Pass-1 permit would never be released, hanging large no-ack
+    /// subtrees. `src` keys the source-side fd-map entry to release (the map is
+    /// inserted under `src`; see `take_for_skipped`); `dst` is carried for
+    /// symmetry/logging.
+    DirectorySkipped {
+        src: std::path::PathBuf,
+        dst: std::path::PathBuf,
     },
     /// Signal destination has finished all operations.
     /// Initiates graceful shutdown via stream closure.

--- a/rlink/src/main.rs
+++ b/rlink/src/main.rs
@@ -155,6 +155,23 @@ struct Args {
     #[command(flatten)]
     common: common::cli::CommonArgs,
 
+    // TOCTOU safety
+    /// Print TOCTOU-safety verdict for this invocation and exit (0 = safe, 1 = not safe)
+    ///
+    /// Analyzes whether the invocation is hardened against symlink/path-swap races
+    /// and exits without performing the link operation.
+    #[arg(long, help_heading = "Security")]
+    toctou_check: bool,
+
+    /// Refuse to run unless the invocation uses the TOCTOU-hardened walk
+    ///
+    /// Refuses non-Linux builds (rlink has no --dereference). It does NOT verify the trust
+    /// of the operand path's prefix — that is the caller's responsibility (lock paths down
+    /// in the sudo rule). See "Scope of TOCTOU safety" in docs/tocttou.md. Intended for
+    /// sudo rules: `NOPASSWD: /usr/bin/rlink --require-toctou-safe *`.
+    #[arg(long, conflicts_with = "toctou_check", help_heading = "Security")]
+    require_toctou_safe: bool,
+
     // ARGUMENTS
     /// Directory with contents we want to update into `dst`
     #[arg()]
@@ -165,39 +182,38 @@ struct Args {
     dst: String, // must be a string to allow for parsing trailing slash
 }
 
-async fn async_main(args: Args) -> Result<common::link::Summary> {
-    for src in &args.src {
-        if src == "."
-            || src
-                .to_str()
-                .expect("input path cannot be converted to string?!")
-                .ends_with("/.")
-        {
-            return Err(anyhow!(
-                "expanding source directory ({:?}) using dot operator ('.') is not supported, please use absolute path or '*' instead",
-                std::path::PathBuf::from(src)
-            ));
-        }
-    }
-    let dst = if args.dst.ends_with('/') {
-        let src_file = args
-            .src
+/// Resolve the effective destination ROOT path that the link operation will
+/// create, applying the trailing-slash ("copy INTO this directory") rule: a `dst`
+/// ending in `/` means the source basename is appended (`dst/<src_basename>`),
+/// otherwise `dst` is used verbatim.
+///
+/// Resolve the destination root the operation writes to, applying the
+/// trailing-slash rule: for a trailing-slash invocation that root is
+/// `dst/<src_basename>`, otherwise it is `dst` itself.
+fn resolve_dst_root(src: &std::path::Path, dst: &str) -> Result<std::path::PathBuf> {
+    if dst.ends_with('/') {
+        let src_file = src
             .file_name()
-            .context(format!("source {:?} does not have a basename", &args.src))
-            .unwrap();
-        let dst_dir = std::path::PathBuf::from(args.dst);
-        dst_dir.join(src_file)
+            .context(format!("source {:?} does not have a basename", src))?;
+        Ok(std::path::PathBuf::from(dst).join(src_file))
     } else {
-        let dst_path = std::path::PathBuf::from(args.dst);
-        if dst_path.exists() && !(args.overwrite || args.delete) {
-            return Err(anyhow!(
-                "Destination path {dst_path:?} already exists! \n\
-                If you want to copy INTO it then follow the destination path with a trailing slash (/) or use \
-                --overwrite if you want to overwrite it"
-            ));
-        }
-        dst_path
-    };
+        Ok(std::path::PathBuf::from(dst))
+    }
+}
+
+async fn async_main(args: Args) -> Result<common::link::Summary> {
+    // `.`/`..` (and `dir/.`, `dir/..`) source operands are supported: `common::link` decomposes them
+    // via `split_root_operand` (canonicalizing `.`/`..`), so `rlink . dst` hard-links the current
+    // directory just like `rrm .`/`rchm .` already work. (`/` is rejected there.) Use a shell glob
+    // (`dir/*`) if you want to expand a directory's contents instead.
+    let dst = resolve_dst_root(&args.src, &args.dst)?;
+    if !args.dst.ends_with('/') && dst.exists() && !(args.overwrite || args.delete) {
+        return Err(anyhow!(
+            "Destination path {dst:?} already exists! \n\
+            If you want to copy INTO it then follow the destination path with a trailing slash (/) or use \
+            --overwrite if you want to overwrite it"
+        ));
+    }
     // parse preserve settings
     let preserve = if let Some(ref settings_str) = args.preserve_settings {
         common::parse_preserve_settings(settings_str)
@@ -263,6 +279,14 @@ async fn async_main(args: Args) -> Result<common::link::Summary> {
 
 fn main() -> Result<()> {
     let args = Args::parse();
+
+    // TOCTOU linter: must run before the async runtime starts.
+    // rlink has no --dereference flag; dereference is always false. The linter
+    // does NOT inspect the operand paths — the trust of a path's prefix is the
+    // caller's responsibility (see the "Scope of TOCTOU safety" section of
+    // docs/tocttou.md).
+    common::toctou_check::enforce_or_exit(false, args.toctou_check, args.require_toctou_safe);
+
     let dry_run_warnings = args.dry_run.map(|_| {
         common::DryRunWarnings::new(
             args.common.progress_requested(),

--- a/rlink/tests/cli_parsing_tests.rs
+++ b/rlink/tests/cli_parsing_tests.rs
@@ -268,3 +268,67 @@ fn test_preserve_settings_custom_value() {
         .assert()
         .success();
 }
+
+// ============================================================================
+// TOCTOU Safety Flag Tests
+// ============================================================================
+
+/// Test that --toctou-check exits without performing the link operation
+#[test]
+fn toctou_check_exits_without_operating() {
+    let output = Command::cargo_bin("rlink")
+        .unwrap()
+        .args(["--toctou-check", "/nonexistent-src", "/nonexistent-dst"])
+        .output()
+        .expect("failed to run rlink");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("TOCTOU"),
+        "expected TOCTOU verdict in stdout, got: {stdout}"
+    );
+    // prove it stopped at the linter and did NOT proceed into the link operation:
+    // a --toctou-check verdict prints to stdout and exits before operating, so
+    // there is no operation-side error (e.g. about the nonexistent source) on
+    // stderr.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.is_empty(),
+        "--toctou-check must not proceed into operation (stderr should be empty), got: {stderr}"
+    );
+}
+
+/// Test that --toctou-check reports safe on Linux (rlink has no --dereference)
+#[cfg(target_os = "linux")]
+#[test]
+fn toctou_check_reports_safe_on_linux() {
+    let output = Command::cargo_bin("rlink")
+        .unwrap()
+        .args(["--toctou-check", "/tmp/src", "/tmp/dst"])
+        .output()
+        .expect("failed to run rlink");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("SAFE") && !stdout.contains("NOT SAFE"),
+        "expected SAFE on Linux for rlink, got: {stdout}"
+    );
+    assert!(
+        output.status.success(),
+        "--toctou-check should exit 0 on Linux"
+    );
+}
+
+/// Test that --toctou-check and --require-toctou-safe conflict
+#[test]
+fn toctou_check_and_require_toctou_safe_conflict() {
+    Command::cargo_bin("rlink")
+        .unwrap()
+        .args([
+            "--toctou-check",
+            "--require-toctou-safe",
+            "/tmp/src",
+            "/tmp/dst",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--require-toctou-safe"));
+}

--- a/rlink/tests/delete.rs
+++ b/rlink/tests/delete.rs
@@ -299,11 +299,18 @@ fn delete_does_not_prune_through_dst_symlink() {
 }
 
 #[test]
-fn delete_excluded_update_type_change_to_excluded_dir_prunes_dst() {
+fn delete_excluded_update_type_change_to_excluded_dir_materializes_src_file() {
     // rlink --delete --delete-excluded --update where an update turns an included source FILE into
-    // an excluded DIRECTORY (`node/`). Nothing is materialized at dst/node, so a stale pre-existing
-    // dst/node must be pruned — the keep-set must reflect the materialized (update) type, not the
-    // source file type.
+    // a DIRECTORY excluded by `node/`. Under union (`--update`, not `--update-exclusive`) the
+    // update's excluded version of the name does NOT displace the src: an excluded update entry is
+    // treated as "no update at this name", so the src `node` FILE (which passed its own filter)
+    // stands and is materialized. The materialized `node` is in the keep-set, so --delete (even
+    // with --delete-excluded) must NOT prune it — pruning would delete the file we just linked.
+    //
+    // This is the corrected behavior from the PR #247 re-review: previously the type-mismatch
+    // branch unconditionally copied the excluded update directory (filter not re-checked against
+    // the update type), and the keep-set dropped `node`. Now the excluded update is dropped and the
+    // src file wins.
     let tmp = tempfile::tempdir().unwrap();
     let src = tmp.path().join("src");
     let upd = tmp.path().join("upd");
@@ -314,7 +321,7 @@ fn delete_excluded_update_type_change_to_excluded_dir_prunes_dst() {
     std::fs::create_dir(upd.join("node")).unwrap(); // update/node is a DIRECTORY (excluded by node/)
     std::fs::write(upd.join("node").join("inner.txt"), b"x").unwrap();
     std::fs::create_dir(&dst).unwrap();
-    std::fs::write(dst.join("node"), b"stale").unwrap(); // pre-existing dst/node
+    std::fs::write(dst.join("node"), b"stale").unwrap(); // pre-existing dst/node (overwritten)
 
     let status = Command::new(rlink_bin())
         .arg("--delete")
@@ -329,9 +336,15 @@ fn delete_excluded_update_type_change_to_excluded_dir_prunes_dst() {
         .unwrap();
     assert!(status.success());
 
+    // the src FILE stands (union); the excluded update directory leaves no leftover.
     assert!(
-        !dst.join("node").exists(),
-        "stale dst/node must be pruned: its materialized (update) type is an excluded directory"
+        dst.join("node").is_file(),
+        "src `node` file must be materialized when the update directory is excluded (union)"
+    );
+    assert_eq!(std::fs::read(dst.join("node")).unwrap(), b"file");
+    assert!(
+        !dst.join("node").join("inner.txt").exists(),
+        "the excluded update directory must not be copied"
     );
 }
 
@@ -548,4 +561,74 @@ fn missing_update_path_without_delete_or_exclusive_falls_back() {
         .unwrap();
     assert!(status.success());
     assert!(dst.join("a.txt").exists());
+}
+
+#[test]
+fn missing_update_path_with_absent_parent_without_delete_or_exclusive_falls_back() {
+    // Regression for PR #247 review: when the update path's PARENT directory is also absent
+    // (e.g. `rlink --update /tmp/no/such src dst` where `/tmp/no` doesn't exist), the prior code
+    // would fail with ENOENT from open_parent_dir before link_internal could apply the missing-
+    // update fallback. Verify that rlink proceeds by linking from src (no error) even when the
+    // update path's entire ancestor chain is missing.
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    // update path whose PARENT directory does not exist (two levels deep into non-existent space)
+    let missing_upd_deep = tmp.path().join("nonexistent_parent").join("also_missing");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"x").unwrap();
+    // intentionally do NOT pre-create dst (same reason as the sibling test above).
+
+    let output = Command::new(rlink_bin())
+        .arg("--update")
+        .arg(&missing_upd_deep)
+        .arg(&src)
+        .arg(&dst)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "rlink --update <path-with-absent-parent> should succeed (no-update fallback); stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        dst.join("a.txt").exists(),
+        "dst/a.txt must be linked from src when update falls back to no-update mode"
+    );
+}
+
+#[test]
+fn require_toctou_safe_with_missing_update_path_proceeds() {
+    // `--require-toctou-safe` must not reject a plain `--update` run whose update path (and its
+    // parent) is absent. The rationale shifted with the scope reframe (docs/tocttou.md "Scope of
+    // TOCTOU safety"): the linter now operates purely on the verdict (`!dereference && linux`) and
+    // no longer inspects operand paths at all, so a missing update path can never cause a refusal —
+    // this passes trivially. (It originally guarded against the removed trusted-prefix check, which
+    // would fail on the missing ancestor before the operation could apply its no-update fallback.)
+    let tmp = tempfile::tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    let missing_upd_deep = tmp.path().join("nonexistent_parent").join("also_missing");
+    std::fs::create_dir(&src).unwrap();
+    std::fs::write(src.join("a.txt"), b"x").unwrap();
+
+    let output = Command::new(rlink_bin())
+        .arg("--require-toctou-safe")
+        .arg("--update")
+        .arg(&missing_upd_deep)
+        .arg(&src)
+        .arg(&dst)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "--require-toctou-safe --update <path-with-absent-parent> must not be rejected by the \
+         linter (the update tree isn't traversed; plain --update falls back to no-update); \
+         stderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        dst.join("a.txt").exists(),
+        "dst/a.txt must be linked from src when the missing update falls back to no-update mode"
+    );
 }

--- a/rrm/src/main.rs
+++ b/rrm/src/main.rs
@@ -110,6 +110,23 @@ struct Args {
     #[command(flatten)]
     common: common::cli::CommonArgs,
 
+    // TOCTOU safety
+    /// Print TOCTOU-safety verdict for this invocation and exit (0 = safe, 1 = not safe)
+    ///
+    /// Analyzes whether the invocation is hardened against symlink/path-swap races
+    /// and exits without performing the removal operation.
+    #[arg(long, help_heading = "Security")]
+    toctou_check: bool,
+
+    /// Refuse to run unless the invocation uses the TOCTOU-hardened walk
+    ///
+    /// Refuses non-Linux builds (rrm has no --dereference). It does NOT verify the trust
+    /// of the operand path's prefix — that is the caller's responsibility (lock paths down
+    /// in the sudo rule). See "Scope of TOCTOU safety" in docs/tocttou.md. Intended for
+    /// sudo rules: `NOPASSWD: /usr/bin/rrm --require-toctou-safe *`.
+    #[arg(long, conflicts_with = "toctou_check", help_heading = "Security")]
+    require_toctou_safe: bool,
+
     // ARGUMENTS
     /// Path(s) to remove
     #[arg()]
@@ -209,6 +226,14 @@ fn main() -> Result<()> {
              rrm against glibc."
         ));
     }
+
+    // TOCTOU linter: must run before the async runtime starts.
+    // rrm has no --dereference flag; dereference is always false. The linter
+    // does NOT inspect the operand paths — the trust of a path's prefix is the
+    // caller's responsibility (see the "Scope of TOCTOU safety" section of
+    // docs/tocttou.md).
+    common::toctou_check::enforce_or_exit(false, args.toctou_check, args.require_toctou_safe);
+
     let dry_run_warnings = args.dry_run.map(|_| {
         common::DryRunWarnings::new(
             args.common.progress_requested(),

--- a/rrm/tests/cli_parsing_tests.rs
+++ b/rrm/tests/cli_parsing_tests.rs
@@ -286,3 +286,62 @@ fn rejects_created_before_on_musl() {
         ));
     let _ = std::fs::remove_dir_all(&tmp);
 }
+
+// ============================================================================
+// TOCTOU Safety Flag Tests
+// ============================================================================
+
+/// Test that --toctou-check exits without performing the removal
+#[test]
+fn toctou_check_exits_without_operating() {
+    let output = Command::cargo_bin("rrm")
+        .unwrap()
+        .args(["--toctou-check", "/nonexistent-path"])
+        .output()
+        .expect("failed to run rrm");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("TOCTOU"),
+        "expected TOCTOU verdict in stdout, got: {stdout}"
+    );
+    // prove it stopped at the linter and did NOT proceed into the removal: with a
+    // --toctou-check verdict the tool prints to stdout and exits before operating,
+    // so there is no operation-side error (e.g. "failed reading metadata" for the
+    // nonexistent path) on stderr.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.is_empty(),
+        "--toctou-check must not proceed into operation (stderr should be empty), got: {stderr}"
+    );
+}
+
+/// Test that --toctou-check reports safe on Linux (rrm has no --dereference)
+#[cfg(target_os = "linux")]
+#[test]
+fn toctou_check_reports_safe_on_linux() {
+    let output = Command::cargo_bin("rrm")
+        .unwrap()
+        .args(["--toctou-check", "/tmp"])
+        .output()
+        .expect("failed to run rrm");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("SAFE") && !stdout.contains("NOT SAFE"),
+        "expected SAFE on Linux for rrm, got: {stdout}"
+    );
+    assert!(
+        output.status.success(),
+        "--toctou-check should exit 0 on Linux"
+    );
+}
+
+/// Test that --toctou-check and --require-toctou-safe conflict
+#[test]
+fn toctou_check_and_require_toctou_safe_conflict() {
+    Command::cargo_bin("rrm")
+        .unwrap()
+        .args(["--toctou-check", "--require-toctou-safe", "/tmp"])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("--require-toctou-safe"));
+}

--- a/scripts/check-source-read-fidelity.sh
+++ b/scripts/check-source-read-fidelity.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Source-Read Fidelity Linter
+# Forbids reading a SOURCE object's payload by name/path in the hardened read modules — the vector
+# that desyncs payload from metadata (a same-name swap pairing one inode's bytes/target with another
+# inode's metadata). Source payload reads must go through the fd-paired primitives, so payload and
+# metadata come from the SAME fd:
+#   files    -> Dir::open_file_read(name) -> (File, FileMeta)
+#   symlinks -> Handle::read_symlink(side) -> (PathBuf, FileMeta)
+#   dirs     -> Dir::read_entries + Dir::meta (same fd)
+#
+# Legitimate exceptions — the `-L`/--dereference path-based walk (intentionally not hardened) and
+# destination-side reads — are marked inline with `// rcp-toctou-allow: <reason>` and skipped.
+#
+# Scope: non-test code only (lines before the first `#[cfg(test)]`; each scanned file keeps its unit
+# tests in a single module at the bottom, or has none).
+#
+# Uses only standard Unix tools (grep/head/cut) available in GitHub CI.
+
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+echo "🔍 Checking source-read fidelity (no by-name/path source payload reads)..."
+
+FILES="common/src/copy.rs common/src/link.rs rcp/src/source.rs"
+# the by-name / by-path SOURCE payload reads. NOT metadata/symlink_metadata: those have legitimate
+# dst-existence / -L / test uses and are not the drift vector (metadata pairing is structural).
+PATTERNS=".read_link_at( tokio::fs::read_link( tokio::fs::File::open( std::fs::File::open("
+MARKER="rcp-toctou-allow:"
+VIOLATIONS=0
+
+for file in $FILES; do
+    if [ ! -f "$file" ]; then
+        echo -e "${RED}ERROR: expected file not found: $file${NC}"
+        exit 1
+    fi
+    # non-test portion: lines before the first `#[cfg(test)]` (whole file if none).
+    cut_line=$(grep -n -m1 -F '#[cfg(test)]' "$file" | cut -d: -f1 || true)
+    if [ -n "$cut_line" ]; then
+        end=$((cut_line - 1))
+    else
+        end=$(wc -l < "$file")
+    fi
+    body=$(head -n "$end" "$file")
+    for pattern in $PATTERNS; do
+        # -F fixed string, -n line numbers; drop allow-marked lines; tolerate no-match under set -e.
+        hits=$(printf '%s\n' "$body" | grep -Fn -- "$pattern" | grep -vF "$MARKER" || true)
+        if [ -n "$hits" ]; then
+            echo -e "${RED}Unmarked source-payload-by-name read '$pattern' in $file:${NC}"
+            while IFS=: read -r n c; do
+                echo -e "  Line $n: ${YELLOW}$c${NC}"
+            done <<< "$hits"
+            VIOLATIONS=1
+        fi
+    done
+done
+
+if [ $VIOLATIONS -eq 1 ]; then
+    echo ""
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${RED}ERROR: a source object's payload is read by name/path in a hardened module${NC}"
+    echo ""
+    echo "Read source payloads through the fd-paired primitives so payload and metadata come from"
+    echo "the SAME fd: open_file_read (files), Handle::read_symlink (symlinks), read_entries +"
+    echo "Dir::meta (dirs). Otherwise a same-name swap can pair one inode's bytes/target with"
+    echo "another inode's metadata (a fidelity drift)."
+    echo ""
+    echo "If this read is genuinely safe (the -L/--dereference path, or a destination-side read),"
+    echo -e "append ${YELLOW}// rcp-toctou-allow: <reason>${NC} to the line."
+    echo "See docs/tocttou.md."
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ Source-read fidelity check passed!${NC}"
+exit 0

--- a/scripts/check-walk-driver-usage.sh
+++ b/scripts/check-walk-driver-usage.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Walk Driver Usage Linter
+# Ensures the single-tree tools (copy, chmod, rm) traverse directories ONLY via
+# the shared safe-walk driver (common/src/walk_driver.rs) and never hand-roll a
+# recursive walk. A hand-rolled walk is detected by the presence of `JoinSet`
+# (spawning child tasks) or `.read_entries(` (enumerating a directory) in the
+# tool's own module.
+#
+# Why: the recursive spawn/classify/permit/drop-before-recurse skeleton — and in
+# particular the leaf-permit "drop before recursion" deadlock invariant — lives in
+# exactly one place (the driver). Reintroducing a JoinSet or read_entries in a tool
+# would fork that skeleton and risk silently re-creating the hold-and-wait deadlock
+# class the driver was built to prevent.
+#
+# Exemptions:
+#   * common/src/link.rs        — rlink is the documented dual-tree special case
+#                                 (two correlated trees) and keeps its own walk
+#                                 while sharing the driver's substrate.
+#   * common/src/walk_driver.rs — where the shared walk legitimately lives.
+#
+# This script uses only standard Unix tools (grep) available in GitHub CI.
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "🔍 Checking walk-driver usage (no hand-rolled walks in copy/chmod/rm)..."
+
+VIOLATIONS_FOUND=0
+
+# Files that must traverse via the shared driver (NOT link.rs / walk_driver.rs).
+DRIVER_TOOLS="common/src/copy.rs common/src/chmod.rs common/src/rm.rs"
+
+# Patterns that indicate a hand-rolled directory walk.
+PATTERNS="JoinSet .read_entries("
+
+for file in $DRIVER_TOOLS; do
+    if [ ! -f "$file" ]; then
+        echo -e "${RED}ERROR: expected file not found: $file${NC}"
+        exit 1
+    fi
+    for pattern in $PATTERNS; do
+        # -F: fixed string, -n: line numbers; tolerate "no match" under `set -e`.
+        matches=$(grep -Fn -- "$pattern" "$file" || true)
+        if [ -n "$matches" ]; then
+            echo -e "${RED}Found hand-rolled-walk marker '$pattern' in $file:${NC}"
+            while IFS=: read -r line_num line_content; do
+                echo -e "  Line $line_num: ${YELLOW}$line_content${NC}"
+            done <<< "$matches"
+            VIOLATIONS_FOUND=1
+        fi
+    done
+done
+
+if [ $VIOLATIONS_FOUND -eq 1 ]; then
+    echo ""
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${RED}ERROR: Found a hand-rolled directory walk in a driver-backed tool${NC}"
+    echo -e "${RED}copy/chmod/rm must traverse via common/src/walk_driver.rs!${NC}"
+    echo ""
+    echo "These tools are WalkVisitor impls: implement the visitor hooks"
+    echo "(visit_leaf / dir_pre / dir_post / on_skip / ...) and let the driver own"
+    echo "the recursive spawn/classify/permit/drop-before-recurse skeleton."
+    echo ""
+    echo -e "Do NOT reintroduce ${RED}JoinSet${NC} or ${RED}.read_entries(${NC} here — that forks"
+    echo "the walk and risks re-creating the leaf-permit hold-and-wait deadlock."
+    echo ""
+    echo "rlink (common/src/link.rs) is the documented dual-tree exemption."
+    echo "See docs/tocttou.md and common/src/walk_driver.rs for details."
+    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ Walk-driver usage check passed!${NC}"
+exit 0


### PR DESCRIPTION
## Summary

Eliminates Time-of-Check-to-Time-of-Use (TOCTOU) symlink/path-swap races across the rcp tool suite, so a privileged run (e.g. root via a constrained `sudo` rule) traversing a tree a less-privileged actor can modify can no longer be redirected into reading, mis-permissioning, deleting, or writing objects outside the intended tree.

**Mechanism — a shared `common/src/safedir.rs` primitive:** hold the parent directory as an fd, derive each child via `openat(O_NOFOLLOW)`, classify by `fstat`-ing that fd, and perform every operation on a held fd or fd-relative `*at()` call. Replaces the previous `lstat`-then-path-operate pattern. A swapped-in symlink/FIFO/dir fails closed (`ELOOP`/`ENOTDIR`/`EINVAL`).

**Converted (all mutating paths, leaf + intermediate-component hardening on Linux):**
- `rcp` local copy, `rlink`, `rchm`, `rrm`, and `--delete` pruning.
- Remote `rcp`: source reads (two-pass `path→Dir` fd-map) and destination writes (directory-tracker fd-map). No wire-protocol change except an added `DirectorySkipped` ack (one response per `Directory`) that also fixes a source-side fd-budget deadlock.
- Data path: explicit `copy_file_range` with a **sparse-aware** fallback (replacing `std::fs::copy` so the dst fd is held across copy + metadata); fd-based chmod/chown/utimes (the symlink-timestamp window closed via raw `utimensat(AT_EMPTY_PATH)`); `recheck` (dev/ino) before overwrite removals.

**New linter:** `--toctou-check` (reports whether an invocation is hardened, exits without operating) and `--require-toctou-safe` (refuses to run unless safe — intended for `sudo` rules, e.g. `user ALL=(root) NOPASSWD: /usr/bin/rcp --require-toctou-safe *`), plus a runtime parent-chain writability check.

**Out of scope (documented, reported "not safe" by the linter):** `--dereference`/`-L` (follows symlinks by request), non-Linux builds (the hardened path is `#[cfg(target_os = "linux")]`), and `rcmp` (read-only — cannot mis-permission). Residual preconditions: `fs.protected_hardlinks=1` (Linux default) and `/proc` mounted (used by `rchm`).

**Docs:** `docs/tocttou.md`, `docs/security.md`, and `docs/remote_protocol.md` updated to match the implementation; design spec + implementation plan under `docs/superpowers/`.

The change was built phase-by-phase with adversarial review at each step; the reviews caught and fixed a use-after-close in the primitive's `unsafe`, an `rm` relax-mode leak, an `rlink` filter regression, a reproduced remote-source deadlock, and a copy-overwrite parallel-path miss.

## Test plan

- [x] `just lint` clean
- [x] `just doc` clean
- [x] `cargo nextest run --workspace` — 1056 passed, 50 skipped (sudo/Docker-gated), debug
- [x] Per-tool TOCTOU swap-loop race tests (copy/rrm/rlink/rchm), remote-source deadlock regression, remote-destination write-escape test, and deterministic overwrite-removal regression tests — all green; race-loop tests empirically observed caught swaps with zero sentinel leaks
- [ ] `just ci` (full, incl. Docker multi-host + release) on CI
