### PR TITLE
Plug test gaps: throttle, DirectoryTracker, chmod, remote swap, manifest chunking

### DIFF
--- a/rchm/tests/tests.rs
+++ b/rchm/tests/tests.rs
@@ -301,3 +301,133 @@ fn defer_dir_changes_with_fail_early_does_not_change_ancestor_after_child_error(
     );
     std::fs::set_permissions(&child, std::fs::Permissions::from_mode(0o755)).unwrap();
 }
+
+/// Supplementary groups the current user belongs to (for privilege-free chgrp tests).
+fn current_groups() -> Vec<u32> {
+    let out = std::process::Command::new("id").arg("-G").output().unwrap();
+    String::from_utf8(out.stdout)
+        .unwrap()
+        .split_whitespace()
+        .filter_map(|g| g.parse().ok())
+        .collect()
+}
+
+#[test]
+fn defer_dir_changes_keep_going_applies_change_despite_open_failure() {
+    // post-order (--defer-dir-changes) + keep-going: a pre-existing 0000 directory cannot be opened
+    // to process its contents, so the run reports an error — but the deferred change to the
+    // directory itself must still be applied via its O_PATH handle (which works on a 0000 dir).
+    let d = tempfile::tempdir().unwrap();
+    let dir = d.path().join("locked");
+    std::fs::create_dir(&dir).unwrap();
+    std::fs::write(dir.join("inner"), b"x").unwrap();
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+    rchm()
+        .args(["--mode", "d:u+rwx", "--defer-dir-changes"])
+        .arg(&dir)
+        .assert()
+        .failure();
+    assert_eq!(
+        mode_of(&dir),
+        0o700,
+        "the deferred change is applied even though the directory open failed"
+    );
+    // dir is now 0o700, so tempdir cleanup can recurse to remove the inner file
+}
+
+#[test]
+fn owner_change_to_current_uid_is_accepted_and_unchanged() {
+    // a file already owned by the current user: --owner <uid> resolves the DSL and the plan
+    // correctly accounts it as unchanged — exercises the owner-resolution path without privilege.
+    let d = tempfile::tempdir().unwrap();
+    let f = d.path().join("f.txt");
+    std::fs::write(&f, b"x").unwrap();
+    let uid = std::fs::metadata(&f).unwrap().uid();
+    let out = rchm()
+        .args(["--owner", &uid.to_string(), "--summary"])
+        .arg(&f)
+        .assert()
+        .success();
+    assert_eq!(
+        std::fs::metadata(&f).unwrap().uid(),
+        uid,
+        "the uid is unchanged"
+    );
+    let stdout = String::from_utf8(out.get_output().stdout.clone()).unwrap();
+    assert!(
+        stdout.contains("files unchanged: 1"),
+        "stdout was: {stdout}"
+    );
+    assert!(stdout.contains("files changed: 0"), "stdout was: {stdout}");
+}
+
+#[test]
+fn group_change_preserves_setgid_across_chgrp() {
+    // changing a setgid file's group to another group the user belongs to needs no privilege; the
+    // kernel clears setgid on chgrp, so rchm must restore it (chown-first, then re-chmod).
+    let d = tempfile::tempdir().unwrap();
+    let f = d.path().join("f.txt");
+    std::fs::write(&f, b"x").unwrap();
+    std::fs::set_permissions(&f, std::fs::Permissions::from_mode(0o2644)).unwrap();
+    let cur_gid = std::fs::symlink_metadata(&f).unwrap().gid();
+    assert_eq!(
+        mode_of(&f),
+        0o2644,
+        "setup: the setgid bit must be set before the chgrp"
+    );
+    let Some(target) = current_groups().into_iter().find(|&g| g != cur_gid) else {
+        eprintln!("skipping: the user belongs to only one group, cannot chgrp without privilege");
+        return;
+    };
+    rchm()
+        .args(["--group", &target.to_string()])
+        .arg(&f)
+        .assert()
+        .success();
+    let after = std::fs::symlink_metadata(&f).unwrap();
+    assert_eq!(
+        after.gid(),
+        target,
+        "the group must change to the target group"
+    );
+    assert_eq!(
+        after.permissions().mode() & 0o7777,
+        0o2644,
+        "the setgid bit must be restored after the chgrp cleared it"
+    );
+}
+
+#[test]
+#[ignore = "requires passwordless sudo"]
+fn sudo_owner_and_group_change_to_root() {
+    // a real uid+gid change needs privilege; this runs only under the sudo-gated CI job. an
+    // unprivileged user can still unlink the resulting root-owned file from its own tempdir.
+    let sudo_ok = std::process::Command::new("sudo")
+        .args(["-n", "true"])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if !sudo_ok {
+        eprintln!("Skipping test: passwordless sudo not available");
+        return;
+    }
+    let d = tempfile::tempdir().unwrap();
+    let f = d.path().join("f.txt");
+    std::fs::write(&f, b"x").unwrap();
+    let status = std::process::Command::new("sudo")
+        .args([
+            "-n",
+            env!("CARGO_BIN_EXE_rchm"),
+            "--owner",
+            "0",
+            "--group",
+            "0",
+        ])
+        .arg(&f)
+        .status()
+        .expect("failed to run sudo rchm");
+    assert!(status.success(), "sudo rchm should succeed");
+    let after = std::fs::symlink_metadata(&f).unwrap();
+    assert_eq!(after.uid(), 0, "owner must change to root");
+    assert_eq!(after.gid(), 0, "group must change to root");
+}

--- a/rcp/src/directory_tracker.rs
+++ b/rcp/src/directory_tracker.rs
@@ -551,3 +551,172 @@ pub fn make_shared(
         error_collector,
     )))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // a sink writer discards every control message, so the completion state machine can be driven
+    // without a real connection.
+    fn mock_stream() -> remote::streams::BoxedSharedSendStream {
+        let writer: remote::streams::BoxedWrite = Box::new(tokio::io::sink());
+        std::sync::Arc::new(tokio::sync::Mutex::new(remote::streams::SendStream::new(
+            writer,
+        )))
+    }
+    fn new_tracker() -> DirectoryTracker {
+        DirectoryTracker::new(
+            mock_stream(),
+            common::preserve::preserve_none(),
+            false,
+            std::sync::Arc::new(common::error_collector::ErrorCollector::default()),
+        )
+    }
+    fn meta() -> remote::protocol::Metadata {
+        remote::protocol::Metadata {
+            mode: 0o755,
+            uid: 0,
+            gid: 0,
+            atime: 0,
+            mtime: 0,
+            atime_nsec: 0,
+            mtime_nsec: 0,
+        }
+    }
+    async fn open_dir(path: &std::path::Path) -> Arc<Dir> {
+        Arc::new(
+            common::safedir::Dir::open_root_dir(path, false, common::Side::Destination)
+                .await
+                .unwrap(),
+        )
+    }
+    #[test]
+    fn has_failed_ancestor_walks_up_to_a_failed_directory() {
+        let mut t = new_tracker();
+        t.mark_directory_failed(std::path::Path::new("/dst/a/b"));
+        assert!(t.has_failed_ancestor(std::path::Path::new("/dst/a/b/c")));
+        assert!(t.has_failed_ancestor(std::path::Path::new("/dst/a/b/c/d")));
+        assert!(
+            !t.has_failed_ancestor(std::path::Path::new("/dst/a/b")),
+            "the failed directory is not its own ancestor"
+        );
+        assert!(
+            !t.has_failed_ancestor(std::path::Path::new("/dst/a/x")),
+            "a sibling subtree is unaffected"
+        );
+    }
+    #[tokio::test]
+    async fn is_done_requires_structure_root_complete_and_no_pending() {
+        let mut t = new_tracker();
+        assert!(!t.is_done(), "a fresh tracker is not done");
+        t.set_structure_complete(true); // has_root_item=true: does NOT auto-complete the root
+        assert!(
+            !t.is_done(),
+            "structure complete but the root item is still pending"
+        );
+        t.set_root_complete();
+        assert!(
+            t.is_done(),
+            "structure + root complete with no pending dirs is done"
+        );
+    }
+    #[tokio::test]
+    async fn structure_complete_with_no_root_item_is_immediately_done() {
+        // dry-run / filtered-root: no root messages will follow, so completion is immediate.
+        let mut t = new_tracker();
+        t.set_structure_complete(false);
+        assert!(t.is_done());
+    }
+    #[tokio::test]
+    async fn send_destination_done_guards_against_double_send() {
+        let mut t = new_tracker();
+        assert!(
+            t.send_destination_done().await.unwrap(),
+            "the first send returns true"
+        );
+        assert!(
+            !t.send_destination_done().await.unwrap(),
+            "a second send is a no-op and returns false"
+        );
+    }
+    #[tokio::test]
+    async fn process_on_untracked_directory_is_a_noop() {
+        // a File/FileSkipped/child entry received under a failed (untracked) ancestor must be
+        // tolerated rather than aborting the destination.
+        let mut t = new_tracker();
+        let untracked = std::path::Path::new("/not/tracked");
+        assert!(!t.process_file(untracked).await.unwrap());
+        t.process_child_entry(untracked).await.unwrap();
+    }
+    #[tokio::test]
+    async fn child_completion_propagates_to_parent_bottom_up() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parent_path = tmp.path().join("parent");
+        let child_path = parent_path.join("child");
+        std::fs::create_dir_all(&child_path).unwrap();
+        let parent_dir = open_dir(&parent_path).await;
+        let child_dir = open_dir(&child_path).await;
+        let mut t = new_tracker();
+        // the root parent expects exactly one child entry (the subdirectory).
+        t.add_directory(
+            &parent_path,
+            &parent_path,
+            parent_dir,
+            meta(),
+            true,
+            true,
+            1,
+            true,
+            vec![],
+        )
+        .await
+        .unwrap();
+        assert!(!t.is_done(), "the parent still awaits its child");
+        // the child has no entries: it completes immediately, notifies the parent, and completes it.
+        t.add_directory(
+            &child_path,
+            &child_path,
+            child_dir,
+            meta(),
+            false,
+            true,
+            0,
+            true,
+            vec![],
+        )
+        .await
+        .unwrap();
+        t.set_structure_complete(true);
+        assert!(
+            t.is_done(),
+            "completing the child must propagate bottom-up and complete the root parent"
+        );
+    }
+    #[tokio::test]
+    async fn empty_created_directory_is_removed_when_not_kept() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root_path = tmp.path().join("root");
+        std::fs::create_dir(&root_path).unwrap();
+        let mut t = new_tracker();
+        // the root's parent fd (the trusted destination parent) backs the fd-relative rmdir.
+        t.set_root_parent_dir(open_dir(tmp.path()).await);
+        let root_dir = open_dir(&root_path).await;
+        // created, empty (entry_count=0), keep_if_empty=false → removed via the parent's pinned fd.
+        t.add_directory(
+            &root_path,
+            &root_path,
+            root_dir,
+            meta(),
+            true,
+            true,
+            0,
+            false,
+            vec![],
+        )
+        .await
+        .unwrap();
+        assert!(
+            !root_path.exists(),
+            "an empty created directory with keep_if_empty=false must be removed"
+        );
+    }
+}

--- a/rcp/tests/remote_tests.rs
+++ b/rcp/tests/remote_tests.rs
@@ -5061,6 +5061,144 @@ fn test_remote_source_file_swap_never_transfers_sentinel() {
     swapper.join().unwrap();
 }
 
+/// Recursively check whether any regular file under `root` contains `needle`.
+fn tree_contains_content(root: &std::path::Path, needle: &str) -> bool {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = std::fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if meta.is_dir() && tree_contains_content(&path, needle) {
+            return true;
+        } else if meta.is_file()
+            && let Ok(content) = std::fs::read_to_string(&path)
+            && content.contains(needle)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Best-effort race: while a remote copy runs, swap an intermediate SOURCE directory between a real
+/// (empty) directory and a symlink to an out-of-tree sentinel directory. The source's fd-relative
+/// `O_NOFOLLOW` descent must never follow the symlink to read the sentinel content into the
+/// destination. A leaked sentinel file is a true-positive failure; a clean run is the expected
+/// outcome. Mirrors `test_remote_source_file_swap_never_transfers_sentinel` for the
+/// intermediate-directory case.
+#[test]
+fn test_remote_source_intermediate_dir_swap_never_escapes() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let sentinel_dir = src_dir.path().join("sentinel_outside");
+    std::fs::create_dir(&sentinel_dir).unwrap();
+    create_test_file(
+        &sentinel_dir.join("secret.txt"),
+        "TOP-SECRET-SENTINEL",
+        0o600,
+    );
+    let tree = src_dir.path().join("tree");
+    std::fs::create_dir(&tree).unwrap();
+    // a bed of real files so the copy has work to do (widens the race window).
+    for i in 0..200 {
+        create_test_file(&tree.join(format!("f{i}.txt")), "real data", 0o644);
+    }
+    // the intermediate dir we race between a real (empty) dir and a symlink to the sentinel dir.
+    let mid = tree.join("mid");
+    std::fs::create_dir(&mid).unwrap();
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop_thread = stop.clone();
+    let mid_thread = mid.clone();
+    let sentinel_thread = sentinel_dir.clone();
+    let swapper = std::thread::spawn(move || {
+        let mut as_link = false;
+        while !stop_thread.load(std::sync::atomic::Ordering::Relaxed) {
+            let _ = std::fs::remove_dir_all(&mid_thread);
+            let _ = std::fs::remove_file(&mid_thread);
+            if as_link {
+                let _ = std::os::unix::fs::symlink(&sentinel_thread, &mid_thread);
+            } else {
+                let _ = std::fs::create_dir(&mid_thread);
+            }
+            as_link = !as_link;
+        }
+        // leave a clean real dir as the final state.
+        let _ = std::fs::remove_dir_all(&mid_thread);
+        let _ = std::fs::remove_file(&mid_thread);
+        let _ = std::fs::create_dir(&mid_thread);
+    });
+    let dst_tree = dst_dir.path().join("tree");
+    let src_remote = format!("localhost:{}", tree.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_tree.to_str().unwrap());
+    for _ in 0..3 {
+        let _ = std::fs::remove_dir_all(&dst_tree);
+        let _ = run_rcp_with_args(&[&src_remote, &dst_remote]);
+        assert!(
+            !tree_contains_content(&dst_tree, "TOP-SECRET-SENTINEL"),
+            "source followed a swapped intermediate symlink and copied the out-of-tree sentinel"
+        );
+    }
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    swapper.join().unwrap();
+}
+
+/// Best-effort race: while a remote copy WRITES into the destination, swap an intermediate
+/// DESTINATION directory between a real directory and a symlink pointing OUTSIDE the destination
+/// tree. The destination's fd-relative writes (pinned parent fd, `O_NOFOLLOW`, recheck-guarded)
+/// must never be redirected through the symlink to create/write outside the tree. Any file leaking
+/// into the out-of-tree "escape" directory is a true-positive failure; a clean run is expected.
+#[test]
+fn test_remote_dest_intermediate_dir_swap_never_escapes() {
+    require_local_ssh();
+    let (src_dir, dst_dir) = setup_test_env();
+    let src_tree = src_dir.path().join("tree");
+    let src_mid = src_tree.join("mid");
+    std::fs::create_dir_all(&src_mid).unwrap();
+    for i in 0..200 {
+        create_test_file(&src_mid.join(format!("c{i}.txt")), "real data", 0o644);
+    }
+    // out-of-tree escape directory: must stay empty (nothing redirected here via a symlink swap).
+    let escape = dst_dir.path().join("escape_outside");
+    std::fs::create_dir(&escape).unwrap();
+    let dst_tree = dst_dir.path().join("tree");
+    let dst_mid = dst_tree.join("mid");
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop_thread = stop.clone();
+    let dst_mid_thread = dst_mid.clone();
+    let escape_thread = escape.clone();
+    let swapper = std::thread::spawn(move || {
+        // repeatedly try to replace the destination's intermediate dir with a symlink to escape.
+        while !stop_thread.load(std::sync::atomic::Ordering::Relaxed) {
+            let _ = std::fs::remove_dir_all(&dst_mid_thread);
+            let _ = std::fs::remove_file(&dst_mid_thread);
+            let _ = std::os::unix::fs::symlink(&escape_thread, &dst_mid_thread);
+            let _ = std::fs::remove_file(&dst_mid_thread);
+        }
+    });
+    let src_remote = format!("localhost:{}", src_tree.to_str().unwrap());
+    let dst_remote = format!("localhost:{}", dst_tree.to_str().unwrap());
+    for _ in 0..3 {
+        let _ = std::fs::remove_dir_all(&dst_tree);
+        // the copy may error as the swapper fights it for the path — that is fine; the invariant is
+        // that nothing is ever written OUTSIDE the destination tree.
+        let _ = run_rcp_with_args(&[&src_remote, &dst_remote]);
+        let escaped: Vec<std::path::PathBuf> = std::fs::read_dir(&escape)
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .collect();
+        assert!(
+            escaped.is_empty(),
+            "destination followed a swapped intermediate symlink and wrote outside the tree: {escaped:?}"
+        );
+    }
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    swapper.join().unwrap();
+}
+
 /// The remote source must not dereference a ROOT symlink for data: a root operand that is a symlink
 /// to an out-of-tree sentinel is copied as a symlink (read fd-relative via its trusted parent),
 /// never followed to write the sentinel's bytes as a destination regular file. Deterministic

--- a/remote/src/protocol/mod.rs
+++ b/remote/src/protocol/mod.rs
@@ -703,6 +703,46 @@ mod tests {
         assert_eq!(chunks[1].len(), 1);
     }
 
+    #[test]
+    fn chunk_manifest_splits_a_large_manifest_at_the_production_budget() {
+        // a realistically large directory manifest (more than two budgets' worth) must split into
+        // multiple frames with the PRODUCTION budget — not just an artificially tiny one — so a
+        // change to the budget or to `estimate_entry_size` that breaks chunking at real scale is
+        // caught. built in memory (no files), so it stays a fast unit test.
+        let per_entry = estimate_entry_size(&mk_entry("file_0000000.dat"));
+        let n = (MANIFEST_CHUNK_BYTE_BUDGET / per_entry) * 2 + 1000;
+        let entries: Vec<_> = (0..n)
+            .map(|i| mk_entry(&format!("file_{i:07}.dat")))
+            .collect();
+        let chunks = chunk_manifest(entries.clone(), MANIFEST_CHUNK_BYTE_BUDGET);
+        assert!(
+            chunks.len() > 1,
+            "a manifest larger than the 4 MiB budget must span multiple chunks, got {}",
+            chunks.len()
+        );
+        // every multi-entry chunk stays within the real budget (frame-safety)
+        for chunk in &chunks {
+            if chunk.len() > 1 {
+                let total: usize = chunk.iter().map(estimate_entry_size).sum();
+                assert!(
+                    total <= MANIFEST_CHUNK_BYTE_BUDGET,
+                    "a chunk exceeds the production budget: {total}"
+                );
+            }
+        }
+        // reassembly invariant at production scale: concat preserves every entry, in order
+        let flat: Vec<_> = chunks.into_iter().flatten().collect();
+        assert_eq!(
+            flat.len(),
+            entries.len(),
+            "reassembly must preserve every entry"
+        );
+        assert!(
+            flat.iter().zip(&entries).all(|(a, b)| a.name == b.name),
+            "reassembly must preserve order"
+        );
+    }
+
     fn minimal_rcpd_config() -> RcpdConfig {
         RcpdConfig {
             verbose: 0,

--- a/throttle/src/lib.rs
+++ b/throttle/src/lib.rs
@@ -357,21 +357,28 @@ async fn get_iops_tokens(tokens: u32) {
     IOPS_THROTTLE.consume_many(tokens).await;
 }
 
+/// Number of IOPS tokens a `file_size`-byte file costs at `chunk_size` granularity: one token per
+/// chunk, ceiling-divided (an empty file still costs one). Returns `None` when `chunk_size == 0` —
+/// IOPS throttling is off for this call, so nothing is charged. The count is a `u64`; callers must
+/// still bound it to `u32` before consuming (see [`get_file_iops_tokens`]).
+fn file_iops_token_count(chunk_size: u64, file_size: u64) -> Option<u64> {
+    (std::cmp::max(1, file_size) - 1)
+        .checked_div(chunk_size)
+        .map(|div| 1 + div)
+}
+
 pub async fn get_file_iops_tokens(chunk_size: u64, file_size: u64) {
-    if let Some(div) = (std::cmp::max(1, file_size) - 1).checked_div(chunk_size) {
-        let tokens = 1 + div;
-        if tokens > u64::from(u32::MAX) {
-            tracing::error!(
-                "chunk size: {} is too small to limit throughput for files this big, size: {}",
-                chunk_size,
-                file_size,
-            );
-        } else {
-            // tokens is guaranteed to be <= u32::MAX by check above
-            let tokens_u32 =
-                u32::try_from(tokens).expect("tokens should fit in u32 after bounds check");
-            get_iops_tokens(tokens_u32).await;
-        }
+    let Some(tokens) = file_iops_token_count(chunk_size, file_size) else {
+        // chunk_size == 0: iops throttling is off for this call
+        return;
+    };
+    match u32::try_from(tokens) {
+        Ok(tokens_u32) => get_iops_tokens(tokens_u32).await,
+        Err(_) => tracing::error!(
+            "chunk size: {} is too small to limit throughput for files this big, size: {}",
+            chunk_size,
+            file_size,
+        ),
     }
 }
 
@@ -441,4 +448,34 @@ pub fn enable_ops_throttle() -> bool {
 #[must_use]
 pub fn current_ops_in_flight_limit(resource: Resource) -> usize {
     ops_in_flight_limit(resource).current_limit()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn file_iops_token_count_is_ceiling_division() {
+        // one token per chunk, rounded up; an empty file still costs one token
+        assert_eq!(file_iops_token_count(10, 0), Some(1));
+        assert_eq!(file_iops_token_count(10, 1), Some(1));
+        assert_eq!(file_iops_token_count(10, 10), Some(1));
+        assert_eq!(file_iops_token_count(10, 11), Some(2));
+        assert_eq!(file_iops_token_count(10, 20), Some(2));
+        assert_eq!(file_iops_token_count(10, 21), Some(3));
+        assert_eq!(file_iops_token_count(10, 100), Some(10));
+    }
+    #[test]
+    fn file_iops_token_count_zero_chunk_charges_nothing() {
+        // chunk_size == 0 means iops throttling is off for this call — no tokens, no divide-by-zero
+        assert_eq!(file_iops_token_count(0, 0), None);
+        assert_eq!(file_iops_token_count(0, 1_000_000), None);
+    }
+    #[test]
+    fn file_iops_token_count_overflows_u32_for_a_tiny_chunk() {
+        // a 1-byte chunk over a >4 GiB file exceeds u32; get_file_iops_tokens logs and skips rather
+        // than consuming a truncated/wrong token count
+        let tokens = file_iops_token_count(1, u64::from(u32::MAX) + 10).unwrap();
+        assert!(tokens > u64::from(u32::MAX));
+        assert!(u32::try_from(tokens).is_err());
+    }
 }

--- a/throttle/src/semaphore.rs
+++ b/throttle/src/semaphore.rs
@@ -265,6 +265,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn consume_many_drains_exactly_n_permits() {
+        let sem = Semaphore::new();
+        sem.set_max(10);
+        sem.consume_many(3).await;
+        assert_eq!(sem.sem.available_permits(), 7);
+        sem.consume_many(0).await;
+        assert_eq!(sem.sem.available_permits(), 7, "consuming zero is a no-op");
+    }
+
+    #[tokio::test]
+    async fn consume_many_is_a_noop_while_disabled() {
+        let sem = Semaphore::new();
+        sem.set_max(10);
+        sem.disable();
+        sem.consume_many(5).await;
+        assert_eq!(
+            sem.sem.available_permits(),
+            10,
+            "a disabled semaphore must not drain permits"
+        );
+    }
+
+    #[tokio::test]
     async fn set_max_to_zero_disables_acquires() {
         let sem = Semaphore::new();
         sem.set_max(4);


### PR DESCRIPTION
## Summary

Plugs the test-coverage gaps from the periodic review, one commit per subsystem. Every expectation was characterized against the real binary/behavior before being pinned; full lint and the 1181-test debug suite pass.

## Gaps covered

1. **throttle** (`e05b23d`) — the crate had no test directory. Extract the pure `file_iops_token_count` (behavior-preserving) so the ceiling-division / empty-file / `chunk_size == 0` (no divide-by-zero) / u32-overflow cases are unit-tested; add `consume_many` tests (drains exactly N; no-op while disabled).
2. **DirectoryTracker** (`da84f02`) — was exercised only via the SSH-backed remote tests. Add direct unit tests behind a sink-mock control stream (real temp-dir fds for the completion paths): `is_done` gating (with-root and no-root paths), the double-`send_destination_done` guard, no-op tolerance for entries under an untracked/failed parent, `has_failed_ancestor`, bottom-up parent completion, and empty-created-dir removal via the pinned parent fd.
3. **chmod** (`b191b68`) — rchm had no `--owner`/`--group` e2e coverage and the `dir_pre` keep-going open-failure branch was untested. Add: the defer-keep-going branch (a 0000 dir can't be opened, so the run errors, but the deferred change still applies via the O_PATH handle); same-uid `--owner` (resolution + unchanged accounting); a real chgrp to a group-of-membership that exercises the actual `fchown` + setgid-restore (no privilege); and a `#[ignore]` sudo-gated uid+gid change following the repo's sudo-test convention.
4. **remote swap-attack** (`a9a07f0`) — the suite had one best-effort swap test (a source leaf file). Mirror it for the intermediate-directory case on both the source and destination sides, adding the destination-escape / intermediate-dir coverage the local sentinel tests already have.
5. **manifest chunking** (`393c3db`) — `chunk_manifest` was tested only with an artificial tiny budget. Add an in-memory test that splits a manifest larger than the real 4 MiB `MANIFEST_CHUNK_BYTE_BUDGET` into multiple frames and round-trips it.

## Note on manifest chunking

A true *wire-level* multi-chunk e2e would need ~16k+ files (4 MiB budget ÷ `name_len + 64` per entry) — impractically slow for CI — and the wire reassembly is a trivial accumulate loop. This PR pins the chunking logic at the production budget instead. Covering the wire path cheaply would mean extracting source.rs's chunk-accumulator into a testable helper (a change to the hot remote dispatch loop); happy to do that as a follow-up if wanted.

## Verification

- `just lint` — clippy (deny-all), fmt, all check scripts
- `just test` — **1181 passed, 0 failed, 51 skipped** (debug)
- The remote swap tests were confirmed stable across repeated SSH runs
- Only one production change, behavior-preserving: the `file_iops_token_count` extraction (throttle tests pass unchanged); everything else is test-only
