### PR TITLE
Documentation fixes: CHANGELOG, README, congestion + stale in-code docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Remote `rcp` skips re-transferring files the destination would leave untouched
+  anyway. The destination sends a manifest of its existing entries; the source
+  compares against it and sends a "file unchanged" notification instead of the file
+  body. Under `--overwrite` this covers destination entries identical to the source
+  (or strictly newer, with `--overwrite-filter=newer`); under `--ignore-existing` it
+  covers any name already present at the destination, regardless of its contents.
+  The per-directory manifest is capped by `--overwrite-manifest-max-entries`
+  (default 5,000,000); a directory exceeding the cap falls back to transferring
+  files normally.
+
 ### Changed
 - `rcp host:~ dst/` (a bare remote home as source with a trailing-slash
   destination) now errors instead of creating a directory literally named `~`
@@ -30,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as root; `--getent-path <ABSOLUTE>` pins an exact binary (intended to be baked
   into a sudo rule) and is rejected if given more than once. Numeric ids never
   invoke `getent`.
+- Fix `rlink` silently reporting success (exit 0) when a filter
+  (`--include`/`--exclude`/`--filter-file`) was active and a directory's only
+  traversed child failed to link: the directory became empty, was pruned by the
+  empty-directory cleanup, and the child's failure was dropped. The collected
+  error is now surfaced, so such a run exits non-zero.
 
 ## [0.33.0] - 2026-05-28
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,9 @@ Warning: This disables both encryption and authentication on the data path.
 - Keep encryption enabled (default) for sensitive data
 - Only use `--no-encryption` on isolated, trusted networks
 
+**TOCTOU-safe mutation (`rrm`, `rchm`, `rcp`, `rlink`):**
+The mutating tools harden their directory walk against symlink/path-swap races (fd-relative `openat`/`O_NOFOLLOW`; see `docs/tocttou.md`). `--toctou-check` prints whether a given invocation is hardened and exits (`0` = safe); `--require-toctou-safe` refuses to run unless it is — handy to pin in a `sudo` rule. Neither verifies the trust of the operand path's *prefix*; lock that down in the rule.
+
 For detailed security architecture and threat model, see `docs/security.md`.
 
 ## Terminal output
@@ -466,6 +469,18 @@ Preview what would happen without making changes:
 ```
 
 **Note:** Dry-run mode is primarily useful for previewing `--include`/`--exclude` filtering. It bypasses `--overwrite` checks and does not check whether files already exist at the destination. `--progress` and `--summary` are suppressed in dry-run mode (use `-v` to still see summary output).
+
+### Age-based filtering (`rrm`, `rchm`)
+
+`rrm` and `rchm` additionally support time-based entry filters: `--modified-before <DURATION>` acts only on entries whose mtime is at least that old, and `--created-before <DURATION>` does the same on birth time (btime). Durations use humantime syntax — note that **`M` means months and lowercase `m` means minutes**. The filter is per-entry: it applies to each file, directory, and symlink by that entry's *own* timestamp (directories are always traversed regardless of their own). For `rrm` specifically, a directory is then removed only when its own timestamp is old enough *and* it ends up empty after its children are processed — a directory left non-empty by a spared child is kept and logged, not an error. (`rchm` changes a matching directory's mode/owner based on its own timestamp regardless of its children.) `--created-before` is **not available on musl static builds** (btime is unreadable there) — use `--modified-before` or a glibc build.
+
+```fish
+# remove only files not modified in the last 30 days
+> rrm --modified-before 30d old-cache/
+
+# chmod only entries older than 6 months (M = months, not minutes)
+> rchm --mode g-w --modified-before 6M archive/
+```
 
 ## Overwrite
 

--- a/common/src/link.rs
+++ b/common/src/link.rs
@@ -613,7 +613,7 @@ async fn link_internal(
             update_handle = None;
         }
     }
-    // ── rlink's acknowledged dual-tree special case (design spec §4): the single permit-drop site ──
+    // ── rlink's acknowledged dual-tree special case (docs/tocttou.md, "One shared traversal driver"): the single permit-drop site ──
     //
     // The spawn loop in `link_dir_contents` pre-acquired this leaf permit (open-files pool) for a
     // regular-file src `hint`, but the authoritative dual-tree decision below may instead COPY

--- a/common/src/safedir.rs
+++ b/common/src/safedir.rs
@@ -262,7 +262,7 @@ impl Dir {
     /// Open a TRUSTED command-line parent-prefix directory, resolving symlinks
     /// normally (the final component IS followed if it is a symlink).
     ///
-    /// The trusted-boundary model (design spec §2) trusts the directory named on
+    /// The trusted-boundary model (docs/tocttou.md, "Trusted boundary") trusts the directory named on
     /// the command line up to and including itself; only entries strictly BELOW
     /// it are hardened with `O_NOFOLLOW`. The parent prefix that CONTAINS the
     /// operand is therefore resolved like a normal path open — a symlinked parent
@@ -819,7 +819,7 @@ impl Dir {
 /// A directory opened by FOLLOWING symlinks normally — the command-line-named
 /// path's trusted parent prefix.
 ///
-/// The trusted-boundary model (design spec §2) trusts the path named on the
+/// The trusted-boundary model (docs/tocttou.md, "Trusted boundary") trusts the path named on the
 /// command line up to and including its container directory; only entries
 /// strictly BELOW the named root are hardened with `O_NOFOLLOW`. A `TrustedDir`
 /// is that trusted container, and it is the ONLY way in this crate to obtain a

--- a/common/src/walk_driver.rs
+++ b/common/src/walk_driver.rs
@@ -33,10 +33,10 @@
 //! per-tool walks do. A dropped surrounding future (timeout, `fail_early` abort,
 //! Ctrl-C) therefore can never leave a spawned task holding a dangling borrow.
 //!
-//! ## How copy will map onto this trait (Phase D validation)
+//! ## How copy maps onto this trait
 //!
-//! `copy` is the reference single-tree visitor (implemented in `rcp::copy` as
-//! `CopyVisitor`); its mapping both validated the trait and shaped this module.
+//! `copy` is the reference single-tree visitor (`rcp::copy::CopyVisitor`); its
+//! mapping shaped this trait.
 //! `CopyVisitor` holds the run-constant state (`dst_root`, `filter_base`,
 //! `Settings`, `preserve::Settings`, the opened top-level destination parent — the
 //! *source* root needs no field, since each entry's source path is its
@@ -88,7 +88,7 @@
 //! branch copy already has. No part of copy needs a trait shape this module does
 //! not provide, which is why the trait stops here (no second-tree concept leaks
 //! into the driver — that asymmetry is what keeps rlink on the substrate, not the
-//! visitor, per the design spec §4).
+//! visitor; see docs/tocttou.md, "One shared traversal driver").
 
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;

--- a/congestion/src/lib.rs
+++ b/congestion/src/lib.rs
@@ -6,21 +6,20 @@
 //! intentionally small and synchronous so algorithms can be implemented and
 //! tested without any I/O, async runtime, or wall-clock dependence.
 //!
-//! Three concentric layers are envisioned for integration with the rcp /
-//! rrm / rlink / filegen tools:
+//! Three concentric layers integrate with the rcp / rrm / rlink / filegen
+//! tools:
 //!
 //! 1. **Algorithm** — the `Controller` trait and its implementations; pure.
-//! 2. **Control loop** — plumbing that collects samples from the hot path,
-//!    drives the controller on a fixed tick, and publishes decisions. Lives
-//!    outside this crate (in `throttle` or a thin adapter) and is not part
-//!    of Phase 1.
+//! 2. **Control loop** — the [`ControlUnit`] plumbing (this crate's
+//!    `control_loop` module) that collects samples from the hot path, drives
+//!    the controller on a fixed tick, and publishes decisions.
 //! 3. **Enforcement** — the existing `throttle` token buckets and
 //!    semaphores, with their limits driven by the control loop.
 //!
 //! # Built-in controllers
 //!
-//! - [`NoopController`] — never limits. Default when congestion control is
-//!   disabled.
+//! - [`NoopController`] — never limits; the explicit unlimited baseline used
+//!   by the simulator and the controller conformance tests.
 //! - [`FixedController`] — honors a static concurrency/rate budget. Mirrors
 //!   the existing manual `--ops-throttle` / `--iops-throttle` knobs and is
 //!   the regression baseline for adaptive algorithms.

--- a/congestion/src/noop.rs
+++ b/congestion/src/noop.rs
@@ -1,4 +1,6 @@
-//! A controller that never limits. Default when congestion control is off.
+//! A no-op [`Controller`](crate::Controller) that never limits (always emits
+//! [`Decision::UNLIMITED`](crate::Decision::UNLIMITED)) — the explicit unlimited baseline used by the
+//! simulator and the controller conformance tests.
 
 use crate::controller::{Controller, Decision, Sample};
 

--- a/docs/congestion_control.md
+++ b/docs/congestion_control.md
@@ -354,7 +354,9 @@ re-bracket `alpha` / `beta` around the observed idle ratio.
 
 A few worked examples make the shape concrete. Assume a 0.5 ms
 baseline percentile (p10), default thresholds, and `cwnd = 20`
-going into the tick:
+going into the tick. (20 is an illustrative midpoint, not a default:
+the controller starts at `initial_cwnd = 1` and grows one step per
+sample-bearing tick.)
 
 | Current percentile (p50) | Ratio | Decision | New `cwnd` |
 |--------------------------|-------|----------|------------|
@@ -381,6 +383,14 @@ defaults are cross (p10 baseline, p50 current). A ratio below 1.0 is
 unusual — it means the recent median is faster than the long-horizon
 p10, which only happens during a clear improvement (e.g. a competing
 client dropped off). The controller treats it as growth headroom.
+
+Third, a tick that consumed no *new* sample since the previous tick holds
+`cwnd` unchanged — it does not re-apply the law to a stale ratio. This
+matters because the tick cadence (default 50 ms) is faster than the sample
+arrival rate under light load; without the guard a single sample could
+otherwise drive many steps over a one-second window. (Likewise, when the
+latency windows age out to "no samples", the ratio resets to `None` and
+`cwnd` is held until fresh samples arrive.)
 
 The "responsiveness" of the controller is shaped by these knobs in
 combination:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -279,10 +279,29 @@ The `.github/workflows/validate.yml` workflow runs:
 ### Running CI Locally
 
 ```bash
-just ci  # Runs: lint + doc + test-all
+just ci  # lint + doc + test-all (debug + release + doctests) + Docker tests
 ```
 
-This replicates the CI checks locally before pushing.
+`just ci` is the primary local "is this ready to push?" gate — it runs the same lint,
+docs, and debug + release + doctest + Docker checks CI does, and is the one command to
+run before pushing. It's a close proxy for the CI matrix rather than a byte-for-byte
+match; a few CI steps live outside it:
+
+- **Sudo-gated tests** (`test(~sudo)`, which need passwordless sudo). CI runs these in a
+  separate step, in both debug and release. Run them yourself when a change touches
+  sudo-only behavior:
+
+  ```bash
+  cargo nextest run --run-ignored only -E 'test(~sudo)'   # add --release to also cover release
+  ```
+
+- **glibc release build.** CI also builds the workspace for `x86_64-unknown-linux-gnu`;
+  `just ci` builds and tests only the default `x86_64-unknown-linux-musl` target.
+
+- **Chaos tests.** `just ci`'s Docker step runs the full `docker` profile *including*
+  chaos (the compose containers are privileged, so they actually run), whereas CI
+  excludes chaos from its main Docker job and runs it in a separate `chaos-tests.yml`
+  workflow. So `just ci` does cover chaos locally — CI just schedules it separately.
 
 ## Chaos Testing
 


### PR DESCRIPTION
## Summary

Documentation-only fixes from the periodic review (no behavior change). Three commits by theme.

### User-facing docs (`dbc20b3`)
- **CHANGELOG** Unreleased: added the remote overwrite skip-identical / manifest feature (`--overwrite-manifest-max-entries`) and the `rlink` filter-empty-dir error-masking fix that were missing.
- **README**: new "Age-based filtering" section documenting `--modified-before`/`--created-before` on `rrm`/`rchm` (including the `M`=months vs `m`=minutes gotcha and the musl-btime caveat), plus the `--toctou-check` / `--require-toctou-safe` security flags.
- **docs/testing.md**: `just ci` was documented as "lint + doc + test-all" but the recipe is `lint doc test-all-with-docker`. Corrected, and framed as the single source of truth for "is this ready to push?".

### Congestion docs (`5117a7c`)
- **docs/congestion_control.md**: noted that the worked example's `cwnd = 20` is illustrative, not a default (the controller starts at `initial_cwnd = 1`); documented the no-fresh-sample hold (a tick that consumed no new sample holds `cwnd` rather than re-applying the law to a stale ratio).
- **congestion code docs**: `NoopController`'s doc claimed it is the "default when congestion control is off" — it isn't (the off path installs no controller). Reworded as the explicit unlimited baseline used by the simulator/tests, and corrected the crate-doc layer description that said the control loop "lives outside this crate / not part of Phase 1" (it's the in-crate `control_loop` module). **The controllers stay in the production build** — only the docs changed.

### Stale in-code docs (`3c9cbe1`)
- `walk_driver`'s "How copy *will* map onto this trait (Phase D validation)" module section was future/planning-tense for the now-implemented `CopyVisitor`; reworded to present tense (content kept — it documents the mapping).
- Re-pointed the dangling `design spec §2/§4` references (walk_driver, safedir ×2, link) — which cited a gitignored working spec — to the corresponding `docs/tocttou.md` sections ("Trusted boundary", "One shared traversal driver").

## Verification

- `just lint` (clippy deny-all compiles every crate + fmt + all check scripts) and `just doc` (rustdoc warnings-denied — validates the doc-comment edits and the new intra-doc links).
- Doc-only: no logic, no doctests, no behavior changed.
