### PR TITLE
Hold MSRV at 1.91.1, decoupled from the dev toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# Least-privilege GITHUB_TOKEN; the called validate workflow only reads the repo.
+permissions:
+  contents: read
+
 jobs:
   validate:
     uses: ./.github/workflows/validate.yml

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,11 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: --cfg tokio_unstable
 
+# Least-privilege GITHUB_TOKEN: every job here only checks out and builds/tests
+# the repo, so read access to contents is all that's needed.
+permissions:
+  contents: read
+
 jobs:
   lint-and-docs:
     runs-on: ubuntu-latest
@@ -66,6 +71,40 @@ jobs:
       run: cargo doc --no-deps --workspace
       env:
         RUSTDOCFLAGS: --cfg tokio_unstable -D warnings
+        PKG_CONFIG_ALLOW_CROSS: "1"
+
+  msrv:
+    runs-on: ubuntu-latest
+    needs: lint-and-docs
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        ref: ${{ inputs.ref || github.sha }}
+
+    - name: Setup Rust (MSRV)
+      uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
+      with:
+        toolchain: "1.91.1"
+        target: x86_64-unknown-linux-musl
+
+    - name: Install musl toolchain deps
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y musl-tools pkg-config
+        sudo ln -sf /usr/bin/musl-gcc /usr/bin/x86_64-unknown-linux-musl-gcc
+
+    - name: Verify the MSRV toolchain is active
+      run: |
+        rustc --version
+        rustc --version | grep -q "1.91.1" || { echo "::error::expected rustc 1.91.1"; exit 1; }
+
+    # Check both shipped targets: musl (default in .cargo/config.toml) and gnu
+    # (build-glibc). Each compiles a different side of the target_env = "musl"
+    # cfg gates (e.g. common/src/filter.rs), so a single target would let an
+    # MSRV regression in the other branch slip through.
+    - name: Check workspace builds on MSRV (gnu + musl)
+      run: cargo check --workspace --locked --all-targets --target x86_64-unknown-linux-gnu --target x86_64-unknown-linux-musl
+      env:
         PKG_CONFIG_ALLOW_CROSS: "1"
 
   test-musl-debug:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Pinned `sysinfo` at `0.38` and froze the minimum supported Rust version (MSRV)
+  at 1.91.1, declared via `rust-version` in `Cargo.toml` and enforced by a
+  dedicated CI job that compiles the workspace on that toolchain. The dev/CI
+  toolchain (latest stable) is now tracked separately from the MSRV, so routine
+  dependency or toolchain updates can't silently raise the floor. `sysinfo` 0.39
+  required Rust 1.95; 0.38 keeps the same `set_open_files_limit` API at MSRV 1.88.
+
 ## [0.34.0] - 2026-06-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,16 +645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags 2.11.1",
- "objc2",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,39 +1385,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags 2.11.1",
- "objc2",
 ]
 
 [[package]]
@@ -1438,17 +1401,6 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-open-directory"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
-dependencies = [
- "objc2",
- "objc2-core-foundation",
- "objc2-foundation",
 ]
 
 [[package]]
@@ -2314,16 +2266,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "objc2-open-directory",
  "windows",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ authors = ["Mateusz Wykurz <wykurz@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/wykurz/rcp"
 edition = "2024"
+rust-version = "1.91.1"
 
 [workspace.dependencies]
 # Internal library crates (use local names as keys)

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 description = "Internal library for RCP file operation tools - shared utilities and core operations (not intended for direct use)"
 readme = "../README.md"
 documentation = "https://docs.rs/rcp-tools-common"
@@ -42,7 +43,7 @@ libc = "0.2"
 nix = { version = "0.31", features = ["dir", "fs", "hostname", "user", "zerocopy"] }
 procfs = "0.18"
 rand = "0.10"
-sysinfo = "0.39"
+sysinfo = "0.38"
 thiserror = "2.0"
 throttle = { workspace = true }
 tokio = { version = "1.52", features = ["full", "parking_lot", "tracing"] }

--- a/congestion/Cargo.toml
+++ b/congestion/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 description = "Internal library for RCP tools - pluggable congestion-control algorithms and a deterministic scenario simulator (not intended for direct use)"
 readme = "../README.md"
 documentation = "https://docs.rs/rcp-tools-congestion"

--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,12 @@ let
     extensions = [ "rust-analysis" "rust-src" ];
     targets = [ "x86_64-unknown-linux-musl" ];
   };
+  msrvToolchain = nixpkgs.rust-bin.stable."1.91.1".minimal.override {
+    targets = [ "x86_64-unknown-linux-gnu" "x86_64-unknown-linux-musl" ];
+  };
+  msrvCheck = nixpkgs.writeShellScriptBin "msrv-check" ''
+    exec ${msrvToolchain}/bin/cargo check --workspace --locked --all-targets --target x86_64-unknown-linux-gnu --target x86_64-unknown-linux-musl "$@"
+  '';
   muslTools =
     if nixpkgs.stdenv.isLinux then {
       gcc = nixpkgs.pkgsCross.musl64.buildPackages.gcc;
@@ -20,6 +26,7 @@ in
           [
             rust-analyzer
             myrust
+            msrvCheck
             binutils
             # cargo-audit
             cargo-bloat

--- a/filegen/Cargo.toml
+++ b/filegen/Cargo.toml
@@ -5,6 +5,7 @@ description = "Test fileset generator - creates sample directory structures and 
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme = "../README.md"
 documentation = "https://docs.rs/rcp-tools-filegen"
 keywords = ["cli", "file", "generator", "testing", "benchmark"]

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,17 @@
           targets = [ "x86_64-unknown-linux-musl" ];
         };
 
+        # MSRV toolchain — used only by the `msrv-check` wrapper (and CI's `msrv`
+        # job) to verify the workspace still compiles on the minimum supported
+        # Rust version. Kept separate from `rustToolchain` (latest stable) so
+        # everyday dev work uses the newest compiler.
+        msrvToolchain = pkgs.rust-bin.stable."1.91.1".minimal.override {
+          targets = [ "x86_64-unknown-linux-gnu" "x86_64-unknown-linux-musl" ];
+        };
+        msrvCheck = pkgs.writeShellScriptBin "msrv-check" ''
+          exec ${msrvToolchain}/bin/cargo check --workspace --locked --all-targets --target x86_64-unknown-linux-gnu --target x86_64-unknown-linux-musl "$@"
+        '';
+
         muslTools =
           if pkgs.stdenv.isLinux then {
             gcc = pkgs.pkgsCross.musl64.buildPackages.gcc;
@@ -129,6 +140,7 @@
             buildInputs =
               [
                 rustToolchain
+                msrvCheck
                 pkgs.rust-analyzer
 
                 # Development tools from the original default.nix

--- a/justfile
+++ b/justfile
@@ -55,6 +55,12 @@ test-all: test doctest test-release doctest-release
 check:
     cargo check --workspace
 
+# Verify the workspace builds on the minimum supported Rust version (MSRV), for
+# both shipped targets (gnu + musl). Separate from `just ci`: needs the nix
+# devShell's `msrv-check` wrapper. GitHub CI enforces the same via the `msrv` job.
+msrv:
+    msrv-check
+
 # Build all packages
 build:
     cargo build --workspace
@@ -67,9 +73,11 @@ build-release:
 doc:
     RUSTDOCFLAGS="--cfg tokio_unstable -D warnings" cargo doc --no-deps --workspace
 
-# Run all CI checks locally before pushing (matches GitHub Actions)
+# Run the standard CI checks locally before pushing (lint, docs, tests + Docker).
+# The MSRV check is intentionally separate — run `just msrv` (it needs the nix
+# devShell's pinned toolchain); GitHub CI runs it as the dedicated `msrv` job.
 ci: lint doc test-all-with-docker
-    @echo "✅ All CI checks passed! Safe to push."
+    @echo "✅ All CI checks passed! (run 'just msrv' for the separate MSRV check)"
 
 # Clean build artifacts
 clean:

--- a/rchm/Cargo.toml
+++ b/rchm/Cargo.toml
@@ -5,6 +5,7 @@ description = "Fast recursive chmod/chgrp/chown for large filesets (a dchmod rep
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme = "../README.md"
 documentation = "https://docs.rs/rcp-tools-rchm"
 keywords = ["cli", "file", "chmod", "chown", "performance"]

--- a/rcmp/Cargo.toml
+++ b/rcmp/Cargo.toml
@@ -5,6 +5,7 @@ description = "Fast file comparison tool - efficiently compares metadata across 
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme = "../README.md"
 documentation = "https://docs.rs/rcp-tools-rcmp"
 keywords = ["cli", "file", "compare", "diff", "performance"]

--- a/rcp/Cargo.toml
+++ b/rcp/Cargo.toml
@@ -5,6 +5,7 @@ description = "Fast file operations tools - rcp (copy) and rcpd (remote copy dae
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme = "../README.md"
 documentation = "https://docs.rs/rcp-tools-rcp"
 keywords = ["cli", "file", "copy", "remote", "performance"]

--- a/remote/Cargo.toml
+++ b/remote/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 description = "Internal library for RCP tools - remote copy protocol and networking (not intended for direct use)"
 readme = "../README.md"
 documentation = "https://docs.rs/rcp-tools-remote"

--- a/rlink/Cargo.toml
+++ b/rlink/Cargo.toml
@@ -5,6 +5,7 @@ description = "Fast hard-linking tool - efficiently creates hard links for large
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme = "../README.md"
 documentation = "https://docs.rs/rcp-tools-rlink"
 keywords = ["cli", "file", "hardlink", "link", "performance"]

--- a/rrm/Cargo.toml
+++ b/rrm/Cargo.toml
@@ -5,6 +5,7 @@ description = "Fast file removal tool - efficiently removes large filesets (simi
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme = "../README.md"
 documentation = "https://docs.rs/rcp-tools-rrm"
 keywords = ["cli", "file", "remove", "delete", "performance"]

--- a/scripts/check-package-metadata.sh
+++ b/scripts/check-package-metadata.sh
@@ -50,7 +50,7 @@ for pkg in $PACKAGES; do
     fi
 
     # Check for workspace-inherited fields
-    for field in "version.workspace" "edition.workspace" "license.workspace" "repository.workspace"; do
+    for field in "version.workspace" "edition.workspace" "license.workspace" "repository.workspace" "rust-version.workspace"; do
         if ! grep -q "$field = true" "$cargo_toml"; then
             echo -e "${RED}ERROR: $cargo_toml missing '$field = true'${NC}"
             VIOLATIONS_FOUND=1
@@ -86,7 +86,7 @@ if [ $VIOLATIONS_FOUND -eq 1 ]; then
     echo ""
     echo "All packages should have:"
     echo "  1. [lints] workspace = true"
-    echo "  2. version.workspace = true, edition.workspace = true, etc."
+    echo "  2. version.workspace = true, edition.workspace = true, rust-version.workspace = true, etc."
     echo "  3. [package.metadata.docs.rs] with:"
     echo "     $EXPECTED_CARGO_ARGS"
     echo "     $EXPECTED_RUSTDOC_ARGS"

--- a/scripts/check-rust-version.sh
+++ b/scripts/check-rust-version.sh
@@ -1,59 +1,85 @@
 #!/bin/bash
 # Rust Version Consistency Linter
-# Ensures all hardcoded Rust toolchain versions match across the repository
 #
-# This script checks that rust-toolchain.toml, flake.nix, and default.nix
-# all reference the same Rust version
+# The project deliberately tracks TWO separate Rust versions:
+#
+#   1. DEV toolchain — the (latest) stable used for day-to-day builds and CI.
+#      Source of truth: `channel` in rust-toolchain.toml.
+#      Must match the `.default` rust-overlay toolchains in flake.nix / default.nix.
+#
+#   2. MSRV (minimum supported Rust version) — the floor the project builds on.
+#      Source of truth: `rust-version` in [workspace.package] of Cargo.toml.
+#      Must match: the `toolchain:` pin of the `msrv` job in
+#      .github/workflows/validate.yml, and the `.minimal` rust-overlay toolchains
+#      in flake.nix / default.nix.
+#
+# The dedicated CI `msrv` job actually compiles the workspace on the MSRV
+# toolchain; this script ensures every file agrees on what that version is, so an
+# accidental bump can't slip through unnoticed.
 
 set -euo pipefail
 
-# colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 NC='\033[0m' # no color
+
+FAIL=0
+fail() { echo -e "${RED}✗ $1${NC}"; FAIL=1; }
+
+# Extract the first dotted version (2 or 3 components) from a line on stdin.
+extract_ver() { sed -n -E 's/.*"([0-9]+\.[0-9]+(\.[0-9]+)?)".*/\1/p'; }
+# Same, but anchored to the rust-overlay stable."..." token, so a trailing quoted
+# token on the same line (e.g. a comment) cannot be matched by mistake.
+extract_nix_ver() { sed -n -E 's/.*stable\."([0-9]+\.[0-9]+(\.[0-9]+)?)".*/\1/p'; }
 
 echo "🔍 checking rust version consistency..."
 
-# extract version from rust-toolchain.toml (source of truth)
-EXPECTED_VERSION=$(grep -E '^channel\s*=\s*"' rust-toolchain.toml | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/')
-
-if [ -z "$EXPECTED_VERSION" ]; then
-    echo -e "${RED}✗ failed to extract version from rust-toolchain.toml${NC}"
-    exit 1
+# --- 1. DEV toolchain ---------------------------------------------------------
+DEV=$(grep -E '^channel[[:space:]]*=' rust-toolchain.toml | head -n1 | extract_ver || true)
+if [ -z "$DEV" ]; then
+    fail "could not read dev toolchain 'channel' from rust-toolchain.toml"
 fi
 
-echo "expected version: $EXPECTED_VERSION"
+for file in flake.nix default.nix; do
+    v=$(grep -E 'rust-bin\.stable\."[0-9.]+"\.default' "$file" | head -n1 | extract_nix_ver || true)
+    if [ -z "$v" ]; then
+        fail "$file: could not find dev toolchain (rust-bin.stable.\"…\".default)"
+    elif [ "$v" != "$DEV" ]; then
+        fail "$file: dev toolchain is $v (expected $DEV from rust-toolchain.toml)"
+    fi
+done
 
-VIOLATIONS=0
-
-# check flake.nix
-FLAKE_VERSION=$(grep -E 'rust-bin\.stable\."[0-9]+\.[0-9]+\.[0-9]+"' flake.nix | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/' || true)
-if [ -z "$FLAKE_VERSION" ]; then
-    echo -e "${RED}✗ failed to extract version from flake.nix (pattern not found)${NC}"
-    VIOLATIONS=$((VIOLATIONS + 1))
-elif [ "$FLAKE_VERSION" != "$EXPECTED_VERSION" ]; then
-    echo -e "${RED}✗ flake.nix has version $FLAKE_VERSION (expected $EXPECTED_VERSION)${NC}"
-    VIOLATIONS=$((VIOLATIONS + 1))
+# --- 2. MSRV ------------------------------------------------------------------
+MSRV=$(grep -E '^rust-version[[:space:]]*=' Cargo.toml | head -n1 | extract_ver || true)
+if [ -z "$MSRV" ]; then
+    fail "could not read 'rust-version' (MSRV) from [workspace.package] in Cargo.toml"
 fi
 
-# check default.nix
-DEFAULT_VERSION=$(grep -E 'rust-bin\.stable\."[0-9]+\.[0-9]+\.[0-9]+"' default.nix | sed -E 's/.*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/' || true)
-if [ -z "$DEFAULT_VERSION" ]; then
-    echo -e "${RED}✗ failed to extract version from default.nix (pattern not found)${NC}"
-    VIOLATIONS=$((VIOLATIONS + 1))
-elif [ "$DEFAULT_VERSION" != "$EXPECTED_VERSION" ]; then
-    echo -e "${RED}✗ default.nix has version $DEFAULT_VERSION (expected $EXPECTED_VERSION)${NC}"
-    VIOLATIONS=$((VIOLATIONS + 1))
+for file in flake.nix default.nix; do
+    v=$(grep -E 'rust-bin\.stable\."[0-9.]+"\.minimal' "$file" | head -n1 | extract_nix_ver || true)
+    if [ -z "$v" ]; then
+        fail "$file: could not find MSRV toolchain (rust-bin.stable.\"…\".minimal)"
+    elif [ "$v" != "$MSRV" ]; then
+        fail "$file: MSRV toolchain is $v (expected $MSRV from Cargo.toml rust-version)"
+    fi
+done
+
+CI_MSRV=$(grep -E '^[[:space:]]*toolchain:[[:space:]]*"?[0-9]+\.[0-9]+' .github/workflows/validate.yml \
+    | head -n1 | sed -E 's/.*toolchain:[[:space:]]*"?([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/' || true)
+if [ -z "$CI_MSRV" ]; then
+    fail ".github/workflows/validate.yml: could not find the msrv job 'toolchain:' pin"
+elif [ "$CI_MSRV" != "$MSRV" ]; then
+    fail ".github/workflows/validate.yml: msrv job pins $CI_MSRV (expected $MSRV)"
 fi
 
-if [ $VIOLATIONS -eq 0 ]; then
-    echo -e "${GREEN}✓ all rust versions are consistent: $EXPECTED_VERSION${NC}"
+# --- result -------------------------------------------------------------------
+if [ "$FAIL" -eq 0 ]; then
+    echo -e "${GREEN}✓ rust versions consistent — dev: $DEV, msrv: $MSRV${NC}"
     exit 0
 else
     echo ""
-    echo -e "${RED}found $VIOLATIONS version mismatch(es)${NC}"
-    echo ""
-    echo "to fix: update all files to use version $EXPECTED_VERSION from rust-toolchain.toml"
+    echo -e "${RED}rust version inconsistencies found (see above)${NC}"
+    echo "dev toolchain source of truth:  rust-toolchain.toml (channel)"
+    echo "msrv source of truth:           Cargo.toml ([workspace.package] rust-version)"
     exit 1
 fi

--- a/throttle/Cargo.toml
+++ b/throttle/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 description = "Internal library for RCP tools - resource throttling and rate limiting (not intended for direct use)"
 readme = "../README.md"
 documentation = "https://docs.rs/rcp-tools-throttle"


### PR DESCRIPTION
## Why

`sysinfo` 0.39 raised its MSRV to rustc **1.95**, which silently bumped the project's effective MSRV when the dependency was upgraded — the pinned toolchain in `rust-toolchain.toml` doubled as the de-facto MSRV, and `check-rust-version.sh` only checked that the three toolchain files *agreed*, so the bump passed unnoticed.

Across the **entire resolved dependency tree**, `sysinfo` 0.39.3 was the *only* crate declaring a `rust-version` above 1.91.1 (next highest is 1.88). `sysinfo` is used in exactly one place (`common/src/runtime_setup.rs` → `set_open_files_limit`), and that API is unchanged across 0.36–0.39, so the downgrade is functionally a no-op. `sysinfo` has no RUSTSEC advisories.

## What

- **Pin `sysinfo` at `0.38`** (MSRV 1.88) to restore a 1.91.1 floor.
- **Decouple the two Rust-version concepts** that were previously a single pin:
  - *Dev/CI toolchain* stays on latest stable (1.95.0) — `rust-toolchain.toml` + the nix `.default` toolchains. Bumped deliberately.
  - *MSRV (1.91.1)* gets its own source of truth: `rust-version` in `[workspace.package]`, inherited by all 10 member crates.
- **Enforce the MSRV in CI**: a dedicated `msrv` job compiles the whole workspace on 1.91.1 (`cargo check --workspace --locked --all-targets`). An accidental bump now fails CI instead of slipping by.
- **Local ergonomics**: a `.minimal` 1.91.1 nix toolchain + a `just msrv` wrapper, so the MSRV check runs from the normal dev shell without switching toolchains.
- **Drift guard**: `check-rust-version.sh` rewritten to keep *both* the dev and MSRV versions consistent across `Cargo.toml`, the CI job, and both nix files; `check-package-metadata.sh` now also requires `rust-version.workspace = true`.

## Verification

- `cargo check --workspace --locked --all-targets` on **rustc 1.91.1** (provisioned via nix) compiles clean — MSRV verified empirically, not just by declared metadata.
- `just lint` green (fmt, clippy, all check scripts).
- The new guards demonstrably fail on an injected dev-toolchain or MSRV-version drift.
- Full test suite runs in CI.
