### PR TITLE
Bump version to 0.36.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "rcp-tools-common"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "rcp-tools-congestion"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "hdrhistogram",
  "proptest",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "rcp-tools-filegen"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "rcp-tools-rchm"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "rcp-tools-rcmp"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "rcp-tools-rcp"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "rcp-tools-remote"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "rcp-tools-rlink"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1939,7 +1939,7 @@ dependencies = [
 
 [[package]]
 name = "rcp-tools-rrm"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "rcp-tools-throttle"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.35.0"
+version = "0.36.0"
 authors = ["Mateusz Wykurz <wykurz@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/wykurz/rcp"
@@ -24,10 +24,10 @@ rust-version = "1.91.1"
 
 [workspace.dependencies]
 # Internal library crates (use local names as keys)
-throttle = { package = "rcp-tools-throttle", version = "0.35.0", path = "throttle" }
-congestion = { package = "rcp-tools-congestion", version = "0.35.0", path = "congestion" }
-common = { package = "rcp-tools-common", version = "0.35.0", path = "common" }
-remote = { package = "rcp-tools-remote", version = "0.35.0", path = "remote" }
+throttle = { package = "rcp-tools-throttle", version = "0.36.0", path = "throttle" }
+congestion = { package = "rcp-tools-congestion", version = "0.36.0", path = "congestion" }
+common = { package = "rcp-tools-common", version = "0.36.0", path = "common" }
+remote = { package = "rcp-tools-remote", version = "0.36.0", path = "remote" }
 
 [workspace.lints.clippy]
 # Deny all warnings to enforce code quality

--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
         # Package builder for RCP tools with custom binary names
         mkRcpPackage = { packageName, binaryName, description }: pkgs.rustPlatform.buildRustPackage {
           pname = binaryName;
-          version = "0.35.0";
+          version = "0.36.0";
           src = ./.;
 
           cargoLock = {
@@ -117,7 +117,7 @@
           # All tools in one package
           rcp-all = pkgs.rustPlatform.buildRustPackage {
             pname = "rcp-all";
-            version = "0.35.0";
+            version = "0.36.0";
             src = ./.;
 
             cargoLock = {


### PR DESCRIPTION
Bump workspace version 0.35.0 → 0.36.0 for the next development cycle. Merge with **Rebase and merge** (click **Update branch** first if GitHub says it's out of date).