### PR TITLE
Skip transferring identical files in remote --overwrite / --ignore-existing

### DIFF
--- a/common/src/copy.rs
+++ b/common/src/copy.rs
@@ -43,6 +43,52 @@ impl std::fmt::Display for OverwriteFilter {
     }
 }
 
+/// A destination entry the source compares against, taken from the directory manifest.
+pub struct ExistingDst<'a, M: crate::preserve::Metadata> {
+    /// The destination entry's metadata (with `size()` populated).
+    pub meta: &'a M,
+    /// Whether the destination entry is a regular file (only files are eligible for the
+    /// metadata-equality compare; a non-file means the source must send so the destination
+    /// can remove-and-replace it).
+    pub is_file: bool,
+}
+
+/// Decide whether the source may SKIP sending a file because the destination already holds a
+/// matching entry. `dst` is `None` when the destination has no entry at that name. Returns
+/// `true` to skip (the caller sends a `FileUnchanged` notification instead of file data).
+///
+/// This mirrors the destination's `process_single_file` identical/`--ignore-existing`/newer
+/// checks, so the source pre-filters exactly the files the destination would otherwise receive
+/// and drain. Skipping performs no filesystem mutation.
+pub fn skip_unchanged_send<S, D>(
+    overwrite_compare: &filecmp::MetadataCmpSettings,
+    overwrite_filter: Option<OverwriteFilter>,
+    ignore_existing: bool,
+    src: &S,
+    dst: Option<ExistingDst<'_, D>>,
+) -> bool
+where
+    S: crate::preserve::Metadata + std::fmt::Debug,
+    D: crate::preserve::Metadata + std::fmt::Debug,
+{
+    let Some(dst) = dst else {
+        return false; // nothing at the destination — must send
+    };
+    if ignore_existing {
+        return true; // any pre-existing entry (file/dir/symlink) — skip
+    }
+    if !dst.is_file {
+        return false; // dest is a non-file under --overwrite — send so dest replaces it
+    }
+    if filecmp::metadata_equal(overwrite_compare, src, dst.meta) {
+        return true; // identical per --overwrite-compare
+    }
+    if overwrite_filter == Some(OverwriteFilter::Newer) && filecmp::dest_is_newer(src, dst.meta) {
+        return true; // --overwrite-filter=newer and destination is strictly newer
+    }
+    false
+}
+
 /// Settings controlling rsync-style `--delete` (mirror) behavior.
 ///
 /// Present (`Some`) only when `--delete` was requested. `None` means the
@@ -5903,5 +5949,209 @@ mod copy_tests {
             assert_eq!(content, format!("content {i}"));
         }
         Ok(())
+    }
+
+    // fake metadata carrying the fields --overwrite-compare can use (size, mtime, uid, gid, mode).
+    #[derive(Clone, Debug)]
+    struct CmpMeta {
+        uid: u32,
+        gid: u32,
+        mode: u32,
+        size: u64,
+        mtime: i64,
+    }
+    impl crate::preserve::Metadata for CmpMeta {
+        fn uid(&self) -> u32 {
+            self.uid
+        }
+        fn gid(&self) -> u32 {
+            self.gid
+        }
+        fn atime(&self) -> i64 {
+            0
+        }
+        fn atime_nsec(&self) -> i64 {
+            0
+        }
+        fn mtime(&self) -> i64 {
+            self.mtime
+        }
+        fn mtime_nsec(&self) -> i64 {
+            0
+        }
+        fn permissions(&self) -> std::fs::Permissions {
+            std::os::unix::fs::PermissionsExt::from_mode(self.mode)
+        }
+        fn size(&self) -> u64 {
+            self.size
+        }
+    }
+
+    fn size_mtime() -> filecmp::MetadataCmpSettings {
+        filecmp::MetadataCmpSettings {
+            size: true,
+            mtime: true,
+            ..Default::default()
+        }
+    }
+    fn base() -> CmpMeta {
+        CmpMeta {
+            uid: 0,
+            gid: 0,
+            mode: 0o644,
+            size: 10,
+            mtime: 100,
+        }
+    }
+
+    #[test]
+    fn skip_send_no_existing_entry_sends() {
+        let src = base();
+        let r = skip_unchanged_send(
+            &size_mtime(),
+            None,
+            false,
+            &src,
+            None::<ExistingDst<CmpMeta>>,
+        );
+        assert!(!r);
+    }
+
+    #[test]
+    fn skip_send_ignore_existing_skips_any_type() {
+        let src = base();
+        let dst = base();
+        let r = skip_unchanged_send(
+            &size_mtime(),
+            None,
+            true,
+            &src,
+            Some(ExistingDst {
+                meta: &dst,
+                is_file: false,
+            }),
+        );
+        assert!(r);
+    }
+
+    #[test]
+    fn skip_send_overwrite_identical_skips() {
+        let src = base();
+        let dst = base();
+        let r = skip_unchanged_send(
+            &size_mtime(),
+            None,
+            false,
+            &src,
+            Some(ExistingDst {
+                meta: &dst,
+                is_file: true,
+            }),
+        );
+        assert!(r);
+    }
+
+    #[test]
+    fn skip_send_overwrite_different_size_sends() {
+        let src = base();
+        let dst = CmpMeta { size: 11, ..base() };
+        let r = skip_unchanged_send(
+            &size_mtime(),
+            None,
+            false,
+            &src,
+            Some(ExistingDst {
+                meta: &dst,
+                is_file: true,
+            }),
+        );
+        assert!(!r);
+    }
+
+    #[test]
+    fn skip_send_overwrite_different_mtime_sends() {
+        let src = base();
+        let dst = CmpMeta {
+            mtime: 200,
+            ..base()
+        };
+        let r = skip_unchanged_send(
+            &size_mtime(),
+            None,
+            false,
+            &src,
+            Some(ExistingDst {
+                meta: &dst,
+                is_file: true,
+            }),
+        );
+        assert!(!r);
+    }
+
+    #[test]
+    fn skip_send_overwrite_non_file_sends() {
+        let src = base();
+        let dst = base();
+        let r = skip_unchanged_send(
+            &size_mtime(),
+            None,
+            false,
+            &src,
+            Some(ExistingDst {
+                meta: &dst,
+                is_file: false,
+            }),
+        );
+        assert!(!r);
+    }
+
+    #[test]
+    fn skip_send_filter_newer_skips_when_dest_newer() {
+        let src = CmpMeta {
+            mtime: 100,
+            size: 5,
+            ..base()
+        };
+        let dst = CmpMeta {
+            mtime: 200,
+            size: 11,
+            ..base()
+        };
+        let r = skip_unchanged_send(
+            &size_mtime(),
+            Some(OverwriteFilter::Newer),
+            false,
+            &src,
+            Some(ExistingDst {
+                meta: &dst,
+                is_file: true,
+            }),
+        );
+        assert!(r);
+    }
+
+    #[test]
+    fn skip_send_filter_newer_sends_when_dest_older() {
+        let src = CmpMeta {
+            mtime: 200,
+            size: 5,
+            ..base()
+        };
+        let dst = CmpMeta {
+            mtime: 100,
+            size: 11,
+            ..base()
+        };
+        let r = skip_unchanged_send(
+            &size_mtime(),
+            Some(OverwriteFilter::Newer),
+            false,
+            &src,
+            Some(ExistingDst {
+                meta: &dst,
+                is_file: true,
+            }),
+        );
+        assert!(!r);
     }
 }

--- a/docs/remote_protocol.md
+++ b/docs/remote_protocol.md
@@ -742,6 +742,24 @@ names are never re-resolved. A skip performs no filesystem mutation; the destina
 `process_single_file` overwrite path still runs for files the source does send. The design's
 containment and permission-fidelity guarantees are therefore unchanged.
 
+**Point-in-time observation (not a re-validation at send time):** the skip decision compares
+two snapshots captured during the *scan* — the source entry from the Pass-2 directory
+enumeration and the destination entry from the Pass-1 manifest build — rather than re-fstatting
+at the moment of the decision. This differs from the transfer path, which re-derives the
+source metadata from the opened fd (`docs/tocttou.md` Guarantee 2 — the wire header must
+describe the bytes actually sent) and re-checks the destination entry at receipt in
+`process_single_file`. The consequence is purely about freshness, not safety: a file the
+manifest shows as identical is left untouched even if the source or destination entry is
+concurrently modified (or the destination entry removed) between the scan and the end of the
+copy. This is consistent with rcp's point-in-time, non-atomic copy semantics — concurrent
+external modification of the source or destination *during* a copy is never guaranteed to be
+reflected (even the transfer path stops re-checking a file once it has handled it; the skip
+path's observation point is simply earlier). Crucially, because a skip reads and writes nothing
+and emits no header describing un-sent bytes, it cannot violate the containment or
+permission-fidelity guarantees — Guarantee 2 governs the data path and does not apply when no
+data is sent. If a copy must reflect an actively-changing source or destination, do not rely on
+the skip optimization for that run (e.g. quiesce writers, or omit `--overwrite`/`--ignore-existing`).
+
 **Limitation — single root-file copy:** When copying a single file (e.g. `rcp h1:/a/file
 h2:/b/file --overwrite`), there is no parent-directory `DirectoryCreated` message to carry a
 manifest. This case is not optimized: the source always transfers the file and the destination

--- a/docs/remote_protocol.md
+++ b/docs/remote_protocol.md
@@ -132,6 +132,15 @@ All TCP connections are encrypted and authenticated using TLS 1.3 with self-sign
 - **Fields**: `src`, `dst`
 - **Usage**: Sent when file open fails (before any data connection is used). Counts as a processed entry for the parent directory's completion tracking. Transport failures after connection is established are fatal.
 
+**`FileUnchanged`**
+- **Purpose**: Notify destination that the source skipped transferring a file because the
+  destination already holds a matching entry (per the directory manifest in `DirectoryCreated`).
+- **Fields**: `src`, `dst`
+- **Usage**: Sent on the control stream like `FileSkipped`, but signals a *successful* skip (the
+  destination copy is already identical) rather than a failure. Counts as a processed entry for
+  the parent directory and as `files_unchanged` (the destination is authoritative for that count).
+  No file data is sent for the skipped file.
+
 **`SymlinkSkipped`**
 - **Purpose**: Notify destination that a symlink failed to read
 - **Fields**: `src_dst: {src, dst}`, `is_root`
@@ -141,8 +150,16 @@ All TCP connections are encrypted and authenticated using TLS 1.3 with self-sign
 
 **`DirectoryCreated`**
 - **Purpose**: Confirm directory created, request file transfers
-- **Fields**: `src`, `dst`
+- **Fields**: `src`, `dst`, `existing: Vec<ExistingEntry>`
 - **Usage**: Sent after successfully creating directory. This is purely the Pass-2 trigger: it tells the source the destination created the directory and is ready to receive its files. The source already retains the authoritative child-file count it computed during the Pass-1 pre-read (hardened: in the fd-map entry; `-L`: in a path→count map), so no count is echoed back. Triggers source to send files. See §7.1.
+- **`existing` field**: A manifest of the reused destination directory's pre-existing entries.
+  Each `ExistingEntry` carries `name`, `is_file`, `metadata`, and `size`. The source uses this
+  to skip transferring files that are already identical at the destination (sending
+  `FileUnchanged` instead of file data). The manifest is **empty** when the directory was
+  freshly created (not reused), when neither `--overwrite` nor `--ignore-existing` is active,
+  or when the directory's entry count exceeds the manifest cap
+  (`--overwrite-manifest-max-entries`, default 5,000,000) — in which case that directory falls
+  back to transferring-and-draining (the baseline behavior). See §7.9.
 
 **`DirectorySkipped`**
 - **Purpose**: Acknowledge a `Directory` message the destination did NOT create (create failed, ancestor failed, or `--ignore-existing` skipped a non-directory), so no files will be requested for it.
@@ -170,6 +187,7 @@ The protocol uses asymmetric error communication between source and destination:
 **Source → Destination: MUST communicate failures**
 - Source must notify destination of skipped files (`FileSkipped`) so destination can track entry counts correctly
 - Source must notify destination of skipped symlinks (`SymlinkSkipped`) for logging purposes
+- Source must notify destination of skipped-identical files (`FileUnchanged`) so destination can track entry counts correctly — an optimization notification (the destination already matched), not a failure, but it serves the same count-tracking role as `FileSkipped`
 - Without these notifications, destination would hang waiting for entries that will never arrive
 - **Note**: `FileSkipped` is only sent for file open failures. Transport failures (send errors after connection established) are fatal and abort the entire transfer
 
@@ -242,13 +260,16 @@ Source                              Destination
   |                                      |  child2 notifies root: entries_processed++ (2/4)
   |  ---- DirStructureComplete --------> |  Structure complete
   |                                      |
-  |  <--- DirectoryCreated(root) ------- |  (trigger only; no count echoed)
-  |  <--- DirectoryCreated(child1) ----- |
+  |  <--- DirectoryCreated(root,          |  (trigger only; no count echoed;
+  |         existing=[...]) ------------ |   existing=[] for freshly-created dirs,
+  |  <--- DirectoryCreated(child1,       |   non-empty only for reused dirs under
+  |         existing=[...]) ------------ |   --overwrite/--ignore-existing within
+  |                                      |   the manifest-cap limit)
   |                                      |
-  |  (look up retained file_count=2; send 2 files from root) |
-  |  ~~~~ File(root/f1) ~~~~~~~~~~~~~~~~>|  Write file
+  |  (look up retained file_count=2; compare root/f1 and root/f2 against manifest) |
+  |  ~~~~ File(root/f1) ~~~~~~~~~~~~~~~~>|  Write file (f1 not in manifest or differs)
   |                                      |  root: entries_processed++ (3/4)
-  |  ~~~~ File(root/f2) ~~~~~~~~~~~~~~~~>|  Write file
+  |  ---- FileUnchanged(root/f2) ------> |  f2 matches manifest; no data sent
   |                                      |  root: entries_processed++ (4/4)
   |                                      |  root complete → apply metadata
   |                                      |
@@ -663,6 +684,52 @@ Two mechanisms work together:
 
 The multiplier ensures work is always queued when connections become available, avoiding
 idle time between file transfers.
+
+### 7.9 Skipping identical files (destination manifest + source decision)
+
+When `--overwrite` or `--ignore-existing` is active, the destination can supply the source
+with a manifest of the reused directory's pre-existing entries so the source can skip
+transferring files that are already up to date.
+
+**Mechanism:**
+
+1. **Pass 1 (directory creation):** When the destination reuses an existing directory and the
+   feature is active, it enumerates the directory's children fd-relatively (using the same
+   `read_entries()` + `child()` pattern as the source's TOCTOU-safe walk — the directory is
+   pinned via an `O_NOFOLLOW` handle and names are never re-resolved by path). The resulting
+   `existing: Vec<ExistingEntry>` list is piggybacked onto the `DirectoryCreated` message.
+
+2. **Pass 2 (file sending):** For each file the source would normally transfer, it looks up the
+   file's name in the manifest. If a matching `ExistingEntry` is found, the source applies the
+   same comparison logic as the local `--overwrite` path (`--overwrite-compare`, default
+   `size,mtime`; `--overwrite-filter=newer` is also honored). Under `--ignore-existing`, any
+   name collision causes a skip regardless of entry type. When the comparison determines the
+   destination copy is already identical (or should be left alone), the source sends
+   `SourceMessage::FileUnchanged { src, dst }` on the control stream instead of opening a data
+   connection and transferring the file.
+
+3. **Accounting:** `FileUnchanged` counts as a processed entry for the parent directory's
+   completion tracking (identical to `FileSkipped`) and increments `files_unchanged` on the
+   destination. The destination is authoritative for `files_unchanged` (consistent with §7.7).
+   No filesystem mutation occurs for a skipped file.
+
+**When the manifest is empty (fallback to baseline behavior):**
+- The directory was freshly created (not reused).
+- Neither `--overwrite` nor `--ignore-existing` is active.
+- The directory's pre-existing entry count exceeds `--overwrite-manifest-max-entries` (default
+  5,000,000). This cap bounds memory usage for pathological cases; it is a backstop, not a
+  normal limit. When exceeded, the manifest is omitted for that directory and the source
+  transfers-and-drains all its files as usual.
+
+**TOCTOU/safety:** The manifest is built fd-relatively on the pinned directory handle, so
+names are never re-resolved. A skip performs no filesystem mutation; the destination's existing
+`process_single_file` overwrite path still runs for files the source does send. The design's
+containment and permission-fidelity guarantees are therefore unchanged.
+
+**Limitation — single root-file copy:** When copying a single file (e.g. `rcp h1:/a/file
+h2:/b/file --overwrite`), there is no parent-directory `DirectoryCreated` message to carry a
+manifest. This case is not optimized: the source always transfers the file and the destination
+drains it.
 
 ## 8. Test Coverage
 

--- a/docs/remote_protocol.md
+++ b/docs/remote_protocol.md
@@ -134,7 +134,7 @@ All TCP connections are encrypted and authenticated using TLS 1.3 with self-sign
 
 **`FileUnchanged`**
 - **Purpose**: Notify destination that the source skipped transferring a file because the
-  destination already holds a matching entry (per the directory manifest in `DirectoryCreated`).
+  destination already holds a matching entry (per the directory manifest in `DirectoryManifestChunk`s).
 - **Fields**: `src`, `dst`
 - **Usage**: Sent on the control stream like `FileSkipped`, but signals a *successful* skip (the
   destination copy is already identical) rather than a failure. Counts as a processed entry for
@@ -148,18 +148,30 @@ All TCP connections are encrypted and authenticated using TLS 1.3 with self-sign
 
 ### 2.3 Destination → Source Messages (Control Stream)
 
+**`DirectoryManifestChunk`**
+- **Purpose**: Carry a chunk of the reused destination directory's pre-existing-entry manifest,
+  used by the source to skip transferring identical files.
+- **Fields**: `dst`, `entries: Vec<ExistingEntry>` (each `ExistingEntry` carries `name`,
+  `is_file`, `metadata`, `size`)
+- **Usage**: A directory's manifest is split into one or more chunks, each well under the control
+  stream's frame limit (`LengthDelimitedCodec`, 8 MiB), and **all** of them are sent **before**
+  that directory's `DirectoryCreated`. The control stream is FIFO, so the source has the complete
+  manifest by the time it processes `DirectoryCreated`. No chunks are sent when the directory was
+  freshly created (not reused), when neither `--overwrite` nor `--ignore-existing` is active, or
+  when the directory's entry count exceeds the manifest cap (`--overwrite-manifest-max-entries`,
+  default 5,000,000) — in which case that directory falls back to transferring-and-draining (the
+  baseline behavior). Chunking the manifest (rather than inlining it in `DirectoryCreated`)
+  ensures the cap stays meaningful without any single control frame exceeding the frame limit.
+  See §7.9.
+
 **`DirectoryCreated`**
 - **Purpose**: Confirm directory created, request file transfers
-- **Fields**: `src`, `dst`, `existing: Vec<ExistingEntry>`
-- **Usage**: Sent after successfully creating directory. This is purely the Pass-2 trigger: it tells the source the destination created the directory and is ready to receive its files. The source already retains the authoritative child-file count it computed during the Pass-1 pre-read (hardened: in the fd-map entry; `-L`: in a path→count map), so no count is echoed back. Triggers source to send files. See §7.1.
-- **`existing` field**: A manifest of the reused destination directory's pre-existing entries.
-  Each `ExistingEntry` carries `name`, `is_file`, `metadata`, and `size`. The source uses this
-  to skip transferring files that are already identical at the destination (sending
-  `FileUnchanged` instead of file data). The manifest is **empty** when the directory was
-  freshly created (not reused), when neither `--overwrite` nor `--ignore-existing` is active,
-  or when the directory's entry count exceeds the manifest cap
-  (`--overwrite-manifest-max-entries`, default 5,000,000) — in which case that directory falls
-  back to transferring-and-draining (the baseline behavior). See §7.9.
+- **Fields**: `src`, `dst`
+- **Usage**: Sent after successfully creating directory, and after any `DirectoryManifestChunk`s
+  for it. This is purely the Pass-2 trigger: it tells the source the destination created the
+  directory and is ready to receive its files. The source already retains the authoritative
+  child-file count it computed during the Pass-1 pre-read (hardened: in the fd-map entry; `-L`: in
+  a path→count map), so no count is echoed back. Triggers source to send files. See §7.1.
 
 **`DirectorySkipped`**
 - **Purpose**: Acknowledge a `Directory` message the destination did NOT create (create failed, ancestor failed, or `--ignore-existing` skipped a non-directory), so no files will be requested for it.
@@ -260,11 +272,11 @@ Source                              Destination
   |                                      |  child2 notifies root: entries_processed++ (2/4)
   |  ---- DirStructureComplete --------> |  Structure complete
   |                                      |
-  |  <--- DirectoryCreated(root,          |  (trigger only; no count echoed;
-  |         existing=[...]) ------------ |   existing=[] for freshly-created dirs,
-  |  <--- DirectoryCreated(child1,       |   non-empty only for reused dirs under
-  |         existing=[...]) ------------ |   --overwrite/--ignore-existing within
-  |                                      |   the manifest-cap limit)
+  |  <--- DirectoryManifestChunk(root, [..]) | (0+ chunks for reused dirs under
+  |                                      |   --overwrite/--ignore-existing, sent
+  |                                      |   BEFORE the trigger; none otherwise)
+  |  <--- DirectoryCreated(root) -------- |  (trigger only; no count echoed)
+  |  <--- DirectoryCreated(child1) ------ |
   |                                      |
   |  (look up retained file_count=2; compare root/f1 and root/f2 against manifest) |
   |  ~~~~ File(root/f1) ~~~~~~~~~~~~~~~~>|  Write file (f1 not in manifest or differs)
@@ -697,7 +709,11 @@ transferring files that are already up to date.
    feature is active, it enumerates the directory's children fd-relatively (using the same
    `read_entries()` + `child()` pattern as the source's TOCTOU-safe walk — the directory is
    pinned via an `O_NOFOLLOW` handle and names are never re-resolved by path). The resulting
-   `existing: Vec<ExistingEntry>` list is piggybacked onto the `DirectoryCreated` message.
+   manifest (`Vec<ExistingEntry>`) is split into one or more `DirectoryManifestChunk` messages,
+   each kept well under the control stream's `LengthDelimitedCodec` frame limit (8 MiB), and sent
+   **before** that directory's `DirectoryCreated`. The control stream is FIFO, so the source has
+   the complete manifest in hand when it processes `DirectoryCreated`. Chunking keeps the entry
+   cap (default 5,000,000) meaningful without ever producing a single oversized control frame.
 
 2. **Pass 2 (file sending):** For each file the source would normally transfer, it looks up the
    file's name in the manifest. If a matching `ExistingEntry` is found, the source applies the

--- a/rcp/src/bin/rcp.rs
+++ b/rcp/src/bin/rcp.rs
@@ -59,6 +59,16 @@ struct Args {
     )]
     overwrite_compare: String,
 
+    /// Max pre-existing destination entries per directory eligible for skip-without-transfer
+    /// (remote --overwrite/--ignore-existing). Above this, that directory transfers normally.
+    #[arg(
+        long,
+        default_value_t = remote::protocol::DEFAULT_OVERWRITE_MANIFEST_MAX_ENTRIES,
+        value_name = "N",
+        help_heading = "Copy options"
+    )]
+    overwrite_manifest_max_entries: usize,
+
     /// Skip overwriting files that match a condition
     ///
     /// Available filters: "newer" (skip if destination mtime is strictly newer than source).
@@ -462,6 +472,7 @@ async fn run_rcpd_master(
         dereference: args.dereference,
         overwrite: args.overwrite,
         overwrite_compare: args.overwrite_compare.clone(),
+        overwrite_manifest_max_entries: args.overwrite_manifest_max_entries,
         overwrite_filter: args.overwrite_filter.map(|f| f.to_string()),
         ignore_existing: args.ignore_existing,
         skip_specials: args.skip_specials,

--- a/rcp/src/bin/rcpd.rs
+++ b/rcp/src/bin/rcpd.rs
@@ -46,6 +46,15 @@ struct Args {
     )]
     overwrite_compare: String,
 
+    /// Max pre-existing destination entries per directory eligible for skip-without-transfer.
+    #[arg(
+        long,
+        default_value_t = remote::protocol::DEFAULT_OVERWRITE_MANIFEST_MAX_ENTRIES,
+        value_name = "N",
+        help_heading = "Copy options"
+    )]
+    overwrite_manifest_max_entries: usize,
+
     /// Skip overwriting files that match a condition (used with --overwrite)
     #[arg(
         long,

--- a/rcp/src/bin/rcpd.rs
+++ b/rcp/src/bin/rcpd.rs
@@ -395,6 +395,7 @@ where
                 &source_data_addr,
                 &server_name,
                 &settings,
+                args.overwrite_manifest_max_entries,
                 &preserve,
                 &tcp_config,
                 cert_key.as_ref(),

--- a/rcp/src/destination.rs
+++ b/rcp/src/destination.rs
@@ -675,6 +675,54 @@ enum DirectoryCreateResult {
     Failed,
 }
 
+/// Enumerate a reused destination directory (fd-relative on its pinned `O_NOFOLLOW` handle) into
+/// a manifest of pre-existing entries, so the source can skip transferring identical files.
+///
+/// Returns an empty manifest (no `child()` stats performed) when the entry count exceeds
+/// `max_entries` — the large-directory safeguard: that directory falls back to today's
+/// transfer-and-drain. Entries that cannot be enumerated/stat'd are omitted (conservative: the
+/// source will send them).
+async fn build_existing_manifest(
+    dir: &Arc<Dir>,
+    max_entries: usize,
+) -> Vec<remote::protocol::ExistingEntry> {
+    use common::preserve::Metadata as _;
+    let entries = match dir.read_entries().await {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::debug!("manifest: cannot enumerate destination directory: {:#}", e);
+            return Vec::new();
+        }
+    };
+    if entries.len() > max_entries {
+        tracing::debug!(
+            "manifest: {} entries exceeds cap {}, skipping manifest (files will transfer)",
+            entries.len(),
+            max_entries
+        );
+        return Vec::new();
+    }
+    let mut manifest = Vec::with_capacity(entries.len());
+    for (name, _hint) in entries {
+        match dir.child(&name).await {
+            Ok(handle) => {
+                let meta = handle.meta();
+                manifest.push(remote::protocol::ExistingEntry {
+                    name: std::path::PathBuf::from(name),
+                    is_file: handle.kind() == common::walk::EntryKind::File,
+                    metadata: remote::protocol::Metadata::from(meta),
+                    size: meta.size(),
+                });
+            }
+            Err(e) => {
+                let e: anyhow::Error = e.into();
+                tracing::debug!("manifest: cannot stat child {:?}: {:#}", name, e);
+            }
+        }
+    }
+    manifest
+}
+
 /// Create a directory fd-relative on the PARENT's held `Dir`, handling overwrite logic.
 ///
 /// All operations resolve relative to `dst_parent`'s pinned fd: classify an existing entry via
@@ -865,6 +913,7 @@ async fn create_symlink(
 #[instrument(skip(error_collector, control_recv_stream, directory_tracker))]
 async fn process_control_stream(
     settings: &common::copy::Settings,
+    overwrite_manifest_max_entries: usize,
     preserve: &common::preserve::Settings,
     mut control_recv_stream: remote::streams::BoxedRecvStream,
     directory_tracker: directory_tracker::SharedDirectoryTracker,
@@ -945,6 +994,14 @@ async fn process_control_stream(
                 match create_result {
                     DirectoryCreateResult::Created(dir)
                     | DirectoryCreateResult::AlreadyExisted(dir) => {
+                        // build the manifest only for a REUSED dir under overwrite/ignore-existing;
+                        // a freshly-created dir is empty and feature-off needs no manifest.
+                        let existing =
+                            if !was_created && (settings.overwrite || settings.ignore_existing) {
+                                build_existing_manifest(&dir, overwrite_manifest_max_entries).await
+                            } else {
+                                Vec::new()
+                            };
                         // add to tracker (sends DirectoryCreated, stores the dir fd in the fd-map)
                         // tracker handles root directory tracking internally
                         directory_tracker
@@ -959,7 +1016,7 @@ async fn process_control_stream(
                                 was_created,
                                 entry_count,
                                 keep_if_empty,
-                                Vec::new(),
+                                existing,
                             )
                             .await
                             .context("Failed to add directory to tracker")?;
@@ -1160,6 +1217,7 @@ pub async fn run_destination(
     src_data_addr: &std::net::SocketAddr,
     _src_server_name: &str,
     settings: &common::copy::Settings,
+    overwrite_manifest_max_entries: usize,
     preserve: &common::preserve::Settings,
     tcp_config: &remote::TcpConfig,
     cert_key: Option<&remote::tls::CertifiedKey>,
@@ -1244,6 +1302,7 @@ pub async fn run_destination(
     );
     let control_future = process_control_stream(
         settings,
+        overwrite_manifest_max_entries,
         preserve,
         control_recv_stream,
         directory_tracker.clone(),
@@ -1312,5 +1371,59 @@ pub async fn run_destination(
         }
         .into()),
         None => Ok(("destination OK".to_string(), summary)),
+    }
+}
+
+#[cfg(test)]
+mod manifest_tests {
+    use super::*;
+
+    async fn open_dir(path: &std::path::Path) -> Arc<Dir> {
+        Arc::new(
+            common::safedir::Dir::open_root_dir(path, false, common::Side::Destination)
+                .await
+                .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn manifest_lists_files_dirs_symlinks() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "hello").unwrap(); // 5 bytes
+        std::fs::create_dir(tmp.path().join("sub")).unwrap();
+        std::os::unix::fs::symlink("a.txt", tmp.path().join("link")).unwrap();
+        let dir = open_dir(tmp.path()).await;
+
+        let manifest = build_existing_manifest(&dir, usize::MAX).await;
+
+        assert_eq!(manifest.len(), 3);
+        let file = manifest
+            .iter()
+            .find(|e| e.name == std::path::Path::new("a.txt"))
+            .unwrap();
+        assert!(file.is_file);
+        assert_eq!(file.size, 5);
+        let sub = manifest
+            .iter()
+            .find(|e| e.name == std::path::Path::new("sub"))
+            .unwrap();
+        assert!(!sub.is_file);
+        let link = manifest
+            .iter()
+            .find(|e| e.name == std::path::Path::new("link"))
+            .unwrap();
+        assert!(!link.is_file);
+    }
+
+    #[tokio::test]
+    async fn manifest_capped_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "x").unwrap();
+        std::fs::write(tmp.path().join("b.txt"), "y").unwrap();
+        let dir = open_dir(tmp.path()).await;
+
+        // 2 entries, cap 1 => fall back to empty manifest (no stats, transfer-and-drain)
+        let manifest = build_existing_manifest(&dir, 1).await;
+        assert!(manifest.is_empty());
     }
 }

--- a/rcp/src/destination.rs
+++ b/rcp/src/destination.rs
@@ -687,6 +687,11 @@ async fn build_existing_manifest(
     max_entries: usize,
 ) -> Vec<remote::protocol::ExistingEntry> {
     use common::preserve::Metadata as _;
+    // a cap of 0 disables the optimization for every non-empty directory; short-circuit before
+    // the readdir so the disable case pays nothing.
+    if max_entries == 0 {
+        return Vec::new();
+    }
     let entries = match dir.read_entries().await {
         Ok(entries) => entries,
         Err(e) => {
@@ -1424,6 +1429,17 @@ mod manifest_tests {
 
         // 2 entries, cap 1 => fall back to empty manifest (no stats, transfer-and-drain)
         let manifest = build_existing_manifest(&dir, 1).await;
+        assert!(manifest.is_empty());
+    }
+
+    #[tokio::test]
+    async fn manifest_zero_cap_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("a.txt"), "x").unwrap();
+        let dir = open_dir(tmp.path()).await;
+
+        // cap 0 disables the optimization (short-circuits before the readdir)
+        let manifest = build_existing_manifest(&dir, 0).await;
         assert!(manifest.is_empty());
     }
 }

--- a/rcp/src/destination.rs
+++ b/rcp/src/destination.rs
@@ -1095,6 +1095,25 @@ async fn process_control_stream(
                     .await
                     .context("Failed to update tracker for skipped file")?;
             }
+            remote::protocol::SourceMessage::FileUnchanged { ref src, ref dst } => {
+                tracing::info!(
+                    "File unchanged, source skipped transfer: {:?} -> {:?}",
+                    src,
+                    dst
+                );
+                // destination is authoritative for files_unchanged (matches the drain path
+                // in process_single_file).
+                prog.files_unchanged.inc();
+                let parent_dir = dst
+                    .parent()
+                    .ok_or_else(|| anyhow::anyhow!("unchanged file {:?} has no parent", dst))?;
+                directory_tracker
+                    .lock()
+                    .await
+                    .process_file(parent_dir)
+                    .await
+                    .context("Failed to update tracker for unchanged file")?;
+            }
             remote::protocol::SourceMessage::SymlinkSkipped {
                 ref src_dst,
                 is_root,

--- a/rcp/src/destination.rs
+++ b/rcp/src/destination.rs
@@ -959,6 +959,7 @@ async fn process_control_stream(
                                 was_created,
                                 entry_count,
                                 keep_if_empty,
+                                Vec::new(),
                             )
                             .await
                             .context("Failed to add directory to tracker")?;

--- a/rcp/src/directory_tracker.rs
+++ b/rcp/src/directory_tracker.rs
@@ -231,22 +231,36 @@ impl DirectoryTracker {
                 keep_if_empty,
             },
         );
-        // send DirectoryCreated to trigger file sending (Pass-2 trigger only; the
-        // source retains the authoritative Pass-1 file count, so none is echoed).
-        let message = remote::protocol::DestinationMessage::DirectoryCreated {
-            src: src.to_path_buf(),
-            dst: dst.to_path_buf(),
+        // stream the pre-existing-entry manifest as chunks (each well under the control stream's
+        // frame limit) BEFORE DirectoryCreated, then send the trigger. The control stream is FIFO,
+        // so the source has the full manifest before it sees DirectoryCreated. The lock is held
+        // across the whole sequence so a directory's chunks stay contiguous with its trigger.
+        let manifest_entries = existing.len();
+        let chunks = remote::protocol::chunk_manifest(
             existing,
-        };
+            remote::protocol::MANIFEST_CHUNK_BYTE_BUDGET,
+        );
         {
             let mut stream = self.control_send_stream.lock().await;
+            for entries in chunks {
+                let chunk_msg = remote::protocol::DestinationMessage::DirectoryManifestChunk {
+                    dst: dst.to_path_buf(),
+                    entries,
+                };
+                stream.send_batch_message(&chunk_msg).await?;
+            }
+            let message = remote::protocol::DestinationMessage::DirectoryCreated {
+                src: src.to_path_buf(),
+                dst: dst.to_path_buf(),
+            };
             stream.send_control_message(&message).await?;
         }
         tracing::info!(
-            "Sent DirectoryCreated: {:?} -> {:?} (entries={})",
+            "Sent DirectoryCreated: {:?} -> {:?} (entries={}, manifest={})",
             src,
             dst,
-            entry_count
+            entry_count,
+            manifest_entries
         );
         // if entry_count is 0, directory is immediately complete
         if entry_count == 0 {

--- a/rcp/src/directory_tracker.rs
+++ b/rcp/src/directory_tracker.rs
@@ -196,6 +196,7 @@ impl DirectoryTracker {
     /// * `was_created` - true if we created this directory, false if it already existed
     /// * `entry_count` - total child entries (files + dirs + symlinks)
     /// * `keep_if_empty` - whether to keep this directory if empty
+    /// * `existing` - pre-existing destination entries to include in the `DirectoryCreated` manifest
     #[allow(clippy::too_many_arguments)]
     pub async fn add_directory(
         &mut self,
@@ -207,6 +208,7 @@ impl DirectoryTracker {
         was_created: bool,
         entry_count: usize,
         keep_if_empty: bool,
+        existing: Vec<remote::protocol::ExistingEntry>,
     ) -> anyhow::Result<()> {
         // store metadata for later application
         self.metadata.insert(dst.to_path_buf(), metadata);
@@ -234,6 +236,7 @@ impl DirectoryTracker {
         let message = remote::protocol::DestinationMessage::DirectoryCreated {
             src: src.to_path_buf(),
             dst: dst.to_path_buf(),
+            existing,
         };
         {
             let mut stream = self.control_send_stream.lock().await;

--- a/rcp/src/source.rs
+++ b/rcp/src/source.rs
@@ -2157,7 +2157,7 @@ async fn dispatch_control_messages_tcp(
                     remote::protocol::DestinationMessage::DirectoryCreated {
                         ref src,
                         ref dst,
-                        ref existing,
+                        existing,
                     } => {
                         tracing::info!(
                             "Received directory creation confirmation for: {:?} -> {:?} ({} existing)",
@@ -2168,9 +2168,11 @@ async fn dispatch_control_messages_tcp(
                         let existing_map: std::sync::Arc<
                             std::collections::HashMap<std::path::PathBuf, remote::protocol::ExistingEntry>,
                         > = std::sync::Arc::new(
+                            // move each entry into the map (only the small name key is cloned),
+                            // avoiding a full per-entry clone of the received manifest.
                             existing
-                                .iter()
-                                .map(|e| (e.name.clone(), e.clone()))
+                                .into_iter()
+                                .map(|e| (e.name.clone(), e))
                                 .collect(),
                         );
                         // build the owned Pass-2 input. In hardened mode this CONSUMES the

--- a/rcp/src/source.rs
+++ b/rcp/src/source.rs
@@ -1693,7 +1693,6 @@ async fn send_files_in_directory_tcp(
         std::collections::HashMap<std::path::PathBuf, remote::protocol::ExistingEntry>,
     >,
 ) -> anyhow::Result<()> {
-    let _ = &existing; // used in a later task (skip identical files)
     // the Pass-1 count is authoritative for this directory's send logic (truncation
     // and synthetic `FileSkipped`). It comes entirely from the source side now (the
     // consumed map entry or the `-L` count map); the destination echoes nothing.
@@ -1900,6 +1899,48 @@ async fn send_files_in_directory_tcp(
     let mut join_set = tokio::task::JoinSet::new();
     for file in file_entries {
         throttle::get_ops_token().await;
+        // skip transfer entirely when the destination already has a matching entry (per the
+        // manifest the destination sent in DirectoryCreated). this never opens a data connection.
+        let src_fm = remote::protocol::FileMetadata {
+            metadata: &file.metadata,
+            size: file.size,
+        };
+        let skip = match existing.get(std::path::Path::new(&file.name)) {
+            Some(e) => {
+                let dst_fm = remote::protocol::FileMetadata {
+                    metadata: &e.metadata,
+                    size: e.size,
+                };
+                common::copy::skip_unchanged_send(
+                    &settings.overwrite_compare,
+                    settings.overwrite_filter,
+                    settings.ignore_existing,
+                    &src_fm,
+                    Some(common::copy::ExistingDst {
+                        meta: &dst_fm,
+                        is_file: e.is_file,
+                    }),
+                )
+            }
+            None => false,
+        };
+        if skip {
+            tracing::info!(
+                "destination already has identical file, skipping transfer (manifest): {:?} -> {:?}",
+                file.src_path,
+                file.dst_path
+            );
+            let msg = remote::protocol::SourceMessage::FileUnchanged {
+                src: file.src_path.clone(),
+                dst: file.dst_path.clone(),
+            };
+            control_send_stream
+                .lock()
+                .await
+                .send_batch_message(&msg)
+                .await?;
+            continue;
+        }
         // wait for a pending slot - this is the main backpressure point
         let permit = pending_limit
             .clone()

--- a/rcp/src/source.rs
+++ b/rcp/src/source.rs
@@ -1670,7 +1670,8 @@ async fn send_files_missing_directory(
     control_send_stream,
     stream_pool,
     pending_limit,
-    pass2_source
+    pass2_source,
+    existing
 ))]
 #[allow(clippy::too_many_arguments)]
 async fn send_files_in_directory_tcp(
@@ -1688,7 +1689,11 @@ async fn send_files_in_directory_tcp(
     pending_limit: std::sync::Arc<tokio::sync::Semaphore>,
     error_collector: std::sync::Arc<common::error_collector::ErrorCollector>,
     control_send_stream: remote::streams::BoxedSharedSendStream,
+    existing: std::sync::Arc<
+        std::collections::HashMap<std::path::PathBuf, remote::protocol::ExistingEntry>,
+    >,
 ) -> anyhow::Result<()> {
+    let _ = &existing; // used in a later task (skip identical files)
     // the Pass-1 count is authoritative for this directory's send logic (truncation
     // and synthetic `FileSkipped`). It comes entirely from the source side now (the
     // consumed map entry or the `-L` count map); the destination echoes nothing.
@@ -2111,11 +2116,21 @@ async fn dispatch_control_messages_tcp(
                     remote::protocol::DestinationMessage::DirectoryCreated {
                         ref src,
                         ref dst,
+                        ref existing,
                     } => {
                         tracing::info!(
-                            "Received directory creation confirmation for: {:?} -> {:?}",
+                            "Received directory creation confirmation for: {:?} -> {:?} ({} existing)",
                             src,
-                            dst
+                            dst,
+                            existing.len()
+                        );
+                        let existing_map: std::sync::Arc<
+                            std::collections::HashMap<std::path::PathBuf, remote::protocol::ExistingEntry>,
+                        > = std::sync::Arc::new(
+                            existing
+                                .iter()
+                                .map(|e| (e.name.clone(), e.clone()))
+                                .collect(),
                         );
                         // build the owned Pass-2 input. In hardened mode this CONSUMES the
                         // directory's held fd-map entry (one-shot ownership) and fails closed
@@ -2140,6 +2155,7 @@ async fn dispatch_control_messages_tcp(
                             pending_limit.clone(),
                             collector,
                             control_send_stream.clone(),
+                            existing_map,
                         ));
                     }
                     remote::protocol::DestinationMessage::DirectorySkipped {

--- a/rcp/src/source.rs
+++ b/rcp/src/source.rs
@@ -2122,6 +2122,13 @@ async fn dispatch_control_messages_tcp(
         }
         control_recv_stream.close().await;
     });
+    // accumulate per-directory manifest chunks (keyed by dst) until the directory's
+    // DirectoryCreated arrives; the FIFO control stream delivers all of a directory's chunks
+    // before its trigger, so the manifest is complete when we assemble it.
+    let mut manifest_chunks: std::collections::HashMap<
+        std::path::PathBuf,
+        Vec<remote::protocol::ExistingEntry>,
+    > = std::collections::HashMap::new();
     // main loop - select between task completions and messages (both are cancel-safe)
     let result = loop {
         tokio::select! {
@@ -2154,13 +2161,22 @@ async fn dispatch_control_messages_tcp(
                     Some(RecvResult::Error(e)) => break Err(e),
                 };
                 match message {
+                    remote::protocol::DestinationMessage::DirectoryManifestChunk {
+                        dst,
+                        entries,
+                    } => {
+                        // accumulate this directory's manifest; all chunks arrive (FIFO) before the
+                        // matching DirectoryCreated assembles and consumes them.
+                        manifest_chunks.entry(dst).or_default().extend(entries);
+                    }
                     remote::protocol::DestinationMessage::DirectoryCreated {
                         ref src,
                         ref dst,
-                        existing,
                     } => {
+                        // take the manifest accumulated from this directory's chunks (empty if none).
+                        let existing = manifest_chunks.remove(dst.as_path()).unwrap_or_default();
                         tracing::info!(
-                            "Received directory creation confirmation for: {:?} -> {:?} ({} existing)",
+                            "Received directory creation confirmation for: {:?} -> {:?} ({} manifest entries)",
                             src,
                             dst,
                             existing.len()
@@ -2168,8 +2184,7 @@ async fn dispatch_control_messages_tcp(
                         let existing_map: std::sync::Arc<
                             std::collections::HashMap<std::path::PathBuf, remote::protocol::ExistingEntry>,
                         > = std::sync::Arc::new(
-                            // move each entry into the map (only the small name key is cloned),
-                            // avoiding a full per-entry clone of the received manifest.
+                            // move each entry into the map (only the small name key is cloned).
                             existing
                                 .into_iter()
                                 .map(|e| (e.name.clone(), e))

--- a/rcp/tests/remote_tests.rs
+++ b/rcp/tests/remote_tests.rs
@@ -5612,3 +5612,117 @@ fn test_remote_overwrite_manifest_cap_falls_back_to_transfer() {
         "above the cap the manifest is omitted, so the source must NOT skip-by-manifest"
     );
 }
+
+/// nested tree: a reused parent containing a REUSED child subdir (identical file → skipped) and a
+/// FRESH child subdir (no destination counterpart → file copied). Proves the manifest is built
+/// per-directory: non-empty for the reused child, empty for the freshly-created child.
+#[test]
+fn test_remote_overwrite_nested_mixed_fresh_and_reused_dirs() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let src_sub = src_dir.path().join("tree");
+    let dst_sub = dst_dir.path().join("tree");
+    // reused child subdir exists on both sides with an identical file
+    std::fs::create_dir_all(src_sub.join("reused")).unwrap();
+    std::fs::create_dir_all(dst_sub.join("reused")).unwrap();
+    create_test_file(&src_sub.join("reused/f.txt"), "shared", 0o644);
+    create_test_file(&dst_sub.join("reused/f.txt"), "shared", 0o644);
+    let t = filetime::FileTime::from_unix_time(1_700_000_000, 0);
+    filetime::set_file_mtime(src_sub.join("reused/f.txt"), t).unwrap();
+    filetime::set_file_mtime(dst_sub.join("reused/f.txt"), t).unwrap();
+    // fresh child subdir exists only on the source
+    std::fs::create_dir_all(src_sub.join("fresh")).unwrap();
+    create_test_file(&src_sub.join("fresh/g.txt"), "new file", 0o644);
+    let src_remote = format!("localhost:{}", src_sub.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_sub.to_str().unwrap());
+    let output =
+        run_rcp_and_expect_success(&["--overwrite", "--summary", &src_remote, &dst_remote]);
+    let summary = parse_summary_from_output(&output).expect("Failed to parse summary");
+    // reused/f.txt skipped (manifest), fresh/g.txt copied into the freshly-created subdir
+    assert_eq!(summary.files_unchanged, 1, "reused/f.txt unchanged");
+    assert_eq!(summary.files_copied, 1, "fresh/g.txt copied");
+    assert_eq!(get_file_content(&dst_sub.join("reused/f.txt")), "shared");
+    assert_eq!(get_file_content(&dst_sub.join("fresh/g.txt")), "new file");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("skipping transfer (manifest)"),
+        "the reused subdir's identical file should be skipped via the manifest, got:\n{combined}"
+    );
+}
+
+/// --overwrite-filter=newer through the manifest path (files within a reused directory): a file
+/// whose destination is strictly newer is skipped; one whose destination is older is re-sent.
+/// Both files differ in content/size so the newer-filter (not metadata-equality) drives the skip.
+#[test]
+fn test_remote_overwrite_filter_newer_in_directory() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let src_sub = src_dir.path().join("tree");
+    let dst_sub = dst_dir.path().join("tree");
+    std::fs::create_dir(&src_sub).unwrap();
+    std::fs::create_dir(&dst_sub).unwrap();
+    // dest is NEWER => skip (kept). content differs so this is the newer-filter, not equality.
+    create_test_file(&src_sub.join("keep_dest.txt"), "src side", 0o644);
+    create_test_file(
+        &dst_sub.join("keep_dest.txt"),
+        "destination is newer",
+        0o644,
+    );
+    filetime::set_file_mtime(
+        src_sub.join("keep_dest.txt"),
+        filetime::FileTime::from_unix_time(1_000_000_000, 0),
+    )
+    .unwrap();
+    filetime::set_file_mtime(
+        dst_sub.join("keep_dest.txt"),
+        filetime::FileTime::from_unix_time(2_000_000_000, 0),
+    )
+    .unwrap();
+    // dest is OLDER => re-send (overwritten).
+    create_test_file(
+        &src_sub.join("update_dest.txt"),
+        "fresh source bytes",
+        0o644,
+    );
+    create_test_file(&dst_sub.join("update_dest.txt"), "old", 0o644);
+    filetime::set_file_mtime(
+        src_sub.join("update_dest.txt"),
+        filetime::FileTime::from_unix_time(2_000_000_000, 0),
+    )
+    .unwrap();
+    filetime::set_file_mtime(
+        dst_sub.join("update_dest.txt"),
+        filetime::FileTime::from_unix_time(1_000_000_000, 0),
+    )
+    .unwrap();
+    let src_remote = format!("localhost:{}", src_sub.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_sub.to_str().unwrap());
+    let output = run_rcp_and_expect_success(&[
+        "--overwrite",
+        "--overwrite-filter=newer",
+        "--summary",
+        &src_remote,
+        &dst_remote,
+    ]);
+    let summary = parse_summary_from_output(&output).expect("Failed to parse summary");
+    assert_eq!(summary.files_unchanged, 1, "dest-newer file kept");
+    assert_eq!(summary.files_copied, 1, "dest-older file re-sent");
+    // newer destination preserved; older destination overwritten with source bytes
+    assert_eq!(
+        get_file_content(&dst_sub.join("keep_dest.txt")),
+        "destination is newer"
+    );
+    assert_eq!(
+        get_file_content(&dst_sub.join("update_dest.txt")),
+        "fresh source bytes"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("skipping transfer (manifest)"),
+        "the dest-newer file should be skipped via the manifest, got:\n{combined}"
+    );
+}

--- a/rcp/tests/remote_tests.rs
+++ b/rcp/tests/remote_tests.rs
@@ -5401,3 +5401,214 @@ fn test_remote_dest_symlink_at_file_path_not_followed_out_of_tree() {
         "planted file-path symlink should remain a symlink"
     );
 }
+
+/// re-syncing a directory whose files are byte-and-mtime identical must transfer NO file data:
+/// every file is files_unchanged, bytes_copied is 0, and the source-skip marker proves the data
+/// path was never opened (vs today's "send then drain").
+#[test]
+fn test_remote_overwrite_skips_identical_files_in_directory() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let src_sub = src_dir.path().join("tree");
+    let dst_sub = dst_dir.path().join("tree");
+    std::fs::create_dir(&src_sub).unwrap();
+    std::fs::create_dir(&dst_sub).unwrap();
+    for i in 0..3 {
+        let name = format!("f{i}.txt");
+        let content = format!("identical content {i}");
+        create_test_file(&src_sub.join(&name), &content, 0o644);
+        create_test_file(&dst_sub.join(&name), &content, 0o644);
+        // make mtimes identical so the default size,mtime quick-check matches
+        let t = filetime::FileTime::from_unix_time(1_700_000_000, 0);
+        filetime::set_file_mtime(src_sub.join(&name), t).unwrap();
+        filetime::set_file_mtime(dst_sub.join(&name), t).unwrap();
+    }
+    let src_remote = format!("localhost:{}", src_sub.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_sub.to_str().unwrap());
+    let output =
+        run_rcp_and_expect_success(&["--overwrite", "--summary", &src_remote, &dst_remote]);
+    let summary = parse_summary_from_output(&output).expect("Failed to parse summary");
+    assert_eq!(summary.files_copied, 0, "no file should be copied");
+    assert_eq!(summary.files_unchanged, 3, "all 3 files unchanged");
+    assert_eq!(summary.bytes_copied, 0, "no bytes written");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("skipping transfer (manifest)"),
+        "source-skip marker should appear (proving data was not sent), got:\n{combined}"
+    );
+}
+
+/// a mix of identical + changed + new files: only changed/new transfer; identical are skipped.
+#[test]
+fn test_remote_overwrite_partial_overlap_transfers_only_changed() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let src_sub = src_dir.path().join("tree");
+    let dst_sub = dst_dir.path().join("tree");
+    std::fs::create_dir(&src_sub).unwrap();
+    std::fs::create_dir(&dst_sub).unwrap();
+    let t = filetime::FileTime::from_unix_time(1_700_000_000, 0);
+    // identical file
+    create_test_file(&src_sub.join("same.txt"), "same", 0o644);
+    create_test_file(&dst_sub.join("same.txt"), "same", 0o644);
+    filetime::set_file_mtime(src_sub.join("same.txt"), t).unwrap();
+    filetime::set_file_mtime(dst_sub.join("same.txt"), t).unwrap();
+    // changed file (different content => different size)
+    create_test_file(&src_sub.join("changed.txt"), "new longer content", 0o644);
+    create_test_file(&dst_sub.join("changed.txt"), "old", 0o644);
+    // brand-new file (not at destination)
+    create_test_file(&src_sub.join("new.txt"), "brand new", 0o644);
+    let src_remote = format!("localhost:{}", src_sub.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_sub.to_str().unwrap());
+    let output =
+        run_rcp_and_expect_success(&["--overwrite", "--summary", &src_remote, &dst_remote]);
+    let summary = parse_summary_from_output(&output).expect("Failed to parse summary");
+    assert_eq!(summary.files_unchanged, 1, "same.txt unchanged");
+    assert_eq!(summary.files_copied, 2, "changed.txt + new.txt copied");
+    // only the changed + new files' bytes cross the wire (18 + 9); same.txt contributes none
+    assert_eq!(summary.bytes_copied, 27, "only changed.txt + new.txt bytes");
+    assert_eq!(
+        get_file_content(&dst_sub.join("changed.txt")),
+        "new longer content"
+    );
+    assert_eq!(get_file_content(&dst_sub.join("new.txt")), "brand new");
+}
+
+/// a file whose SIZE matches but mtime differs must be re-sent (default compare is size,mtime).
+/// content is held same-length-but-different only so we can confirm the new bytes actually land —
+/// the size,mtime quick-check ignores content, so the resend is attributable to the mtime.
+#[test]
+fn test_remote_overwrite_resends_when_mtime_differs() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let src_sub = src_dir.path().join("tree");
+    let dst_sub = dst_dir.path().join("tree");
+    std::fs::create_dir(&src_sub).unwrap();
+    std::fs::create_dir(&dst_sub).unwrap();
+    // same length (10 bytes), different bytes, different mtime
+    create_test_file(&src_sub.join("f.txt"), "fresh data", 0o644);
+    create_test_file(&dst_sub.join("f.txt"), "stale data", 0o644);
+    filetime::set_file_mtime(
+        src_sub.join("f.txt"),
+        filetime::FileTime::from_unix_time(2_000_000_000, 0),
+    )
+    .unwrap();
+    filetime::set_file_mtime(
+        dst_sub.join("f.txt"),
+        filetime::FileTime::from_unix_time(1_000_000_000, 0),
+    )
+    .unwrap();
+    let src_remote = format!("localhost:{}", src_sub.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_sub.to_str().unwrap());
+    let output =
+        run_rcp_and_expect_success(&["--overwrite", "--summary", &src_remote, &dst_remote]);
+    let summary = parse_summary_from_output(&output).expect("Failed to parse summary");
+    assert_eq!(summary.files_copied, 1, "mtime differs => re-send");
+    assert_eq!(summary.files_unchanged, 0);
+    // confirm the resend actually wrote the source bytes (not merely counted it)
+    assert_eq!(get_file_content(&dst_sub.join("f.txt")), "fresh data");
+}
+
+/// --ignore-existing skips any colliding file by name without transfer (content untouched).
+#[test]
+fn test_remote_ignore_existing_skips_colliding_files_in_directory() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let src_sub = src_dir.path().join("tree");
+    let dst_sub = dst_dir.path().join("tree");
+    std::fs::create_dir(&src_sub).unwrap();
+    std::fs::create_dir(&dst_sub).unwrap();
+    create_test_file(&src_sub.join("keep.txt"), "source version", 0o644);
+    create_test_file(&dst_sub.join("keep.txt"), "destination version", 0o644);
+    create_test_file(&src_sub.join("fresh.txt"), "fresh", 0o644);
+    let src_remote = format!("localhost:{}", src_sub.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_sub.to_str().unwrap());
+    let output =
+        run_rcp_and_expect_success(&["--ignore-existing", "--summary", &src_remote, &dst_remote]);
+    assert_eq!(
+        get_file_content(&dst_sub.join("keep.txt")),
+        "destination version"
+    );
+    assert_eq!(get_file_content(&dst_sub.join("fresh.txt")), "fresh");
+    let summary = parse_summary_from_output(&output).expect("Failed to parse summary");
+    assert_eq!(summary.files_unchanged, 1);
+    assert_eq!(summary.files_copied, 1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("skipping transfer (manifest)"),
+        "source-skip marker should appear for the colliding file, got:\n{combined}"
+    );
+}
+
+/// type mismatch under --overwrite: dest has a SYMLINK where source has a file => must send and
+/// replace (the manifest marks it is_file=false, so the source does not skip).
+#[test]
+fn test_remote_overwrite_sends_when_dest_entry_is_symlink() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let src_sub = src_dir.path().join("tree");
+    let dst_sub = dst_dir.path().join("tree");
+    std::fs::create_dir(&src_sub).unwrap();
+    std::fs::create_dir(&dst_sub).unwrap();
+    create_test_file(&src_sub.join("x"), "real file content", 0o644);
+    std::os::unix::fs::symlink("/nonexistent", dst_sub.join("x")).unwrap();
+    let src_remote = format!("localhost:{}", src_sub.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_sub.to_str().unwrap());
+    let output =
+        run_rcp_and_expect_success(&["--overwrite", "--summary", &src_remote, &dst_remote]);
+    assert!(
+        !dst_sub.join("x").is_symlink(),
+        "symlink should be replaced by a file"
+    );
+    assert_eq!(get_file_content(&dst_sub.join("x")), "real file content");
+    let summary = parse_summary_from_output(&output).expect("Failed to parse summary");
+    assert_eq!(summary.files_copied, 1);
+    assert_eq!(
+        summary.files_unchanged, 0,
+        "a type-mismatched dest entry must not be skipped"
+    );
+}
+
+/// large-directory safeguard: with the cap set to 1, a 2-entry reused dir falls back to
+/// transfer-and-drain — identical files are still unchanged, but the source-skip marker is absent.
+#[test]
+fn test_remote_overwrite_manifest_cap_falls_back_to_transfer() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let src_sub = src_dir.path().join("tree");
+    let dst_sub = dst_dir.path().join("tree");
+    std::fs::create_dir(&src_sub).unwrap();
+    std::fs::create_dir(&dst_sub).unwrap();
+    let t = filetime::FileTime::from_unix_time(1_700_000_000, 0);
+    for i in 0..2 {
+        let name = format!("f{i}.txt");
+        create_test_file(&src_sub.join(&name), "same", 0o644);
+        create_test_file(&dst_sub.join(&name), "same", 0o644);
+        filetime::set_file_mtime(src_sub.join(&name), t).unwrap();
+        filetime::set_file_mtime(dst_sub.join(&name), t).unwrap();
+    }
+    let src_remote = format!("localhost:{}", src_sub.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_sub.to_str().unwrap());
+    let output = run_rcp_and_expect_success(&[
+        "--overwrite",
+        "--overwrite-manifest-max-entries=1",
+        "--summary",
+        &src_remote,
+        &dst_remote,
+    ]);
+    let summary = parse_summary_from_output(&output).expect("Failed to parse summary");
+    // still correct: identical files are unchanged (destination drains them), no bytes written
+    assert_eq!(summary.files_unchanged, 2);
+    assert_eq!(summary.bytes_copied, 0);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        !combined.contains("skipping transfer (manifest)"),
+        "above the cap the manifest is omitted, so the source must NOT skip-by-manifest"
+    );
+}

--- a/remote/src/protocol/mod.rs
+++ b/remote/src/protocol/mod.rs
@@ -19,10 +19,11 @@
 //!   |  ---- Symlink(...) ----------------> |  Create symlink
 //!   |  ---- DirStructureComplete --------> |  Structure complete
 //!   |                                      |
-//!   |  <--- DirectoryCreated(root,          |  existing=[...] for reused dirs
-//!   |         existing=[...]) ------------ |  under --overwrite/--ignore-existing
-//!   |  <--- DirectoryCreated(child,        |  (empty for freshly-created dirs or
-//!   |         existing=[...]) ------------ |  when cap exceeded)
+//!   |  <--- DirectoryManifestChunk(root,..)|  0+ manifest chunks for reused dirs
+//!   |                                      |  under --overwrite/--ignore-existing,
+//!   |                                      |  sent BEFORE the trigger (FIFO)
+//!   |  <--- DirectoryCreated(root) -------- |  Pass-2 trigger
+//!   |  <--- DirectoryCreated(child) ------- |
 //!   |                                      |
 //!   |  ~~~~ File(f) ~~~~~~~~~~~~~~~~~~~~~> |  Write file (not in manifest / differs)
 //!   |  ---- FileUnchanged(g) -----------> |  identical g not transferred
@@ -153,7 +154,7 @@ impl From<&common::safedir::FileMeta> for Metadata {
     }
 }
 
-/// One pre-existing destination directory entry, sent in `DirectoryCreated`'s manifest so the
+/// One pre-existing destination directory entry, sent in a `DirectoryManifestChunk` so the
 /// source can skip transferring identical files. `name` is the child name (serialized as a
 /// `PathBuf`, matching the rest of the protocol's path handling). `metadata`/`size` are only
 /// meaningful when `is_file`.
@@ -163,6 +164,42 @@ pub struct ExistingEntry {
     pub is_file: bool,
     pub metadata: Metadata,
     pub size: u64,
+}
+
+/// Conservative byte budget for a single `DirectoryManifestChunk`. Well under the control
+/// stream's 8 MiB `LengthDelimitedCodec` frame limit, leaving ample margin for the message
+/// envelope and the worst-case final entry (a single ~`PATH_MAX` name).
+pub const MANIFEST_CHUNK_BYTE_BUDGET: usize = 4 * 1024 * 1024;
+
+/// Conservative serialized-size estimate for one `ExistingEntry`: the variable-length name plus a
+/// fixed allowance covering `is_file` + `Metadata` + `size` + per-entry framing overhead. Used
+/// only to bound chunk sizes, so over-estimating (smaller, safer chunks) is fine.
+fn estimate_entry_size(entry: &ExistingEntry) -> usize {
+    entry.name.as_os_str().len() + 64
+}
+
+/// Split a directory manifest into chunks each estimated to stay within `byte_budget`, so every
+/// `DirectoryManifestChunk` frame fits under the control stream's frame limit. A single entry
+/// larger than the budget still gets its own chunk (it cannot be split further); with the 4 MiB
+/// budget versus a worst-case ~4 KiB path, a chunk never approaches the 8 MiB frame limit.
+/// `chunk_manifest(v, b).concat() == v` for any `v` (no entries lost or reordered).
+pub fn chunk_manifest(entries: Vec<ExistingEntry>, byte_budget: usize) -> Vec<Vec<ExistingEntry>> {
+    let mut chunks: Vec<Vec<ExistingEntry>> = Vec::new();
+    let mut current: Vec<ExistingEntry> = Vec::new();
+    let mut current_bytes = 0usize;
+    for entry in entries {
+        let size = estimate_entry_size(&entry);
+        if !current.is_empty() && current_bytes + size > byte_budget {
+            chunks.push(std::mem::take(&mut current));
+            current_bytes = 0;
+        }
+        current_bytes += size;
+        current.push(entry);
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    chunks
 }
 
 /// File header sent on unidirectional streams, followed by raw file data.
@@ -267,20 +304,26 @@ pub struct SrcDst {
 /// Messages sent from destination to source on the control stream.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum DestinationMessage {
+    /// Carry a chunk of the (reused) destination directory's pre-existing-entry manifest, used
+    /// by the source to skip transferring identical files. A directory's manifest is split into
+    /// one or more chunks (each well under the control stream's frame limit) and ALL of them are
+    /// sent BEFORE the directory's `DirectoryCreated`; the control stream is FIFO, so the source
+    /// has the complete manifest by the time it sees `DirectoryCreated`. No chunks are sent for a
+    /// freshly-created directory, when neither `--overwrite` nor `--ignore-existing` is active, or
+    /// when the directory exceeds the manifest cap (see `RcpdConfig::overwrite_manifest_max_entries`).
+    DirectoryManifestChunk {
+        dst: std::path::PathBuf,
+        entries: Vec<ExistingEntry>,
+    },
     /// Confirm directory created, request file transfers. This is purely the
     /// Pass-2 trigger: it tells the source the destination created the directory
     /// and is ready to receive its files. The source already retains the
     /// authoritative Pass-1 file count for the directory (in its fd-map entry under
     /// hardened reads, or in a path→count map under `-L`), so no count is echoed
-    /// back here.
+    /// back here. Any `DirectoryManifestChunk`s for this directory precede this message.
     DirectoryCreated {
         src: std::path::PathBuf,
         dst: std::path::PathBuf,
-        /// Pre-existing entries in the (reused) destination directory, used by the source to
-        /// skip transferring identical files. Empty for freshly-created dirs, when neither
-        /// `--overwrite` nor `--ignore-existing` is active, or when the directory exceeds the
-        /// manifest cap (see `RcpdConfig::overwrite_manifest_max_entries`).
-        existing: Vec<ExistingEntry>,
     },
     /// Acknowledge a `Directory` message the destination did NOT create (create
     /// failed, ancestor failed, or `--ignore-existing` skipped a non-directory).
@@ -593,6 +636,72 @@ pub enum RcpdResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn mk_entry(name: &str) -> ExistingEntry {
+        ExistingEntry {
+            name: std::path::PathBuf::from(name),
+            is_file: true,
+            metadata: Metadata {
+                mode: 0o644,
+                uid: 0,
+                gid: 0,
+                atime: 0,
+                mtime: 0,
+                atime_nsec: 0,
+                mtime_nsec: 0,
+            },
+            size: 0,
+        }
+    }
+
+    #[test]
+    fn chunk_manifest_empty_yields_no_chunks() {
+        assert!(chunk_manifest(vec![], MANIFEST_CHUNK_BYTE_BUDGET).is_empty());
+    }
+
+    #[test]
+    fn chunk_manifest_small_is_single_chunk() {
+        let entries: Vec<_> = (0..100).map(|i| mk_entry(&format!("f{i}.txt"))).collect();
+        let chunks = chunk_manifest(entries, MANIFEST_CHUNK_BYTE_BUDGET);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].len(), 100);
+    }
+
+    #[test]
+    fn chunk_manifest_splits_and_preserves_all_entries_in_order() {
+        let entries: Vec<_> = (0..1000)
+            .map(|i| mk_entry(&format!("file_{i:04}.dat")))
+            .collect();
+        // a tiny budget forces many chunks (each entry estimate is name.len() + 64 ≈ ~78 bytes)
+        let chunks = chunk_manifest(entries.clone(), 256);
+        assert!(
+            chunks.len() > 1,
+            "tiny budget should produce multiple chunks"
+        );
+        // frame-safety property: every multi-entry chunk stays within budget, so a chunk frame
+        // never approaches the control stream's frame limit
+        for chunk in &chunks {
+            if chunk.len() > 1 {
+                let total: usize = chunk.iter().map(estimate_entry_size).sum();
+                assert!(total <= 256, "multi-entry chunk exceeds budget: {total}");
+            }
+        }
+        // reassembly invariant: concat preserves every entry, in order, with nothing lost
+        let flat: Vec<_> = chunks.into_iter().flatten().collect();
+        assert_eq!(flat.len(), entries.len());
+        for (got, want) in flat.iter().zip(entries.iter()) {
+            assert_eq!(got.name, want.name);
+        }
+    }
+
+    #[test]
+    fn chunk_manifest_entry_larger_than_budget_gets_its_own_chunk() {
+        // budget smaller than a single entry: each still lands in its own chunk (never dropped).
+        let chunks = chunk_manifest(vec![mk_entry("a"), mk_entry("b")], 1);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), 1);
+        assert_eq!(chunks[1].len(), 1);
+    }
 
     fn minimal_rcpd_config() -> RcpdConfig {
         RcpdConfig {

--- a/remote/src/protocol/mod.rs
+++ b/remote/src/protocol/mod.rs
@@ -19,11 +19,13 @@
 //!   |  ---- Symlink(...) ----------------> |  Create symlink
 //!   |  ---- DirStructureComplete --------> |  Structure complete
 //!   |                                      |
-//!   |  <--- DirectoryCreated(root) ------- |
-//!   |  <--- DirectoryCreated(child) ------ |
+//!   |  <--- DirectoryCreated(root,          |  existing=[...] for reused dirs
+//!   |         existing=[...]) ------------ |  under --overwrite/--ignore-existing
+//!   |  <--- DirectoryCreated(child,        |  (empty for freshly-created dirs or
+//!   |         existing=[...]) ------------ |  when cap exceeded)
 //!   |                                      |
-//!   |  ~~~~ File(f, total=N) ~~~~~~~~~~~~> |  Write file, track count
-//!   |  ~~~~ File(...) ~~~~~~~~~~~~~~~~~~-> |  ...
+//!   |  ~~~~ File(f) ~~~~~~~~~~~~~~~~~~~~~> |  Write file (not in manifest / differs)
+//!   |  ---- FileUnchanged(g) -----------> |  identical g not transferred
 //!   |                                      |  All files done → apply metadata
 //!   |                                      |
 //!   |  <--- DestinationDone -------------- |  Close send side
@@ -34,8 +36,11 @@
 //! # Error Communication
 //!
 //! The protocol uses asymmetric error communication:
-//! - **Source → Destination**: Must communicate failures (FileSkipped, SymlinkSkipped)
-//!   so destination can track file counts correctly
+//! - **Source → Destination**: Must communicate failures (`FileSkipped`, `SymlinkSkipped`)
+//!   so destination can track file counts correctly. `FileUnchanged` is also sent Source →
+//!   Destination but is an optimization notification (not a failure): it signals the source
+//!   skipped a file whose destination copy is already identical, and is counted as
+//!   `files_unchanged` on the destination.
 //! - **Destination → Source**: Does NOT communicate failures. Destination handles
 //!   errors locally and source continues sending the full structure.
 //!

--- a/remote/src/protocol/mod.rs
+++ b/remote/src/protocol/mod.rs
@@ -50,6 +50,12 @@ use serde::{Deserialize, Serialize};
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::prelude::PermissionsExt;
 
+/// Default cap on the number of pre-existing destination entries the destination will put in a
+/// directory's overwrite/ignore-existing manifest. Above this, the manifest is omitted and that
+/// directory falls back to transferring-and-draining files (see `docs/remote_protocol.md`). High
+/// by default — rcp typically runs on large hosts; the cap is a backstop, not a normal limit.
+pub const DEFAULT_OVERWRITE_MANIFEST_MAX_ENTRIES: usize = 5_000_000;
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Metadata {
     pub mode: u32,
@@ -299,6 +305,8 @@ pub struct RcpdConfig {
     pub dereference: bool,
     pub overwrite: bool,
     pub overwrite_compare: String,
+    /// Cap on pre-existing entries put into a directory's overwrite/ignore-existing manifest.
+    pub overwrite_manifest_max_entries: usize,
     pub overwrite_filter: Option<String>,
     pub ignore_existing: bool,
     pub skip_specials: bool,
@@ -341,6 +349,10 @@ impl RcpdConfig {
             format!("--iops-throttle={}", self.iops_throttle),
             format!("--chunk-size={}", self.chunk_size),
             format!("--overwrite-compare={}", self.overwrite_compare),
+            format!(
+                "--overwrite-manifest-max-entries={}",
+                self.overwrite_manifest_max_entries
+            ),
         ];
         if self.verbose > 0 {
             args.push(format!("-{}", "v".repeat(self.verbose as usize)));
@@ -596,7 +608,20 @@ mod tests {
             tokio_console_port: None,
             encryption: true,
             master_cert_fingerprint: None,
+            overwrite_manifest_max_entries: DEFAULT_OVERWRITE_MANIFEST_MAX_ENTRIES,
         }
+    }
+
+    #[test]
+    fn to_args_includes_overwrite_manifest_max_entries() {
+        let mut config = minimal_rcpd_config();
+        config.overwrite_manifest_max_entries = 123_456;
+        let args = config.to_args();
+        assert!(
+            args.iter()
+                .any(|a| a == "--overwrite-manifest-max-entries=123456"),
+            "expected manifest cap flag in {args:?}"
+        );
     }
 
     #[test]

--- a/remote/src/protocol/mod.rs
+++ b/remote/src/protocol/mod.rs
@@ -148,6 +148,18 @@ impl From<&common::safedir::FileMeta> for Metadata {
     }
 }
 
+/// One pre-existing destination directory entry, sent in `DirectoryCreated`'s manifest so the
+/// source can skip transferring identical files. `name` is the child name (serialized as a
+/// `PathBuf`, matching the rest of the protocol's path handling). `metadata`/`size` are only
+/// meaningful when `is_file`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ExistingEntry {
+    pub name: std::path::PathBuf,
+    pub is_file: bool,
+    pub metadata: Metadata,
+    pub size: u64,
+}
+
 /// File header sent on unidirectional streams, followed by raw file data.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct File {
@@ -259,6 +271,11 @@ pub enum DestinationMessage {
     DirectoryCreated {
         src: std::path::PathBuf,
         dst: std::path::PathBuf,
+        /// Pre-existing entries in the (reused) destination directory, used by the source to
+        /// skip transferring identical files. Empty for freshly-created dirs, when neither
+        /// `--overwrite` nor `--ignore-existing` is active, or when the directory exceeds the
+        /// manifest cap (see `RcpdConfig::overwrite_manifest_max_entries`).
+        existing: Vec<ExistingEntry>,
     },
     /// Acknowledge a `Directory` message the destination did NOT create (create
     /// failed, ancestor failed, or `--ignore-existing` skipped a non-directory).

--- a/remote/src/protocol/mod.rs
+++ b/remote/src/protocol/mod.rs
@@ -221,6 +221,14 @@ pub enum SourceMessage {
         src: std::path::PathBuf,
         dst: std::path::PathBuf,
     },
+    /// Notify destination that the source skipped sending a file because the destination
+    /// already holds a matching entry (per the directory manifest). Counts as a processed
+    /// entry for the parent directory and as `files_unchanged` (the destination is the
+    /// authority for that count). The control-stream sibling of `FileSkipped`.
+    FileUnchanged {
+        src: std::path::PathBuf,
+        dst: std::path::PathBuf,
+    },
     /// Notify destination that a symlink failed to read.
     /// If `is_root` is true, this signals that root processing is complete (even if failed).
     /// Non-root skipped symlinks count as a processed entry for the parent directory.


### PR DESCRIPTION
## Summary

Remote copy no longer sends a file's data over the network when the destination already has a matching file. Previously the destination received the **entire** file and then discarded it (`drain_file_data`) when it turned out identical — wasting the whole transfer.

- **Mechanism:** when the destination *reuses* an existing directory, it builds a manifest of that directory's pre-existing entries (`ExistingEntry { name, is_file, metadata, size }`) and piggybacks it on the `DirectoryCreated` control message (the Pass-2 trigger). In Pass 2 the source compares each file against the manifest via a shared pure helper (`common::copy::skip_unchanged_send`, mirroring the local `process_single_file` checks) and, for skippable files, sends a new `SourceMessage::FileUnchanged` control message **instead of** opening a data connection.
- **Semantics:** honors `--overwrite-compare` (default `size,mtime`), `--overwrite-filter=newer`, and `--ignore-existing` (any-type name collision). The destination stays authoritative for the `files_unchanged` count (§7.7).
- **Large-directory safeguard:** configurable `--overwrite-manifest-max-entries` (default 5,000,000) bounds the manifest; above it that directory falls back to today's transfer-and-drain — no per-entry stat storm, no giant control message.
- **Zero-cost when off:** no manifest is built (no extra syscalls, empty `Vec` on the wire) for a freshly-created destination directory or when neither `--overwrite` nor `--ignore-existing` is active.
- **TOCTOU:** the destination enumerates the reused directory fd-relative on its pinned `O_NOFOLLOW` handle (same hardened `read_entries()` + `child()` pattern as the source walk); a skip mutates nothing, and the destination's `process_single_file` still runs for files that are sent — so containment + permission-fidelity guarantees are unchanged.
- **Limitation:** a single root-file copy (`rcp h1:/a/file h2:/b/file --overwrite`) has no parent `DirectoryCreated` to carry a manifest, so it is not optimized — documented.

`docs/remote_protocol.md` (the protocol source of truth) is updated: new `FileUnchanged` message (§2.2), `DirectoryCreated.existing` manifest field (§2.3), flow diagram (§4.1), and a new rationale subsection (§7.9).

Compatibility relies on the existing exact-version match across master/source/destination (all the same build); the workspace is already `0.34.0` (> last tag `0.33.0`), so the wire change is version-gated.

## Test plan

- [ ] `just ci` (lint + doc + debug/release tests + Docker multi-host)

Locally verified on this branch:
- `just lint` — clean (fmt, clippy, all CI check scripts incl. `check-source-read-fidelity`, `check-remote-test-naming`)
- `just test` (nextest, debug) — 1140 passed, 50 skipped
- `just test-release` — 1140 passed
- `just doc` — clean

New integration tests (`rcp/tests/remote_tests.rs`). The source-side `skipping transfer (manifest)` log marker is the discriminator that data was *not* sent (since `bytes_copied` is 0 for unchanged files either way):
- re-sync all-identical → 0 files copied, 0 bytes, all `files_unchanged`, marker present
- partial overlap (identical + changed + new) → only changed/new transfer (exact byte count asserted)
- mtime-differs → re-sent (content-write confirmed)
- `--ignore-existing` → colliding files skipped, destination untouched
- type mismatch (dest symlink where source has a file) → sent + replaced
- cap fallback (`--overwrite-manifest-max-entries=1`) → no skip marker, counts still correct
- nested mixed fresh/reused subdirectories → per-directory manifest behavior
- `--overwrite-filter=newer` via manifest → dest-newer skipped, dest-older re-sent

Plus unit tests for the decision helper (`common`) and the manifest builder + cap (`rcp`).
