### PR TITLE
Reorg: walk.rs doc, hoist test fixtures, extract settings_parse

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -101,9 +101,7 @@
 //! # }
 //! ```
 
-use crate::cmp::ObjType;
 use anyhow::Context;
-use anyhow::anyhow;
 use std::io::IsTerminal;
 use tracing::instrument;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -130,6 +128,7 @@ pub mod preserve;
 pub mod remote_tracing;
 pub mod rm;
 pub mod safedir;
+mod settings_parse;
 pub mod version;
 
 pub mod filecmp;
@@ -149,6 +148,10 @@ pub use config::{
 // without taking a direct dependency on `congestion`.
 pub use congestion::{MetadataOp, Side};
 pub use progress::{RcpdProgressPrinter, SerializableProgress};
+pub use settings_parse::{
+    parse_compare_settings, parse_metadata_cmp_settings, parse_preserve_settings,
+    validate_update_compare_vs_preserve,
+};
 
 // Define RcpdType in common since remote depends on common
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, enum_map::Enum)]
@@ -534,146 +537,6 @@ impl Drop for ProgressTracker {
             pbar_thread.join().unwrap();
         }
     }
-}
-
-pub fn parse_metadata_cmp_settings(
-    settings: &str,
-) -> Result<filecmp::MetadataCmpSettings, anyhow::Error> {
-    let mut metadata_cmp_settings = filecmp::MetadataCmpSettings::default();
-    for setting in settings.split(',') {
-        match setting {
-            "uid" => metadata_cmp_settings.uid = true,
-            "gid" => metadata_cmp_settings.gid = true,
-            "mode" => metadata_cmp_settings.mode = true,
-            "size" => metadata_cmp_settings.size = true,
-            "mtime" => metadata_cmp_settings.mtime = true,
-            "ctime" => metadata_cmp_settings.ctime = true,
-            _ => {
-                return Err(anyhow!("Unknown metadata comparison setting: {}", setting));
-            }
-        }
-    }
-    Ok(metadata_cmp_settings)
-}
-
-fn parse_type_settings(
-    settings: &str,
-) -> Result<(preserve::UserAndTimeSettings, Option<preserve::ModeMask>), anyhow::Error> {
-    let mut user_and_time = preserve::UserAndTimeSettings::default();
-    let mut mode_mask = None;
-    for setting in settings.split(',') {
-        match setting {
-            "uid" => user_and_time.uid = true,
-            "gid" => user_and_time.gid = true,
-            "time" => user_and_time.time = true,
-            _ => {
-                if let Ok(mask) = u32::from_str_radix(setting, 8) {
-                    mode_mask = Some(mask);
-                } else {
-                    return Err(anyhow!("Unknown preserve attribute specified: {}", setting));
-                }
-            }
-        }
-    }
-    Ok((user_and_time, mode_mask))
-}
-
-pub fn parse_preserve_settings(settings: &str) -> Result<preserve::Settings, anyhow::Error> {
-    // handle presets
-    match settings {
-        "all" => return Ok(preserve::preserve_all()),
-        "none" => return Ok(preserve::preserve_none()),
-        _ => {}
-    }
-    let mut preserve_settings = preserve::Settings::default();
-    for type_settings in settings.split_whitespace() {
-        if let Some((obj_type, obj_settings)) = type_settings.split_once(':') {
-            let (user_and_time_settings, mode_opt) = parse_type_settings(obj_settings).context(
-                format!("parsing preserve settings: {obj_settings}, type: {obj_type}"),
-            )?;
-            match obj_type {
-                "f" | "file" => {
-                    preserve_settings.file = preserve::FileSettings::default();
-                    preserve_settings.file.user_and_time = user_and_time_settings;
-                    if let Some(mode) = mode_opt {
-                        preserve_settings.file.mode_mask = mode;
-                    }
-                }
-                "d" | "dir" | "directory" => {
-                    preserve_settings.dir = preserve::DirSettings::default();
-                    preserve_settings.dir.user_and_time = user_and_time_settings;
-                    if let Some(mode) = mode_opt {
-                        preserve_settings.dir.mode_mask = mode;
-                    }
-                }
-                "l" | "link" | "symlink" => {
-                    preserve_settings.symlink = preserve::SymlinkSettings::default();
-                    preserve_settings.symlink.user_and_time = user_and_time_settings;
-                }
-                _ => {
-                    return Err(anyhow!("Unknown object type: {}", obj_type));
-                }
-            }
-        } else {
-            return Err(anyhow!("Invalid preserve settings: {}", settings));
-        }
-    }
-    Ok(preserve_settings)
-}
-
-/// Validates that every attribute checked by --update's comparison is actually being preserved.
-/// Skips size (always preserved via content copy) and ctime (kernel-managed, cannot be set).
-pub fn validate_update_compare_vs_preserve(
-    update_compare: &filecmp::MetadataCmpSettings,
-    preserve: &preserve::Settings,
-) -> Result<(), String> {
-    let mut missing = Vec::new();
-    if update_compare.mtime && !preserve.file.user_and_time.time {
-        missing.push("mtime");
-    }
-    if update_compare.uid && !preserve.file.user_and_time.uid {
-        missing.push("uid");
-    }
-    if update_compare.gid && !preserve.file.user_and_time.gid {
-        missing.push("gid");
-    }
-    // metadata_equal compares full mode (0o7777), so a partial mask is lossy
-    if update_compare.mode && preserve.file.mode_mask != 0o7777 {
-        missing.push("mode");
-    }
-    if missing.is_empty() {
-        Ok(())
-    } else {
-        Err(format!(
-            "--update compares [{}] but --preserve-settings does not preserve them. \
-             Use --allow-lossy-update to override or adjust --preserve-settings.",
-            missing.join(", ")
-        ))
-    }
-}
-
-pub fn parse_compare_settings(settings: &str) -> Result<cmp::ObjSettings, anyhow::Error> {
-    let mut cmp_settings = cmp::ObjSettings::default();
-    for type_settings in settings.split_whitespace() {
-        if let Some((obj_type, obj_settings)) = type_settings.split_once(':') {
-            let obj_cmp_settings = parse_metadata_cmp_settings(obj_settings).context(format!(
-                "parsing preserve settings: {obj_settings}, type: {obj_type}"
-            ))?;
-            let obj_type = match obj_type {
-                "f" | "file" => ObjType::File,
-                "d" | "dir" | "directory" => ObjType::Dir,
-                "l" | "link" | "symlink" => ObjType::Symlink,
-                "o" | "other" => ObjType::Other,
-                _ => {
-                    return Err(anyhow!("Unknown obj type: {}", obj_type));
-                }
-            };
-            cmp_settings[obj_type] = obj_cmp_settings;
-        } else {
-            return Err(anyhow!("Invalid preserve settings: {}", settings));
-        }
-    }
-    Ok(cmp_settings)
 }
 
 pub async fn cmp(
@@ -1791,152 +1654,6 @@ mod runtime_stats_tests {
         let nonexistent_process = procfs::process::Process::new(i32::MAX).ok();
         let stats = collect_runtime_stats_inner(nonexistent_process);
         assert_eq!(stats, RuntimeStats::default());
-    }
-}
-
-#[cfg(test)]
-mod parse_preserve_settings_tests {
-    use super::*;
-    #[test]
-    fn preset_all_returns_preserve_all() {
-        let settings = parse_preserve_settings("all").unwrap();
-        let expected = preserve::preserve_all();
-        assert_eq!(settings.file.mode_mask, expected.file.mode_mask);
-        assert!(settings.file.user_and_time.uid);
-        assert!(settings.file.user_and_time.gid);
-        assert!(settings.file.user_and_time.time);
-        assert_eq!(settings.dir.mode_mask, expected.dir.mode_mask);
-        assert!(settings.dir.user_and_time.uid);
-        assert!(settings.dir.user_and_time.gid);
-        assert!(settings.dir.user_and_time.time);
-        assert!(settings.symlink.user_and_time.uid);
-        assert!(settings.symlink.user_and_time.gid);
-        assert!(settings.symlink.user_and_time.time);
-    }
-    #[test]
-    fn preset_none_returns_preserve_none() {
-        let settings = parse_preserve_settings("none").unwrap();
-        let expected = preserve::preserve_none();
-        assert_eq!(settings.file.mode_mask, expected.file.mode_mask);
-        assert!(!settings.file.user_and_time.uid);
-        assert!(!settings.file.user_and_time.gid);
-        assert!(!settings.file.user_and_time.time);
-        assert_eq!(settings.dir.mode_mask, expected.dir.mode_mask);
-        assert!(!settings.dir.user_and_time.uid);
-        assert!(!settings.dir.user_and_time.gid);
-        assert!(!settings.dir.user_and_time.time);
-        assert!(!settings.symlink.user_and_time.uid);
-        assert!(!settings.symlink.user_and_time.gid);
-        assert!(!settings.symlink.user_and_time.time);
-    }
-    #[test]
-    fn per_type_settings_still_work() {
-        let settings = parse_preserve_settings("f:uid,time,0777 d:gid").unwrap();
-        assert!(settings.file.user_and_time.uid);
-        assert!(settings.file.user_and_time.time);
-        assert!(!settings.file.user_and_time.gid);
-        assert_eq!(settings.file.mode_mask, 0o777);
-        assert!(!settings.dir.user_and_time.uid);
-        assert!(settings.dir.user_and_time.gid);
-        assert!(!settings.dir.user_and_time.time);
-    }
-    #[test]
-    fn invalid_settings_returns_error() {
-        assert!(parse_preserve_settings("invalid").is_err());
-        assert!(parse_preserve_settings("f:unknown_attr").is_err());
-    }
-}
-
-#[cfg(test)]
-mod validate_update_compare_vs_preserve_tests {
-    use super::*;
-    #[test]
-    fn detects_mtime_mismatch() {
-        let compare = filecmp::MetadataCmpSettings {
-            mtime: true,
-            ..Default::default()
-        };
-        let preserve = preserve::preserve_none();
-        let result = validate_update_compare_vs_preserve(&compare, &preserve);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("mtime"));
-    }
-    #[test]
-    fn detects_uid_mismatch() {
-        let compare = filecmp::MetadataCmpSettings {
-            uid: true,
-            ..Default::default()
-        };
-        let preserve = preserve::preserve_none();
-        let result = validate_update_compare_vs_preserve(&compare, &preserve);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("uid"));
-    }
-    #[test]
-    fn detects_gid_mismatch() {
-        let compare = filecmp::MetadataCmpSettings {
-            gid: true,
-            ..Default::default()
-        };
-        let preserve = preserve::preserve_none();
-        let result = validate_update_compare_vs_preserve(&compare, &preserve);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("gid"));
-    }
-    #[test]
-    fn detects_mode_mismatch() {
-        let compare = filecmp::MetadataCmpSettings {
-            mode: true,
-            ..Default::default()
-        };
-        let mut preserve = preserve::preserve_none();
-        preserve.file.mode_mask = 0;
-        let result = validate_update_compare_vs_preserve(&compare, &preserve);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("mode"));
-    }
-    #[test]
-    fn detects_multiple_mismatches() {
-        let compare = filecmp::MetadataCmpSettings {
-            mtime: true,
-            uid: true,
-            gid: true,
-            ..Default::default()
-        };
-        let preserve = preserve::preserve_none();
-        let result = validate_update_compare_vs_preserve(&compare, &preserve);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.contains("mtime"));
-        assert!(err.contains("uid"));
-        assert!(err.contains("gid"));
-    }
-    #[test]
-    fn passes_when_preserve_covers_all_compared_attrs() {
-        let compare = filecmp::MetadataCmpSettings {
-            mtime: true,
-            uid: true,
-            gid: true,
-            mode: true,
-            size: true,  // always preserved, should not cause error
-            ctime: true, // kernel-managed, should not cause error
-        };
-        let preserve = preserve::preserve_all();
-        let result = validate_update_compare_vs_preserve(&compare, &preserve);
-        assert!(result.is_ok());
-    }
-    #[test]
-    fn fails_with_partial_mode_mask_when_mode_compared() {
-        // default mode_mask is 0o0777 which drops setuid/setgid/sticky bits,
-        // but metadata_equal compares full mode (0o7777) — so this is lossy
-        let compare = filecmp::MetadataCmpSettings {
-            mode: true,
-            ..Default::default()
-        };
-        let preserve = preserve::preserve_none();
-        let result = validate_update_compare_vs_preserve(&compare, &preserve);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("mode"));
     }
 }
 

--- a/common/src/settings_parse.rs
+++ b/common/src/settings_parse.rs
@@ -1,0 +1,294 @@
+//! Parsers for the CLI string-setting DSLs shared by the tools: `--preserve` /
+//! `--metadata-compare` / `--compare`, plus the `--update` compare-vs-preserve validation. These
+//! are pure `&str -> typed settings` functions with no dependency on the runtime/progress
+//! machinery; they are re-exported from the crate root (`common::parse_*`).
+
+use crate::cmp::{self, ObjType};
+use crate::{filecmp, preserve};
+use anyhow::{Context, anyhow};
+
+pub fn parse_metadata_cmp_settings(
+    settings: &str,
+) -> Result<filecmp::MetadataCmpSettings, anyhow::Error> {
+    let mut metadata_cmp_settings = filecmp::MetadataCmpSettings::default();
+    for setting in settings.split(',') {
+        match setting {
+            "uid" => metadata_cmp_settings.uid = true,
+            "gid" => metadata_cmp_settings.gid = true,
+            "mode" => metadata_cmp_settings.mode = true,
+            "size" => metadata_cmp_settings.size = true,
+            "mtime" => metadata_cmp_settings.mtime = true,
+            "ctime" => metadata_cmp_settings.ctime = true,
+            _ => {
+                return Err(anyhow!("Unknown metadata comparison setting: {}", setting));
+            }
+        }
+    }
+    Ok(metadata_cmp_settings)
+}
+
+fn parse_type_settings(
+    settings: &str,
+) -> Result<(preserve::UserAndTimeSettings, Option<preserve::ModeMask>), anyhow::Error> {
+    let mut user_and_time = preserve::UserAndTimeSettings::default();
+    let mut mode_mask = None;
+    for setting in settings.split(',') {
+        match setting {
+            "uid" => user_and_time.uid = true,
+            "gid" => user_and_time.gid = true,
+            "time" => user_and_time.time = true,
+            _ => {
+                if let Ok(mask) = u32::from_str_radix(setting, 8) {
+                    mode_mask = Some(mask);
+                } else {
+                    return Err(anyhow!("Unknown preserve attribute specified: {}", setting));
+                }
+            }
+        }
+    }
+    Ok((user_and_time, mode_mask))
+}
+
+pub fn parse_preserve_settings(settings: &str) -> Result<preserve::Settings, anyhow::Error> {
+    // handle presets
+    match settings {
+        "all" => return Ok(preserve::preserve_all()),
+        "none" => return Ok(preserve::preserve_none()),
+        _ => {}
+    }
+    let mut preserve_settings = preserve::Settings::default();
+    for type_settings in settings.split_whitespace() {
+        if let Some((obj_type, obj_settings)) = type_settings.split_once(':') {
+            let (user_and_time_settings, mode_opt) = parse_type_settings(obj_settings).context(
+                format!("parsing preserve settings: {obj_settings}, type: {obj_type}"),
+            )?;
+            match obj_type {
+                "f" | "file" => {
+                    preserve_settings.file = preserve::FileSettings::default();
+                    preserve_settings.file.user_and_time = user_and_time_settings;
+                    if let Some(mode) = mode_opt {
+                        preserve_settings.file.mode_mask = mode;
+                    }
+                }
+                "d" | "dir" | "directory" => {
+                    preserve_settings.dir = preserve::DirSettings::default();
+                    preserve_settings.dir.user_and_time = user_and_time_settings;
+                    if let Some(mode) = mode_opt {
+                        preserve_settings.dir.mode_mask = mode;
+                    }
+                }
+                "l" | "link" | "symlink" => {
+                    preserve_settings.symlink = preserve::SymlinkSettings::default();
+                    preserve_settings.symlink.user_and_time = user_and_time_settings;
+                }
+                _ => {
+                    return Err(anyhow!("Unknown object type: {}", obj_type));
+                }
+            }
+        } else {
+            return Err(anyhow!("Invalid preserve settings: {}", settings));
+        }
+    }
+    Ok(preserve_settings)
+}
+
+/// Validates that every attribute checked by --update's comparison is actually being preserved.
+/// Skips size (always preserved via content copy) and ctime (kernel-managed, cannot be set).
+pub fn validate_update_compare_vs_preserve(
+    update_compare: &filecmp::MetadataCmpSettings,
+    preserve: &preserve::Settings,
+) -> Result<(), String> {
+    let mut missing = Vec::new();
+    if update_compare.mtime && !preserve.file.user_and_time.time {
+        missing.push("mtime");
+    }
+    if update_compare.uid && !preserve.file.user_and_time.uid {
+        missing.push("uid");
+    }
+    if update_compare.gid && !preserve.file.user_and_time.gid {
+        missing.push("gid");
+    }
+    // metadata_equal compares full mode (0o7777), so a partial mask is lossy
+    if update_compare.mode && preserve.file.mode_mask != 0o7777 {
+        missing.push("mode");
+    }
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "--update compares [{}] but --preserve-settings does not preserve them. \
+             Use --allow-lossy-update to override or adjust --preserve-settings.",
+            missing.join(", ")
+        ))
+    }
+}
+
+pub fn parse_compare_settings(settings: &str) -> Result<cmp::ObjSettings, anyhow::Error> {
+    let mut cmp_settings = cmp::ObjSettings::default();
+    for type_settings in settings.split_whitespace() {
+        if let Some((obj_type, obj_settings)) = type_settings.split_once(':') {
+            let obj_cmp_settings = parse_metadata_cmp_settings(obj_settings).context(format!(
+                "parsing compare settings: {obj_settings}, type: {obj_type}"
+            ))?;
+            let obj_type = match obj_type {
+                "f" | "file" => ObjType::File,
+                "d" | "dir" | "directory" => ObjType::Dir,
+                "l" | "link" | "symlink" => ObjType::Symlink,
+                "o" | "other" => ObjType::Other,
+                _ => {
+                    return Err(anyhow!("Unknown obj type: {}", obj_type));
+                }
+            };
+            cmp_settings[obj_type] = obj_cmp_settings;
+        } else {
+            return Err(anyhow!("Invalid compare settings: {}", settings));
+        }
+    }
+    Ok(cmp_settings)
+}
+
+#[cfg(test)]
+mod parse_preserve_settings_tests {
+    use super::*;
+    #[test]
+    fn preset_all_returns_preserve_all() {
+        let settings = parse_preserve_settings("all").unwrap();
+        let expected = preserve::preserve_all();
+        assert_eq!(settings.file.mode_mask, expected.file.mode_mask);
+        assert!(settings.file.user_and_time.uid);
+        assert!(settings.file.user_and_time.gid);
+        assert!(settings.file.user_and_time.time);
+        assert_eq!(settings.dir.mode_mask, expected.dir.mode_mask);
+        assert!(settings.dir.user_and_time.uid);
+        assert!(settings.dir.user_and_time.gid);
+        assert!(settings.dir.user_and_time.time);
+        assert!(settings.symlink.user_and_time.uid);
+        assert!(settings.symlink.user_and_time.gid);
+        assert!(settings.symlink.user_and_time.time);
+    }
+    #[test]
+    fn preset_none_returns_preserve_none() {
+        let settings = parse_preserve_settings("none").unwrap();
+        let expected = preserve::preserve_none();
+        assert_eq!(settings.file.mode_mask, expected.file.mode_mask);
+        assert!(!settings.file.user_and_time.uid);
+        assert!(!settings.file.user_and_time.gid);
+        assert!(!settings.file.user_and_time.time);
+        assert_eq!(settings.dir.mode_mask, expected.dir.mode_mask);
+        assert!(!settings.dir.user_and_time.uid);
+        assert!(!settings.dir.user_and_time.gid);
+        assert!(!settings.dir.user_and_time.time);
+        assert!(!settings.symlink.user_and_time.uid);
+        assert!(!settings.symlink.user_and_time.gid);
+        assert!(!settings.symlink.user_and_time.time);
+    }
+    #[test]
+    fn per_type_settings_still_work() {
+        let settings = parse_preserve_settings("f:uid,time,0777 d:gid").unwrap();
+        assert!(settings.file.user_and_time.uid);
+        assert!(settings.file.user_and_time.time);
+        assert!(!settings.file.user_and_time.gid);
+        assert_eq!(settings.file.mode_mask, 0o777);
+        assert!(!settings.dir.user_and_time.uid);
+        assert!(settings.dir.user_and_time.gid);
+        assert!(!settings.dir.user_and_time.time);
+    }
+    #[test]
+    fn invalid_settings_returns_error() {
+        assert!(parse_preserve_settings("invalid").is_err());
+        assert!(parse_preserve_settings("f:unknown_attr").is_err());
+    }
+}
+
+#[cfg(test)]
+mod validate_update_compare_vs_preserve_tests {
+    use super::*;
+    #[test]
+    fn detects_mtime_mismatch() {
+        let compare = filecmp::MetadataCmpSettings {
+            mtime: true,
+            ..Default::default()
+        };
+        let preserve = preserve::preserve_none();
+        let result = validate_update_compare_vs_preserve(&compare, &preserve);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("mtime"));
+    }
+    #[test]
+    fn detects_uid_mismatch() {
+        let compare = filecmp::MetadataCmpSettings {
+            uid: true,
+            ..Default::default()
+        };
+        let preserve = preserve::preserve_none();
+        let result = validate_update_compare_vs_preserve(&compare, &preserve);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("uid"));
+    }
+    #[test]
+    fn detects_gid_mismatch() {
+        let compare = filecmp::MetadataCmpSettings {
+            gid: true,
+            ..Default::default()
+        };
+        let preserve = preserve::preserve_none();
+        let result = validate_update_compare_vs_preserve(&compare, &preserve);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("gid"));
+    }
+    #[test]
+    fn detects_mode_mismatch() {
+        let compare = filecmp::MetadataCmpSettings {
+            mode: true,
+            ..Default::default()
+        };
+        let mut preserve = preserve::preserve_none();
+        preserve.file.mode_mask = 0;
+        let result = validate_update_compare_vs_preserve(&compare, &preserve);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("mode"));
+    }
+    #[test]
+    fn detects_multiple_mismatches() {
+        let compare = filecmp::MetadataCmpSettings {
+            mtime: true,
+            uid: true,
+            gid: true,
+            ..Default::default()
+        };
+        let preserve = preserve::preserve_none();
+        let result = validate_update_compare_vs_preserve(&compare, &preserve);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("mtime"));
+        assert!(err.contains("uid"));
+        assert!(err.contains("gid"));
+    }
+    #[test]
+    fn passes_when_preserve_covers_all_compared_attrs() {
+        let compare = filecmp::MetadataCmpSettings {
+            mtime: true,
+            uid: true,
+            gid: true,
+            mode: true,
+            size: true,  // always preserved, should not cause error
+            ctime: true, // kernel-managed, should not cause error
+        };
+        let preserve = preserve::preserve_all();
+        let result = validate_update_compare_vs_preserve(&compare, &preserve);
+        assert!(result.is_ok());
+    }
+    #[test]
+    fn fails_with_partial_mode_mask_when_mode_compared() {
+        // default mode_mask is 0o0777 which drops setuid/setgid/sticky bits,
+        // but metadata_equal compares full mode (0o7777) — so this is lossy
+        let compare = filecmp::MetadataCmpSettings {
+            mode: true,
+            ..Default::default()
+        };
+        let preserve = preserve::preserve_none();
+        let result = validate_update_compare_vs_preserve(&compare, &preserve);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("mode"));
+    }
+}

--- a/common/src/walk.rs
+++ b/common/src/walk.rs
@@ -1,14 +1,24 @@
-//! Shared primitives for directory-walking operations (copy, link, rm).
+//! Shared primitives for directory-walking operations (copy, link, rm, chmod, cmp).
 //!
-//! [`EntryKind`] classifies a directory entry by file type, and exposes the
-//! per-type bits (dry-run label, skipped-counter increment) so callers don't
-//! re-implement the dispatch.
-//!
-//! [`next_entry_probed`] wraps `tokio::fs::ReadDir::next_entry` (plus the
-//! follow-up `file_type()` lookup) with the static ops rate gate so
-//! copy/link/rm share a single source of truth for walk iteration. The
-//! walk path is deliberately not congestion-probed — see the function's
-//! own docs for why.
+//! This module collects several small, related helpers used by `walk_driver` and the per-tool
+//! visitors:
+//! - `EntryKind` — classifies a directory entry by file type and exposes the per-type bits
+//!   (dry-run label, skipped-counter increment) so callers don't re-implement the dispatch.
+//! - leaf-permit lifecycle (`PermitKind` / `LeafPermit` / `preacquire_leaf_permit`) — acquires a
+//!   leaf's open-files permit before spawning, co-located with the driver's drop-before-recurse
+//!   invariant.
+//! - congestion↔throttle bridges (`throttle_side` / `throttle_op` / `meta_resource`) — map the
+//!   walk's side/op enums onto the throttle and congestion resource enums.
+//! - metadata-probe wrappers (`next_entry_probed` / `run_metadata_probed`) — wrap the path-based
+//!   `ReadDir`/`metadata` calls with the static ops rate gate (deliberately not congestion-probed
+//!   — see the function docs). These are the iteration primitive for the PATH-based walks (rcmp and
+//!   the `-L`/dereference and remote-source paths); the TOCTOU-hardened copy/link/rm/chmod walks go
+//!   through the fd-based `walk_driver` instead.
+//! - filter helpers (`filter_is_dir` / `should_skip_entry`) — apply include/exclude filtering and
+//!   entry classification during enumeration.
+//! - root-operand parsing (`split_root_operand` / `root_operand_basename` /
+//!   `without_trailing_separators`) — resolve a user-specified source operand (trailing slashes,
+//!   `.`/`..`) into its components.
 
 use crate::filter::{FilterResult, FilterSettings};
 use crate::progress::Progress;

--- a/rcp/tests/remote_tests.rs
+++ b/rcp/tests/remote_tests.rs
@@ -1,23 +1,8 @@
 use std::os::unix::fs::PermissionsExt;
 
-fn setup_test_env() -> (tempfile::TempDir, tempfile::TempDir) {
-    let src_dir = tempfile::tempdir().unwrap();
-    let dst_dir = tempfile::tempdir().unwrap();
-    (src_dir, dst_dir)
-}
-
-fn create_test_file(path: &std::path::Path, content: &str, mode: u32) {
-    std::fs::write(path, content).unwrap();
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap();
-}
-
-fn get_file_content(path: &std::path::Path) -> String {
-    std::fs::read_to_string(path).unwrap()
-}
-
-fn get_file_mode(path: &std::path::Path) -> u32 {
-    std::fs::metadata(path).unwrap().permissions().mode() & 0o7777
-}
+#[path = "support/fixtures.rs"]
+mod fixtures;
+use fixtures::{create_test_file, get_file_content, get_file_mode, setup_test_env};
 
 fn interpret_exit_code(code: i32) -> String {
     match code {

--- a/rcp/tests/support/fixtures.rs
+++ b/rcp/tests/support/fixtures.rs
@@ -1,0 +1,31 @@
+//! Shared filesystem fixtures for the rcp integration tests.
+//!
+//! Included via `#[path = "support/fixtures.rs"] mod fixtures;` rather than `mod support;` so it
+//! does not pull the heavier `docker_env` helpers into every test binary. `dead_code` is allowed
+//! because not every consuming binary uses every helper.
+#![allow(dead_code)]
+
+use std::os::unix::fs::PermissionsExt;
+
+pub fn setup_test_env() -> (tempfile::TempDir, tempfile::TempDir) {
+    let src_dir = tempfile::tempdir().unwrap();
+    let dst_dir = tempfile::tempdir().unwrap();
+    (src_dir, dst_dir)
+}
+
+pub fn create_test_file(path: &std::path::Path, content: &str, mode: u32) {
+    std::fs::write(path, content).unwrap();
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap();
+}
+
+pub fn create_symlink(src: &std::path::Path, dst: &std::path::Path) {
+    std::os::unix::fs::symlink(src, dst).unwrap();
+}
+
+pub fn get_file_content(path: &std::path::Path) -> String {
+    std::fs::read_to_string(path).unwrap()
+}
+
+pub fn get_file_mode(path: &std::path::Path) -> u32 {
+    std::fs::metadata(path).unwrap().permissions().mode() & 0o7777
+}

--- a/rcp/tests/tests.rs
+++ b/rcp/tests/tests.rs
@@ -7,28 +7,9 @@ fn check_rcp_help() {
     cmd.arg("--help").assert().success();
 }
 
-fn setup_test_env() -> (tempfile::TempDir, tempfile::TempDir) {
-    let src_dir = tempfile::tempdir().unwrap();
-    let dst_dir = tempfile::tempdir().unwrap();
-    (src_dir, dst_dir)
-}
-
-fn create_test_file(path: &std::path::Path, content: &str, mode: u32) {
-    std::fs::write(path, content).unwrap();
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).unwrap();
-}
-
-fn create_symlink(src: &std::path::Path, dst: &std::path::Path) {
-    std::os::unix::fs::symlink(src, dst).unwrap();
-}
-
-fn get_file_mode(path: &std::path::Path) -> u32 {
-    std::fs::metadata(path).unwrap().permissions().mode() & 0o7777
-}
-
-fn get_file_content(path: &std::path::Path) -> String {
-    std::fs::read_to_string(path).unwrap()
-}
+#[path = "support/fixtures.rs"]
+mod fixtures;
+use fixtures::{create_symlink, create_test_file, get_file_content, get_file_mode, setup_test_env};
 
 #[test]
 fn test_preserve_permissions_basic() {


### PR DESCRIPTION
## Summary

Low-risk structural cleanups from the periodic review. Each candidate was **critically re-reviewed before implementing**, and most of the originally-proposed churn was rejected (see below) — this PR is only the validated, genuinely-low-risk subset, as three independent commits.

## What's here

1. **Document all of walk.rs's helper groups** (`a90ce9f`) — the module doc described only `EntryKind` + `next_entry_probed`; it now enumerates all the groups the file actually holds, and corrects a stale claim: the TOCTOU-hardened copy/link/rm/chmod walks go through `walk_driver`, while `next_entry_probed` is the iteration primitive for the path-based walks (rcmp, `-L`/dereference, remote source). Doc-only.
2. **Hoist duplicated rcp test fixtures** (`b4a8faf`) — `setup_test_env`/`create_test_file`/`get_file_mode`/`get_file_content`/`create_symlink` were duplicated byte-for-byte between `rcp/tests/tests.rs` and `rcp/tests/remote_tests.rs`. Moved into `rcp/tests/support/fixtures.rs`, included via `#[path]` (not `mod support;`) so the heavier 844-line `docker_env` isn't pulled into these binaries. `rlink` left alone (separate crate; its `setup_test_env` returns a third update tempdir).
3. **Extract CLI settings parsers from lib.rs** (`57750f7`) — the crate root mixed the pure `--preserve`/`--metadata-compare`/`--compare` DSL parsers (and the `--update` compare-vs-preserve validation) with the runtime/progress machinery. Moved them, with their two test modules, into a new `settings_parse` module, re-exported from the root so `common::parse_*` is unchanged. Pure code motion.

## Rejected after review (not in this PR)

- **lib.rs progress-driver fold into `progress.rs`** — would *add* `indicatif` coupling to a deliberately-clean module.
- **source.rs `dir_map` extraction** — mischaracterized as "clean"; it's the most entangled + protocol-sensitive code and would widen RAII-invariant types to `pub(crate)`.
- **remote_tests.rs feature-split** — escapes `check-remote-test-naming.sh` (hardcoded filename), adds 4–5 test binaries (permanent compile cost), and rested on a false "bundles non-remote tests" premise (all 135 are already `test_remote_*`).
- **walk.rs 6-way split** — `pub(crate)→pub` widening + 8-file import churn for a 706-line, 30%-test file.

The lib.rs `runtime_setup.rs` extraction (the only change that genuinely slims the root, ~950 lines *moved*) is deferred — it's a navigability reorg, not a simplification, and threads the `PROGRESS`/`PBAR` statics + `run()` across a new boundary; worth its own PR only if slimming the root is an explicit goal.

## Verification

- `just lint` (clippy deny-all, fmt, all check scripts) and `just doc` (rustdoc — the doc changes render)
- `just test` — **1181 passed, 0 failed, 51 skipped** (debug, incl. SSH remote tests)
- The 11 moved parser tests and the hoisted-fixture tests pass in their new locations
