### PR TITLE
Update CHANGELOG for v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-06-15
+
 ### Changed
 - Pinned `sysinfo` at `0.38` and froze the minimum supported Rust version (MSRV)
   at 1.91.1, declared via `rust-version` in `Cargo.toml` and enforced by a
@@ -264,7 +266,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See git history for changes in previous versions.
 
-[Unreleased]: https://github.com/wykurz/rcp/compare/v0.34.0...HEAD
+[Unreleased]: https://github.com/wykurz/rcp/compare/v0.35.0...HEAD
+[0.35.0]: https://github.com/wykurz/rcp/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/wykurz/rcp/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/wykurz/rcp/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/wykurz/rcp/compare/v0.31.0...v0.32.0


### PR DESCRIPTION
Finalize release notes for v0.35.0. Merge with **Rebase and merge** once checks pass (click **Update branch** first if GitHub says it's out of date), then run `just release` to create and push the tag.