### PR TITLE
Fix `.`/`..` source operands with a trailing-slash destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .codex
 .direnv/
 /codex-review*/
+# session working artifacts (specs/plans) — never checked in
+/docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ cargo install cargo-nextest  # required for `just test`, `just test-release`, `j
 ### Common Commands
 
 - `just` or `just --list` — list all available commands
-- `just lint` — run lints (fmt, clippy, error logging, package metadata)
+- `just lint` — run lints (fmt, clippy, and the repo's CI check scripts)
 - `just fmt` — format code
 - `just test` — run tests in debug mode
 - `just test-release` — run tests in release mode
@@ -98,6 +98,16 @@ Enforced by `scripts/check-package-metadata.sh`.
 - Doc comments (`///`, `//!`): start with a capitalized sentence, read naturally.
 - Regular comments (`//`): start lowercase (see CONVENTIONS.md).
 
+### Structural Simplification
+
+Always look for structural simplifications in the area you touch. The goal is simplicity —
+de-duplication is a means to it, not an absolute rule. The most common smell: re-deriving a
+value from raw input that an earlier stage already computed (e.g. re-parsing a string the CLI
+already parsed into a typed value); re-derivation drifts from the source of truth and breeds
+inconsistency bugs. Thread the already-computed value through when that is the simpler shape;
+keep a small redundancy when *it* is. Apply low-risk simplifications as part of the change;
+describe larger restructurings in the PR rather than bundling them.
+
 ## Testing
 
 Name tests after observed behavior (e.g., `copies_directory_tree`, `fails_on_permission_denied`). Use the `filegen` crate for repeatable fixtures.
@@ -116,14 +126,15 @@ Before making any changes to remote copy operations, **always read [docs/remote_
 
 **Security**: Never commit SSH config or keys to the repository.
 
-## Agent Team Workflow
-
+## Pull Requests
 
 After creating a PR, check all review comments (including automated ones from Copilot). Evaluate each on its merit — address valid suggestions and respond to ones that aren't applicable.
 
 ## Commit Guidelines
 
 Keep commit subjects concise and imperative, matching the existing history style (e.g., "Fix how we manage dependencies"). Provide context and issue links in the body when applicable.
+
+Squash work-in-progress commits before opening a PR — land clean, reviewable commits. Never commit working specs or implementation plans (e.g. `docs/superpowers/`, which is gitignored); they are session artifacts.
 
 ## Shell Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `rcp host:~ dst/` (a bare remote home as source with a trailing-slash
+  destination) now errors instead of creating a directory literally named `~`
+  under `dst/`: the remote home's basename cannot be resolved locally. Use a
+  destination without a trailing slash to name the result explicitly.
+
+### Fixed
+- Fix `rcp`/`rlink` rejecting `.`/`..` source operands (`.`, `./`, `..`, `../`,
+  `tree/..`) when the destination ends with a slash, e.g. `rcp . out/` or
+  `rlink tree/.. out/` previously failed with "source ... does not have a
+  basename". The source basename for the trailing-slash form is now resolved
+  through the same canonicalization the copy/link operation uses, so `dst/<name>`
+  always matches the entry that gets created.
+
 ## [0.33.0] - 2026-05-28
 
 ### Added

--- a/common/src/walk.rs
+++ b/common/src/walk.rs
@@ -478,6 +478,31 @@ pub async fn split_root_operand(path: &std::path::Path) -> anyhow::Result<RootOp
     })
 }
 
+/// The basename a root operand contributes to the trailing-slash "copy INTO directory" rule: the
+/// name of the entry the walk will create for `path`, so a CLI forming `dst/<name>` matches it
+/// exactly (`rcp . out/` / `rlink . out/` -> `out/<cwd-name>`; `… tree/.. out/` ->
+/// `out/<parent-name>`).
+///
+/// This is the synchronous twin of [`split_root_operand`]'s `name`, for the CLI path-resolution
+/// layer (which is not async): a normal operand uses [`std::path::Path::file_name`]; an operand
+/// with no `file_name()` (`.`/`..`/`dir/..`) is canonicalized first, exactly as
+/// [`split_root_operand`] does. The filesystem root has no basename and is rejected. The
+/// `root_operand_basename_matches_split_root_operand` test keeps the two in lock-step.
+pub fn root_operand_basename(path: &std::path::Path) -> anyhow::Result<std::ffi::OsString> {
+    let stripped = without_trailing_separators(path);
+    if let Some(name) = stripped.file_name() {
+        return Ok(name.to_owned());
+    }
+    // final component is `.`/`..` (or the operand is `/`): canonicalize to a concrete path so it
+    // has a real basename — the same resolution `split_root_operand` performs for the walk.
+    let canonical = std::fs::canonicalize(&stripped)
+        .with_context(|| format!("cannot resolve operand {stripped:?}"))?;
+    canonical
+        .file_name()
+        .map(std::ffi::OsStr::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("cannot operate on the filesystem root {canonical:?}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -650,6 +675,45 @@ mod tests {
         assert_eq!(op.name, canonical_tmp.file_name().unwrap());
         assert_eq!(op.display, canonical_tmp);
         // the filesystem root has no parent and is rejected with a clear error.
+        assert!(split_root_operand(Path::new("/")).await.is_err());
+        Ok(())
+    }
+
+    // `root_operand_basename` (the sync CLI helper) must return exactly `split_root_operand`'s
+    // `name` for every operand shape, so a `dst/<name>` the CLI builds always matches the entry the
+    // walk creates. This lock-step is what makes the trailing-slash result deterministic.
+    #[tokio::test]
+    async fn root_operand_basename_matches_split_root_operand() -> anyhow::Result<()> {
+        use std::path::Path;
+        // operands with a real `file_name()` (no canonicalize): both take the lexical basename.
+        for p in ["a/b", "foo", "foo/", "dir/.", "a/b/."] {
+            assert_eq!(
+                root_operand_basename(Path::new(p))?,
+                split_root_operand(Path::new(p)).await?.name,
+                "operand {p:?}"
+            );
+        }
+        // `.`/`..`/`dir/..` (no `file_name()`): both canonicalize to a real path first. Use real
+        // dirs so canonicalize succeeds; assert only that the two helpers agree (the concrete
+        // basename depends on the cwd / temp path).
+        let tmp = testutils::create_temp_dir().await?;
+        let sub = tmp.join("sub");
+        tokio::fs::create_dir(&sub).await?;
+        let dot_operands = [
+            std::path::PathBuf::from("."),
+            std::path::PathBuf::from(".."),
+            sub.join(".."),
+            sub.join("../.."),
+        ];
+        for p in &dot_operands {
+            assert_eq!(
+                root_operand_basename(p)?,
+                split_root_operand(p).await?.name,
+                "operand {p:?}"
+            );
+        }
+        // the filesystem root has no basename: both reject it.
+        assert!(root_operand_basename(Path::new("/")).is_err());
         assert!(split_root_operand(Path::new("/")).await.is_err());
         Ok(())
     }

--- a/rcp/src/bin/rcp.rs
+++ b/rcp/src/bin/rcp.rs
@@ -896,10 +896,9 @@ async fn async_main(args: Args) -> anyhow::Result<common::copy::Summary> {
     }
     // if any of the src/dst paths are remote, we'll be using the rcpd
     let remote_src_dst = if has_remote_paths {
-        // resolve destination path with trailing slash logic for remote case
-        let resolved_dst_string = path::resolve_destination_path(&src_strings[0], dst_string)?;
-        let resolved_dst_path_type = parse_fn(&resolved_dst_string)?;
-        match (first_src_path_type.clone(), resolved_dst_path_type) {
+        // resolve the destination with trailing-slash logic on the already-parsed paths
+        let resolved_dst = path::resolve_destination(&parsed_srcs[0], &dst_parsed, dst_string)?;
+        match (first_src_path_type.clone(), resolved_dst) {
             (path::PathType::Remote(src_remote), path::PathType::Remote(dst_remote)) => {
                 Some((src_remote, dst_remote))
             }
@@ -984,13 +983,12 @@ async fn async_main(args: Args) -> anyhow::Result<common::copy::Summary> {
             destination path with a trailing slash"
         ));
     }
-    let src_dst: Vec<(std::path::PathBuf, std::path::PathBuf)> = src_strings
+    let src_dst: Vec<(std::path::PathBuf, std::path::PathBuf)> = parsed_srcs
         .iter()
-        .zip(parsed_srcs.iter())
-        .map(|(src_str, parsed_src)| {
-            let resolved_dst = path::resolve_destination_path(src_str, dst_string)?;
-            // parse the resolved destination to handle localhost: prefix correctly
-            let dst_path = match parse_fn(&resolved_dst)? {
+        .map(|parsed_src| {
+            // the resolver preserves the destination's variant and this branch only runs when
+            // the destination parsed as local, so a remote result is an internal error
+            let dst_path = match path::resolve_destination(parsed_src, &dst_parsed, dst_string)? {
                 path::PathType::Local(p) => p,
                 path::PathType::Remote(_) => {
                     return Err(anyhow!(

--- a/rcp/src/path.rs
+++ b/rcp/src/path.rs
@@ -59,6 +59,18 @@ impl RemotePath {
             self.needs_remote_home = false;
         }
     }
+
+    /// Returns this path with `name` appended; the session and `needs_remote_home` flag are
+    /// preserved. Joining a name onto an absolute path stays absolute, and a
+    /// `needs_remote_home` path is allowed to be relative, so the [`RemotePath::new`]
+    /// invariant cannot be violated.
+    #[must_use]
+    pub fn joined(&self, name: &std::ffi::OsStr) -> RemotePath {
+        RemotePath {
+            path: self.path.join(name),
+            ..self.clone()
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -152,20 +164,6 @@ fn split_remote_path(path_str: &str) -> (Option<String>, &str) {
 /// For local paths, returns the original path
 fn extract_filesystem_path(path_str: &str) -> &str {
     split_remote_path(path_str).1
-}
-
-/// Joins a filesystem path with a filename, handling both remote and local cases
-/// For example: ("user@host:22:", "/path/", "file.txt") -> "user@host:22:/path/file.txt"
-/// For local: (None, "/path/", "file.txt") -> "/path/file.txt"
-fn join_path_with_filename(host_prefix: Option<String>, dir_path: &str, filename: &str) -> String {
-    let fs_path = std::path::Path::new(dir_path);
-    let joined = fs_path.join(filename);
-    let joined_str = joined.to_string_lossy();
-    if let Some(prefix) = host_prefix {
-        format!("{prefix}{joined_str}")
-    } else {
-        joined_str.to_string()
-    }
 }
 
 pub fn expand_local_home(path: &str) -> anyhow::Result<std::path::PathBuf> {
@@ -306,40 +304,104 @@ pub fn validate_destination_path(dst_path_str: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Resolves destination path handling trailing slash semantics for both local and remote paths.
+/// Resolve the final destination for one source, applying the trailing-slash ("copy INTO
+/// directory") rule on the already-parsed destination.
 ///
-/// This function implements the logic: "foo/bar -> baz/" becomes "foo/bar -> baz/bar"
-/// i.e., when destination ends with '/', copy source INTO the directory.
-///
-/// # Arguments
-/// * `src_path_str` - Source path as string (before parsing)
-/// * `dst_path_str` - Destination path as string (before parsing)
-///
-/// # Returns
-/// * `Ok(resolved_dst_path)` - Destination path with trailing slash logic applied
-/// * `Err(...)` - If path resolution fails or invalid combination detected
-pub fn resolve_destination_path(src_path_str: &str, dst_path_str: &str) -> anyhow::Result<String> {
-    // validate destination path doesn't end with problematic patterns
-    validate_destination_path(dst_path_str)?;
-    if dst_path_str.ends_with('/') {
-        // extract source file name to append to destination directory
-        let actual_src_path = std::path::Path::new(extract_filesystem_path(src_path_str));
-        let src_file_name = actual_src_path.file_name().ok_or_else(|| {
-            anyhow::anyhow!("Source path {:?} does not have a basename", actual_src_path)
-        })?;
-        // construct destination: "baz/" + "bar" -> "baz/bar"
-        let (host_prefix, dir_path) = split_remote_path(dst_path_str);
-        let filename = src_file_name.to_string_lossy();
-        Ok(join_path_with_filename(host_prefix, dir_path, &filename))
-    } else {
+/// A `dst_str` ending in `/` means "copy INTO this directory": the source basename is appended
+/// to the parsed destination (`dst/<src_basename>`); otherwise the parsed destination is used
+/// verbatim. Classification (local vs remote) comes exclusively from the parsed values — the
+/// caller parses both with the active parse function, so `--force-remote` and the `localhost:`
+/// escape hatch are honored by construction. `dst_str` is consulted only for validation and
+/// the trailing-slash rule (parsing does not preserve a trailing slash). `dst` must be the
+/// result of parsing this same `dst_str` — the function trusts `dst_str` for the slash rule
+/// and `dst` for the value.
+pub fn resolve_destination(
+    src: &PathType,
+    dst: &PathType,
+    dst_str: &str,
+) -> anyhow::Result<PathType> {
+    // validate the destination string doesn't end with problematic patterns; rcp also
+    // validates once up front for early error ordering — these are cheap suffix checks, so
+    // the small redundancy keeps this function safe in isolation
+    validate_destination_path(dst_str)?;
+    if !dst_str.ends_with('/') {
         // no trailing slash - use destination as-is
-        Ok(dst_path_str.to_string())
+        return Ok(dst.clone());
     }
+    // derive the source basename to append, using the parser's classification
+    let src_file_name = match src {
+        PathType::Local(src_path) => {
+            // Local source: use the SAME decomposition the copy operation uses
+            // (`root_operand_basename` canonicalizes `.`/`..`/`dir/..`), so `dst/<name>` names
+            // exactly the entry that gets created — `rcp . out/` -> `out/<cwd-name>`. The path
+            // is already `~`-expanded and `localhost:`-stripped by the parser. A plain
+            // `file_name()` returns None for those operands and would reject them here, before
+            // `common::copy` could canonicalize the source.
+            common::walk::root_operand_basename(src_path)
+                .with_context(|| format!("resolving source operand {src_path:?}"))?
+        }
+        PathType::Remote(src_remote) => {
+            // Remote source: the basename must be resolved on the remote host, so only a
+            // lexical `file_name()` is available here. A remote operand with no basename — a
+            // path ending in `..`, or a bare `host:~` (stored as an empty path until the
+            // remote home is known) — would need remote resolution and is not supported.
+            let src_path = src_remote.path();
+            src_path
+                .file_name()
+                .map(std::ffi::OsStr::to_owned)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Remote source path {:?} does not have a basename that can be \
+                         resolved locally (e.g. a bare `host:~` or a path ending in `..`); \
+                         use a destination without a trailing slash to name the result \
+                         explicitly",
+                        src_path
+                    )
+                })?
+        }
+    };
+    // append the basename on the parsed destination: "baz/" + "bar" -> "baz/bar"
+    Ok(match dst {
+        PathType::Local(dir) => PathType::Local(dir.join(&src_file_name)),
+        PathType::Remote(dir) => PathType::Remote(dir.joined(&src_file_name)),
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Unwrap a local PathType or panic with a useful message.
+    fn expect_local(pt: PathType) -> std::path::PathBuf {
+        match pt {
+            PathType::Local(p) => p,
+            PathType::Remote(r) => panic!("expected local path, got remote {r:?}"),
+        }
+    }
+
+    /// Unwrap a remote PathType or panic with a useful message.
+    fn expect_remote(pt: PathType) -> RemotePath {
+        match pt {
+            PathType::Remote(r) => r,
+            PathType::Local(p) => panic!("expected remote path, got local {p:?}"),
+        }
+    }
+
+    #[test]
+    fn remote_path_joined_appends_and_preserves_session_and_home_flag() {
+        // absolute remote path: joined name stays absolute, session fields preserved
+        let remote = expect_remote(parse_path("user@host:22:/backup/").unwrap());
+        let joined = remote.joined(std::ffi::OsStr::new("file.txt"));
+        assert_eq!(joined.path(), std::path::Path::new("/backup/file.txt"));
+        assert_eq!(joined.session(), remote.session());
+        assert!(!joined.needs_remote_home());
+        // bare remote tilde ("host:~/" parses to an empty path with needs_remote_home):
+        // the flag is preserved and the joined path stays relative until home expansion
+        let tilde = expect_remote(parse_path("host:~/").unwrap());
+        let joined = tilde.joined(std::ffi::OsStr::new("file.txt"));
+        assert!(joined.needs_remote_home());
+        assert_eq!(joined.path(), std::path::Path::new("file.txt"));
+    }
 
     #[test]
     fn test_parse_path_local() {
@@ -490,40 +552,126 @@ mod tests {
 
     #[test]
     fn test_resolve_destination_path_local_with_trailing_slash() {
-        let result = resolve_destination_path("/path/to/file.txt", "/dest/").unwrap();
-        assert_eq!(result, "/dest/file.txt");
+        let src = parse_path("/path/to/file.txt").unwrap();
+        let dst = parse_path("/dest/").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "/dest/").unwrap());
+        assert_eq!(result, std::path::Path::new("/dest/file.txt"));
     }
 
     #[test]
     fn test_resolve_destination_path_local_without_trailing_slash() {
-        let result = resolve_destination_path("/path/to/file.txt", "/dest/newname.txt").unwrap();
-        assert_eq!(result, "/dest/newname.txt");
+        let src = parse_path("/path/to/file.txt").unwrap();
+        let dst = parse_path("/dest/newname.txt").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "/dest/newname.txt").unwrap());
+        assert_eq!(result, std::path::Path::new("/dest/newname.txt"));
+    }
+
+    #[test]
+    fn test_resolve_destination_path_local_dotdot_source_uses_canonical_basename() {
+        // A local source with no lexical basename (`.`/`..`/`dir/..`) resolves through the same
+        // canonicalization the copy uses, so a trailing-slash dst appends the REAL entry name
+        // instead of failing. `<tmp>/sub/..` canonicalizes to `<tmp>`.
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let src = parse_path(&format!("{}/sub/..", tmp.path().to_str().unwrap())).unwrap();
+        let dst = parse_path("/dest/").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "/dest/").unwrap());
+        let expected_name = tmp.path().file_name().unwrap().to_str().unwrap();
+        assert_eq!(
+            result,
+            std::path::PathBuf::from(format!("/dest/{expected_name}"))
+        );
+    }
+
+    #[test]
+    fn test_resolve_destination_path_local_dotdot_source_into_remote_dest() {
+        // A LOCAL `.`/`..` source copied INTO a remote trailing-slash directory: the basename is
+        // resolved locally (canonicalize) and appended to the parsed remote destination.
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let src = parse_path(&format!("{}/sub/..", tmp.path().to_str().unwrap())).unwrap();
+        let dst = parse_path("host:/backup/").unwrap();
+        let result = expect_remote(resolve_destination(&src, &dst, "host:/backup/").unwrap());
+        let expected_name = tmp.path().file_name().unwrap().to_str().unwrap();
+        assert_eq!(
+            result.path(),
+            std::path::Path::new(&format!("/backup/{expected_name}"))
+        );
+        assert_eq!(result.session().host, "host");
+    }
+
+    #[test]
+    fn test_resolve_destination_path_localhost_dotdot_source_uses_canonical_basename() {
+        // A `localhost:`-prefixed source parses as LOCAL (escape hatch), so its basename resolves
+        // through the same canonicalization a plain local source uses, not lexically from the raw
+        // string. `<tmp>/sub/..` canonicalizes to `<tmp>`, so a trailing-slash dst appends the
+        // REAL entry name rather than failing on the missing lexical basename.
+        let tmp = tempfile::tempdir().unwrap();
+        let sub = tmp.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        let src = parse_path(&format!(
+            "localhost:{}/sub/..",
+            tmp.path().to_str().unwrap()
+        ))
+        .unwrap();
+        let dst = parse_path("/dest/").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "/dest/").unwrap());
+        let expected_name = tmp.path().file_name().unwrap().to_str().unwrap();
+        assert_eq!(
+            result,
+            std::path::PathBuf::from(format!("/dest/{expected_name}"))
+        );
+    }
+
+    #[test]
+    fn test_resolve_destination_path_remote_dotdot_source_is_unsupported() {
+        // A remote source's basename must be resolved on the remote host; a remote `.`/`..`
+        // operand (no lexical basename) is unsupported and errors rather than canonicalizing
+        // against the LOCAL filesystem.
+        let src = parse_path("host:/data/proj/..").unwrap();
+        let dst = parse_path("/dest/").unwrap();
+        let result = resolve_destination(&src, &dst, "/dest/");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("does not have a basename")
+        );
     }
 
     #[test]
     fn test_resolve_destination_path_remote_with_trailing_slash() {
-        let result = resolve_destination_path("host:/path/to/file.txt", "/dest/").unwrap();
-        assert_eq!(result, "/dest/file.txt");
+        let src = parse_path("host:/path/to/file.txt").unwrap();
+        let dst = parse_path("/dest/").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "/dest/").unwrap());
+        assert_eq!(result, std::path::Path::new("/dest/file.txt"));
     }
 
     #[test]
     fn test_resolve_destination_path_remote_without_trailing_slash() {
-        let result =
-            resolve_destination_path("host:/path/to/file.txt", "/dest/newname.txt").unwrap();
-        assert_eq!(result, "/dest/newname.txt");
+        let src = parse_path("host:/path/to/file.txt").unwrap();
+        let dst = parse_path("/dest/newname.txt").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "/dest/newname.txt").unwrap());
+        assert_eq!(result, std::path::Path::new("/dest/newname.txt"));
     }
 
     #[test]
     fn test_resolve_destination_path_remote_complex() {
-        let result =
-            resolve_destination_path("user@host:22:/home/user/docs/report.pdf", "host2:/backup/")
-                .unwrap();
-        assert_eq!(result, "host2:/backup/report.pdf");
+        let src = parse_path("user@host:22:/home/user/docs/report.pdf").unwrap();
+        let dst = parse_path("host2:/backup/").unwrap();
+        let result = expect_remote(resolve_destination(&src, &dst, "host2:/backup/").unwrap());
+        assert_eq!(result.path(), std::path::Path::new("/backup/report.pdf"));
+        assert_eq!(result.session().host, "host2");
+        assert_eq!(result.session().user, None);
+        assert_eq!(result.session().port, None);
     }
 
     #[test]
     fn test_validate_destination_path_dot_local() {
-        let result = resolve_destination_path("/path/to/file.txt", "/dest/.");
+        let result = validate_destination_path("/dest/.");
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert!(error.to_string().contains("cannot end with '/.'"));
@@ -532,7 +680,7 @@ mod tests {
 
     #[test]
     fn test_validate_destination_path_double_dot_local() {
-        let result = resolve_destination_path("/path/to/file.txt", "/dest/..");
+        let result = validate_destination_path("/dest/..");
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert!(error.to_string().contains("cannot end with '/..'"));
@@ -541,7 +689,7 @@ mod tests {
 
     #[test]
     fn test_validate_destination_path_dot_remote() {
-        let result = resolve_destination_path("host:/path/to/file.txt", "host2:/dest/.");
+        let result = validate_destination_path("host2:/dest/.");
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert!(error.to_string().contains("cannot end with '/.'"));
@@ -549,7 +697,7 @@ mod tests {
 
     #[test]
     fn test_validate_destination_path_double_dot_remote() {
-        let result = resolve_destination_path("host:/path/to/file.txt", "host2:/dest/..");
+        let result = validate_destination_path("host2:/dest/..");
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert!(error.to_string().contains("cannot end with '/..'"));
@@ -557,7 +705,7 @@ mod tests {
 
     #[test]
     fn test_validate_destination_path_bare_dot() {
-        let result = resolve_destination_path("/path/to/file.txt", ".");
+        let result = validate_destination_path(".");
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert!(error.to_string().contains("cannot be '.'"));
@@ -565,7 +713,7 @@ mod tests {
 
     #[test]
     fn test_validate_destination_path_bare_double_dot() {
-        let result = resolve_destination_path("/path/to/file.txt", "..");
+        let result = validate_destination_path("..");
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert!(error.to_string().contains("cannot be '..'"));
@@ -573,7 +721,7 @@ mod tests {
 
     #[test]
     fn test_validate_destination_path_remote_bare_dot() {
-        let result = resolve_destination_path("host:/path/to/file.txt", "host2:.");
+        let result = validate_destination_path("host2:.");
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert!(error.to_string().contains("cannot be '.'"));
@@ -581,7 +729,7 @@ mod tests {
 
     #[test]
     fn test_validate_destination_path_remote_bare_double_dot() {
-        let result = resolve_destination_path("host:/path/to/file.txt", "host2:..");
+        let result = validate_destination_path("host2:..");
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert!(error.to_string().contains("cannot be '..'"));
@@ -590,34 +738,51 @@ mod tests {
     #[test]
     fn test_validate_destination_path_dot_with_slash_allowed() {
         // these should work fine because they end with '/' not '.'
-        let result = resolve_destination_path("/path/to/file.txt", "./").unwrap();
-        assert_eq!(result, "./file.txt");
-        let result = resolve_destination_path("/path/to/file.txt", "../").unwrap();
-        assert_eq!(result, "../file.txt");
+        let src = parse_path("/path/to/file.txt").unwrap();
+        let dst = parse_path("./").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "./").unwrap());
+        assert_eq!(result, std::path::Path::new("./file.txt"));
+        let dst = parse_path("../").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "../").unwrap());
+        assert_eq!(result, std::path::Path::new("../file.txt"));
     }
 
     #[test]
     fn test_validate_destination_path_normal_paths_allowed() {
         // normal paths should work fine
-        let result = resolve_destination_path("/path/to/file.txt", "/dest/normal").unwrap();
-        assert_eq!(result, "/dest/normal");
-        let result = resolve_destination_path("/path/to/file.txt", "/dest.txt").unwrap();
-        assert_eq!(result, "/dest.txt");
+        let src = parse_path("/path/to/file.txt").unwrap();
+        let dst = parse_path("/dest/normal").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "/dest/normal").unwrap());
+        assert_eq!(result, std::path::Path::new("/dest/normal"));
+        let dst = parse_path("/dest.txt").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "/dest.txt").unwrap());
+        assert_eq!(result, std::path::Path::new("/dest.txt"));
         // paths containing dots but not ending with them should work
-        let result = resolve_destination_path("/path/to/file.txt", "/dest.backup/").unwrap();
-        assert_eq!(result, "/dest.backup/file.txt");
+        let dst = parse_path("/dest.backup/").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "/dest.backup/").unwrap());
+        assert_eq!(result, std::path::Path::new("/dest.backup/file.txt"));
     }
 
     #[test]
     fn test_resolve_destination_path_remote_with_complex_host() {
-        // test with complex remote paths including ports and IPv6
+        // complex remote destinations including ports and IPv6
+        let src = parse_path("host:/path/to/file.txt").unwrap();
+        let dst = parse_path("user@host2:22:/backup/").unwrap();
         let result =
-            resolve_destination_path("host:/path/to/file.txt", "user@host2:22:/backup/").unwrap();
-        assert_eq!(result, "user@host2:22:/backup/file.txt");
-
+            expect_remote(resolve_destination(&src, &dst, "user@host2:22:/backup/").unwrap());
+        assert_eq!(result.path(), std::path::Path::new("/backup/file.txt"));
+        assert_eq!(result.session().user, Some("user".to_string()));
+        assert_eq!(result.session().host, "host2");
+        assert_eq!(result.session().port, Some(22));
+        // note: bare [::1] parses as LOCAL (localhost escape hatch) — the source basename is
+        // identical either way; the IPv6 destination keeps host and port
+        let src = parse_path("[::1]:/path/file.txt").unwrap();
+        let dst = parse_path("[2001:db8::1]:8080:/dest/").unwrap();
         let result =
-            resolve_destination_path("[::1]:/path/file.txt", "[2001:db8::1]:8080:/dest/").unwrap();
-        assert_eq!(result, "[2001:db8::1]:8080:/dest/file.txt");
+            expect_remote(resolve_destination(&src, &dst, "[2001:db8::1]:8080:/dest/").unwrap());
+        assert_eq!(result.path(), std::path::Path::new("/dest/file.txt"));
+        assert_eq!(result.session().host, "[2001:db8::1]");
+        assert_eq!(result.session().port, Some(8080));
     }
 
     #[test]
@@ -672,29 +837,6 @@ mod tests {
     }
 
     #[test]
-    fn test_join_path_with_filename() {
-        // test remote path joining
-        assert_eq!(
-            join_path_with_filename(Some("user@host:22:".to_string()), "/backup/", "file.txt"),
-            "user@host:22:/backup/file.txt"
-        );
-        assert_eq!(
-            join_path_with_filename(Some("[::1]:8080:".to_string()), "/dest/", "file.txt"),
-            "[::1]:8080:/dest/file.txt"
-        );
-
-        // test local path joining
-        assert_eq!(
-            join_path_with_filename(None, "/backup/", "file.txt"),
-            "/backup/file.txt"
-        );
-        assert_eq!(
-            join_path_with_filename(None, "relative/", "file.txt"),
-            "relative/file.txt"
-        );
-    }
-
-    #[test]
     fn test_ipv6_edge_cases_consistency() {
         // Test that helper functions and parse_path handle IPv6 consistently
         // Note: [::1] without user/port is now treated as local (localhost),
@@ -725,14 +867,6 @@ mod tests {
                     );
                 }
                 PathType::Local(_) => panic!("parse_path should detect {case} as remote"),
-            }
-            // Test that join_path_with_filename can reconstruct correctly
-            if let (Some(host_prefix), dir_path) = split_remote_path(&case.replace("file", "")) {
-                let reconstructed = join_path_with_filename(Some(host_prefix), dir_path, "file");
-                assert_eq!(
-                    reconstructed, case,
-                    "Should be able to reconstruct {case} correctly"
-                );
             }
         }
         // [::1] without user/port is now local (localhost loopback)
@@ -836,5 +970,82 @@ mod tests {
         assert!(is_localhost("[::1]"));
         assert!(!is_localhost("example.com"));
         assert!(!is_localhost("192.168.1.1"));
+    }
+
+    #[test]
+    fn resolve_destination_no_trailing_slash_returns_dst_verbatim() {
+        // I1: without a trailing slash the parsed destination is the final name, used verbatim
+        let src = parse_path("/path/to/file.txt").unwrap();
+        let dst = parse_path("/dest/newname.txt").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "/dest/newname.txt").unwrap());
+        assert_eq!(result, std::path::Path::new("/dest/newname.txt"));
+    }
+
+    #[test]
+    fn resolve_destination_joins_basename_on_local_dest() {
+        // I2: trailing-slash local destination gets the source basename appended; a
+        // `localhost:` destination parses as local (escape hatch) and behaves identically.
+        // (the `~/x/` local-destination leg needs a real HOME and is covered end-to-end by
+        // tilde_tests::test_local_copy_with_tilde_source_and_destination)
+        let src = parse_path("/path/to/file.txt").unwrap();
+        let dst = parse_path("/dest/").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "/dest/").unwrap());
+        assert_eq!(result, std::path::Path::new("/dest/file.txt"));
+        let dst = parse_path("localhost:/dest/").unwrap();
+        let result = expect_local(resolve_destination(&src, &dst, "localhost:/dest/").unwrap());
+        assert_eq!(result, std::path::Path::new("/dest/file.txt"));
+    }
+
+    #[test]
+    fn resolve_destination_joins_basename_on_remote_dest_preserving_session() {
+        // I3: trailing-slash remote destination joins the name and keeps user/host/port
+        let src = parse_path("/path/to/file.txt").unwrap();
+        let dst = parse_path("user@host2:22:/backup/").unwrap();
+        let result =
+            expect_remote(resolve_destination(&src, &dst, "user@host2:22:/backup/").unwrap());
+        assert_eq!(result.path(), std::path::Path::new("/backup/file.txt"));
+        assert_eq!(result.session().user, Some("user".to_string()));
+        assert_eq!(result.session().host, "host2");
+        assert_eq!(result.session().port, Some(22));
+    }
+
+    #[test]
+    fn resolve_destination_remote_tilde_dest_preserves_needs_remote_home() {
+        // I4: "host:~/" parses to an empty remote path with needs_remote_home; joining the
+        // basename preserves that bookkeeping so apply_remote_home later yields home/<name>
+        let src = parse_path("/path/to/file.txt").unwrap();
+        let dst = parse_path("host:~/").unwrap();
+        let mut result = expect_remote(resolve_destination(&src, &dst, "host:~/").unwrap());
+        assert!(result.needs_remote_home());
+        assert_eq!(result.path(), std::path::Path::new("file.txt"));
+        result.apply_remote_home(std::path::Path::new("/home/user"));
+        assert_eq!(result.path(), std::path::Path::new("/home/user/file.txt"));
+    }
+
+    #[test]
+    fn resolve_destination_force_remote_localhost_dest_stays_remote() {
+        // I5: classification follows the caller's parse function — with --force-remote
+        // parsing, a localhost: destination resolves as remote (and a localhost: source
+        // uses the lexical remote basename)
+        let src = parse_path_force_remote("localhost:/src/file.txt").unwrap();
+        let dst = parse_path_force_remote("localhost:/dest/").unwrap();
+        let result = expect_remote(resolve_destination(&src, &dst, "localhost:/dest/").unwrap());
+        assert_eq!(result.path(), std::path::Path::new("/dest/file.txt"));
+        assert_eq!(result.session().host, "localhost");
+    }
+
+    #[test]
+    fn resolve_destination_rejects_invalid_destination_string() {
+        // the resolver is safe in isolation: it validates dst_str before touching the paths
+        let src = parse_path("/path/to/file.txt").unwrap();
+        let dst = parse_path("/dest/.").unwrap();
+        let result = resolve_destination(&src, &dst, "/dest/.");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("cannot end with '/.'")
+        );
     }
 }

--- a/rcp/tests/tests.rs
+++ b/rcp/tests/tests.rs
@@ -1237,3 +1237,113 @@ fn test_preserve_settings_symlink_uses_symlink_settings() {
         "symlink mtime should be preserved with l:time (got recent mtime)"
     );
 }
+
+/// Build `<root>/proj/sub/file.txt` plus an empty sibling `<root>/dest`, returning
+/// `(root, sub, dest)`. Tests run the tool with cwd set to `sub` via `Command::current_dir`
+/// (child-process cwd only — no global state mutation), so a relative `.` resolves to `sub` and
+/// `..` to `proj`. `dest` is a sibling of `proj`, so copying `proj` into `dest` never self-copies.
+fn setup_dot_operand_tree() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let root = tempfile::tempdir().unwrap();
+    let sub = root.path().join("proj").join("sub");
+    std::fs::create_dir_all(&sub).unwrap();
+    create_test_file(&sub.join("file.txt"), "hello dot", 0o644);
+    let dest = root.path().join("dest");
+    std::fs::create_dir(&dest).unwrap();
+    (root, sub, dest)
+}
+
+#[test]
+fn copies_dot_and_dotdot_source_operands_into_trailing_slash_dest() {
+    // The trailing-slash "copy INTO dir" rule must work for `.`/`..` source operands, deriving the
+    // basename from the SAME canonicalization the copy operation uses, so `dest/<name>` matches the
+    // entry that gets created. cwd is `<root>/proj/sub`, so `.` == sub and `..` == proj.
+    let (_root, sub, dest) = setup_dot_operand_tree();
+    // (source operand run from cwd `sub`, expected file path created under `dest/`)
+    let cases: &[(&str, &str)] = &[
+        (".", "sub/file.txt"),
+        ("./", "sub/file.txt"),
+        ("..", "proj/sub/file.txt"),
+        ("../", "proj/sub/file.txt"),
+        ("../sub/..", "proj/sub/file.txt"), // embedded `..` canonicalizes to `proj`
+        ("../sub/.", "sub/file.txt"),       // trailing `/.` names the dir itself -> `sub`
+    ];
+    for (src, expected) in cases {
+        // fresh dest per case (rcp refuses to clobber an existing destination entry)
+        std::fs::remove_dir_all(&dest).unwrap();
+        std::fs::create_dir(&dest).unwrap();
+        let dst_arg = format!("{}/", dest.to_str().unwrap());
+        let mut cmd = assert_cmd::Command::cargo_bin("rcp").unwrap();
+        cmd.current_dir(&sub)
+            .args([*src, dst_arg.as_str()])
+            .assert()
+            .success();
+        let created = dest.join(expected);
+        assert!(
+            created.is_file(),
+            "operand {src:?} should copy the source into {created:?}"
+        );
+        assert_eq!(get_file_content(&created), "hello dot");
+    }
+}
+
+#[test]
+fn dot_source_without_trailing_slash_uses_dest_name_verbatim() {
+    // Deterministic contrast: WITHOUT a trailing slash the destination is the final name, so the
+    // result is knowable from the slash alone, independent of the source spelling. `rcp . X/named`
+    // copies the current directory AS `named`.
+    let (_root, sub, dest) = setup_dot_operand_tree();
+    let dst_arg = dest.join("named");
+    let mut cmd = assert_cmd::Command::cargo_bin("rcp").unwrap();
+    cmd.current_dir(&sub)
+        .args([".", dst_arg.to_str().unwrap()])
+        .assert()
+        .success();
+    let created = dest.join("named").join("file.txt");
+    assert!(created.is_file());
+    assert_eq!(get_file_content(&created), "hello dot");
+}
+
+#[test]
+fn copies_localhost_prefixed_dotdot_source_operand_into_trailing_slash_dest() {
+    // A `localhost:`-prefixed source parses as LOCAL (escape hatch), so its basename must be
+    // resolved the same way a plain local source is — by canonicalizing `..` — not lexically from
+    // the raw string (which still sees the `localhost:` host prefix and rejects the missing
+    // basename). `<root>/proj/sub/..` canonicalizes to `<root>/proj`, so the file lands at
+    // `dest/proj/sub/file.txt`.
+    let (root, sub, dest) = setup_dot_operand_tree();
+    let src_arg = format!("localhost:{}/proj/sub/..", root.path().to_str().unwrap());
+    let dst_arg = format!("{}/", dest.to_str().unwrap());
+    let mut cmd = assert_cmd::Command::cargo_bin("rcp").unwrap();
+    cmd.current_dir(&sub)
+        .args([src_arg.as_str(), dst_arg.as_str()])
+        .assert()
+        .success();
+    let created = dest.join("proj").join("sub").join("file.txt");
+    assert!(
+        created.is_file(),
+        "localhost-prefixed `..` source should copy into {created:?}"
+    );
+    assert_eq!(get_file_content(&created), "hello dot");
+}
+
+#[test]
+fn copies_tilde_dotdot_source_operand_into_trailing_slash_dest() {
+    // A `~`-prefixed source is tilde-expanded by the parser before canonicalization; the basename
+    // must be derived from the expanded path, not from the literal `~` (which has no real path to
+    // canonicalize). With HOME set to `<root>`, `~/proj/sub/..` expands to `<root>/proj/sub/..`,
+    // which canonicalizes to `<root>/proj`, so the file lands at `dest/proj/sub/file.txt`.
+    let (root, sub, dest) = setup_dot_operand_tree();
+    let dst_arg = format!("{}/", dest.to_str().unwrap());
+    let mut cmd = assert_cmd::Command::cargo_bin("rcp").unwrap();
+    cmd.current_dir(&sub)
+        .env("HOME", root.path())
+        .args(["~/proj/sub/..", dst_arg.as_str()])
+        .assert()
+        .success();
+    let created = dest.join("proj").join("sub").join("file.txt");
+    assert!(
+        created.is_file(),
+        "tilde-prefixed `..` source should copy into {created:?}"
+    );
+    assert_eq!(get_file_content(&created), "hello dot");
+}

--- a/rlink/src/main.rs
+++ b/rlink/src/main.rs
@@ -182,20 +182,20 @@ struct Args {
     dst: String, // must be a string to allow for parsing trailing slash
 }
 
-/// Resolve the effective destination ROOT path that the link operation will
-/// create, applying the trailing-slash ("copy INTO this directory") rule: a `dst`
-/// ending in `/` means the source basename is appended (`dst/<src_basename>`),
-/// otherwise `dst` is used verbatim.
-///
-/// Resolve the destination root the operation writes to, applying the
-/// trailing-slash rule: for a trailing-slash invocation that root is
-/// `dst/<src_basename>`, otherwise it is `dst` itself.
+/// Resolve the effective destination ROOT path that the link operation will create, applying the
+/// trailing-slash ("copy INTO this directory") rule: a `dst` ending in `/` means the source
+/// basename is appended (`dst/<src_basename>`), otherwise `dst` is used verbatim.
 fn resolve_dst_root(src: &std::path::Path, dst: &str) -> Result<std::path::PathBuf> {
     if dst.ends_with('/') {
-        let src_file = src
-            .file_name()
-            .context(format!("source {:?} does not have a basename", src))?;
-        Ok(std::path::PathBuf::from(dst).join(src_file))
+        // Derive the basename via the SAME decomposition the link operation uses:
+        // `root_operand_basename` (the sync twin of `split_root_operand`) canonicalizes
+        // `.`/`..`/`dir/..` — which have no `Path::file_name()` — so `dst/<name>` names exactly the
+        // entry the link will create: `rlink . out/` -> `out/<cwd-name>`, `rlink tree/.. out/` ->
+        // `out/<parent-name>`. A plain `file_name()` returns None for those operands and would
+        // reject them before the link operation could canonicalize the source.
+        let src_name = common::walk::root_operand_basename(src)
+            .context(format!("resolving source operand {src:?}"))?;
+        Ok(std::path::PathBuf::from(dst).join(src_name))
     } else {
         Ok(std::path::PathBuf::from(dst))
     }

--- a/rlink/tests/tests.rs
+++ b/rlink/tests/tests.rs
@@ -625,3 +625,68 @@ fn test_preserve_settings_dir_7777_preserves_special_bits() {
         ));
     }
 }
+
+/// Build `<root>/proj/sub/file.txt` plus an empty sibling `<root>/dest`, returning
+/// `(root, sub, dest)`. Tests run the tool with cwd set to `sub` via `Command::current_dir`
+/// (child-process cwd only — no global state mutation), so a relative `.` resolves to `sub` and
+/// `..` to `proj`. `dest` is a sibling of `proj`, so copying `proj` into `dest` never self-copies.
+fn setup_dot_operand_tree() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+    let root = tempfile::tempdir().unwrap();
+    let sub = root.path().join("proj").join("sub");
+    std::fs::create_dir_all(&sub).unwrap();
+    create_test_file(&sub.join("file.txt"), "hello dot", 0o644);
+    let dest = root.path().join("dest");
+    std::fs::create_dir(&dest).unwrap();
+    (root, sub, dest)
+}
+
+#[test]
+fn links_dot_and_dotdot_source_operands_into_trailing_slash_dest() {
+    // The trailing-slash "copy INTO dir" rule must work for `.`/`..` source operands, deriving the
+    // basename from the SAME canonicalization the link operation uses, so `dest/<name>` matches the
+    // entry that gets created. cwd is `<root>/proj/sub`, so `.` == sub and `..` == proj.
+    let (_root, sub, dest) = setup_dot_operand_tree();
+    // (source operand run from cwd `sub`, expected file path created under `dest/`)
+    let cases: &[(&str, &str)] = &[
+        (".", "sub/file.txt"),
+        ("./", "sub/file.txt"),
+        ("..", "proj/sub/file.txt"),
+        ("../", "proj/sub/file.txt"),
+        ("../sub/..", "proj/sub/file.txt"), // embedded `..` canonicalizes to `proj`
+        ("../sub/.", "sub/file.txt"),       // trailing `/.` names the dir itself -> `sub`
+    ];
+    for (src, expected) in cases {
+        // fresh dest per case (rlink refuses to clobber an existing destination entry)
+        std::fs::remove_dir_all(&dest).unwrap();
+        std::fs::create_dir(&dest).unwrap();
+        let dst_arg = format!("{}/", dest.to_str().unwrap());
+        let mut cmd = assert_cmd::Command::cargo_bin("rlink").unwrap();
+        cmd.current_dir(&sub)
+            .args([*src, dst_arg.as_str()])
+            .assert()
+            .success();
+        let created = dest.join(expected);
+        assert!(
+            are_files_hardlinked(&sub.join("file.txt"), &created),
+            "operand {src:?} should hard-link the source into {created:?}"
+        );
+    }
+}
+
+#[test]
+fn dot_source_without_trailing_slash_uses_dest_name_verbatim() {
+    // Deterministic contrast: WITHOUT a trailing slash the destination is the final name, so the
+    // result is knowable from the slash alone, independent of the source spelling. `rlink . X/named`
+    // links the current directory AS `named`.
+    let (_root, sub, dest) = setup_dot_operand_tree();
+    let dst_arg = dest.join("named");
+    let mut cmd = assert_cmd::Command::cargo_bin("rlink").unwrap();
+    cmd.current_dir(&sub)
+        .args([".", dst_arg.to_str().unwrap()])
+        .assert()
+        .success();
+    assert!(are_files_hardlinked(
+        &sub.join("file.txt"),
+        &dest.join("named").join("file.txt")
+    ));
+}


### PR DESCRIPTION
`rcp . out/`, `rlink tree/.. out/` and the like previously failed with "source ... does not have a basename". Both tools derived the trailing-slash basename via `Path::file_name()`, which returns None for operands normalizing to `.`/`..` (`.`, `./`, `..`, `../`, `tree/..`), rejecting them before `common::copy`/`common::link` could canonicalize the source via `split_root_operand`. The non-slash form worked because the basename came from the explicit destination name.

Derive the basename from the SAME decomposition the copy/link uses: `rlink::resolve_dst_root` goes through the new `common::walk::root_operand_basename` (a synchronous twin of `split_root_operand`, kept in lock-step by a cross-check test). rcp goes further and resolves the whole destination on already-parsed paths: the string round-trip in `resolve_destination_path` (rebuild host prefix + dir + basename, then re-parse) is replaced by `resolve_destination`, which applies the trailing-slash rule on the parsed destination directly — Local joins on the PathBuf, Remote via the new `RemotePath::joined` (session and needs_remote_home preserved) — so classification follows the caller's parse function by construction (`localhost:` escape hatch, `~` expansion, --force-remote) and `join_path_with_filename` is removed as dead. A remote operand with no locally resolvable basename (`host:/p/..`, bare `host:~`) errors with guidance — previously a bare `host:~` source with a trailing-slash destination produced a directory literally named `~`.

Coverage: `.`, `./`, `..`, `../`, `tree/..`, `dir/.` with and without a trailing slash, single- and multi-source, local->local and local->remote, `localhost:`-prefixed and `~`-expanded forms, plus unit invariants for the parsed-path resolver (verbatim no-slash, local/remote joins, remote-tilde home bookkeeping, force-remote localhost).

Also: AGENTS.md gains Structural Simplification guidance and commit-hygiene notes (squash WIP commits; never commit working specs/plans — docs/superpowers/ is now gitignored), plus small cleanups.
